### PR TITLE
Add jre version to node info

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -157,7 +157,7 @@ public class API {
                 if (trans == null || tps == null) {
                     return ErrorResponse.create("getInclusionStates Bad Request.");
                 }
-                
+
                 if (invalidSubtangleStatus()) {
                     return ErrorResponse
                             .create("This operations cannot be executed: The subtangle has not been updated yet.");
@@ -169,7 +169,7 @@ public class API {
             }
             case "getNodeInfo": {
                 return GetNodeInfoResponse.create(IRI.NAME, IRI.VERSION, Runtime.getRuntime().availableProcessors(),
-                        Runtime.getRuntime().freeMemory(), Runtime.getRuntime().maxMemory(),
+                        Runtime.getRuntime().freeMemory(), System.getProperty("java.version"), Runtime.getRuntime().maxMemory(),
                         Runtime.getRuntime().totalMemory(), Milestone.latestMilestone, Milestone.latestMilestoneIndex,
                         Milestone.latestSolidSubtangleMilestone, Milestone.latestSolidSubtangleMilestoneIndex,
                         Node.instance().howManyNeighbors(), Node.instance().queuedTransactionsSize(),

--- a/src/main/java/com/iota/iri/service/dto/AbstractResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/AbstractResponse.java
@@ -6,9 +6,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public abstract class AbstractResponse {
-	
+
 	private static class Emptyness extends AbstractResponse {}
-	
+
     private Integer duration;
 
     @Override
@@ -25,15 +25,15 @@ public abstract class AbstractResponse {
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj, false);
     }
-    
+
     public Integer getDuration() {
         return duration;
     }
-    
+
     public void setDuration(Integer duration) {
 		this.duration = duration;
 	}
-    
+
     public static AbstractResponse createEmptyResponse() {
     	return new Emptyness();
     }

--- a/src/main/java/com/iota/iri/service/dto/GetNodeInfoResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNodeInfoResponse.java
@@ -3,20 +3,21 @@ package com.iota.iri.service.dto;
 import com.iota.iri.model.Hash;
 
 public class GetNodeInfoResponse extends AbstractResponse {
-	
-	private String appName; 
+
+	private String appName;
 	private String appVersion;
 	private int jreAvailableProcessors;
 	private long jreFreeMemory;
-	
+	private String jreVersion;
+
     private long jreMaxMemory;
     private long jreTotalMemory;
     private String latestMilestone;
     private int latestMilestoneIndex;
-    
+
     private String latestSolidSubtangleMilestone;
     private int latestSolidSubtangleMilestoneIndex;
-    
+
     private int neighbors;
     private int packetsQueueSize;
     private long time;
@@ -24,8 +25,8 @@ public class GetNodeInfoResponse extends AbstractResponse {
     private int transactionsToRequest;
 
 	public static AbstractResponse create(String appName, String appVersion, int jreAvailableProcessors, long jreFreeMemory,
-	        long maxMemory, long totalMemory, Hash latestMilestone, int latestMilestoneIndex,
-	        Hash latestSolidSubtangleMilestone, int latestSolidSubtangleMilestoneIndex, 
+	        String jreVersion, long maxMemory, long totalMemory, Hash latestMilestone, int latestMilestoneIndex,
+	        Hash latestSolidSubtangleMilestone, int latestSolidSubtangleMilestoneIndex,
 	        int neighbors, int packetsQueueSize,
 	        long currentTimeMillis, int tips, int numberOfTransactionsToRequest) {
 		final GetNodeInfoResponse res = new GetNodeInfoResponse();
@@ -33,15 +34,16 @@ public class GetNodeInfoResponse extends AbstractResponse {
 		res.appVersion = appVersion;
 		res.jreAvailableProcessors = jreAvailableProcessors;
 		res.jreFreeMemory = jreFreeMemory;
-		
+		res.jreVersion = jreVersion;
+
 		res.jreMaxMemory = maxMemory;
 		res.jreTotalMemory = totalMemory;
 		res.latestMilestone = latestMilestone.toString();
 		res.latestMilestoneIndex = latestMilestoneIndex;
-		
+
 		res.latestSolidSubtangleMilestone = latestSolidSubtangleMilestone.toString();
 		res.latestSolidSubtangleMilestoneIndex = latestSolidSubtangleMilestoneIndex;
-		
+
 		res.neighbors = neighbors;
 		res.packetsQueueSize = packetsQueueSize;
 		res.time = currentTimeMillis;
@@ -72,6 +74,10 @@ public class GetNodeInfoResponse extends AbstractResponse {
 
 	public long getJreTotalMemory() {
 		return jreTotalMemory;
+	}
+
+	public String getJreVersion() {
+		return jreVersion;
 	}
 
 	public String getLatestMilestone() {
@@ -109,5 +115,5 @@ public class GetNodeInfoResponse extends AbstractResponse {
 	public int getTransactionsToRequest() {
 		return transactionsToRequest;
 	}
-	
+
 }

--- a/src/test/java/com/iota/iri/APIIntegrationTests.java
+++ b/src/test/java/com/iota/iri/APIIntegrationTests.java
@@ -43,6 +43,7 @@ public class APIIntegrationTests {
                 body(containsString("jreFreeMemory")).
                 body(containsString("jreMaxMemory")).
                 body(containsString("jreTotalMemory")).
+                body(containsString("jreVersion")).
                 body(containsString("latestMilestone")).
                 body(containsString("latestMilestoneIndex")).
                 body(containsString("jreAvailableProcessors")).


### PR DESCRIPTION
Minor change to nodeInfo command to also return the jre version.  The intent is to provide a bit more info when troubleshooting nodes (mostly other people's) who are having issues.  It's also a way to get my feet wet a bit with IRI.