### PR TITLE
Threading issues in PearlDiver.java

### DIFF
--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -91,10 +91,12 @@ public class PearlDiver {
             }
         }
 
+		Thread[] workers = new Thread[numberOfThreads];
+		
         while (numberOfThreads-- > 0) {
 
             final int threadIndex = numberOfThreads;
-            (new Thread(() -> {
+            Thread worker = (new Thread(() -> {
 
                 final long[] midCurlStateCopyLow = new long[CURL_STATE_LENGTH], midCurlStateCopyHigh = new long[CURL_STATE_LENGTH];
                 System.arraycopy(midCurlStateLow, 0, midCurlStateCopyLow, 0, CURL_STATE_LENGTH);
@@ -139,7 +141,9 @@ public class PearlDiver {
                         break;
                     }
                 }
-            })).start();
+            }));
+			workers[threadIndex] = worker;
+            worker.start();
         }
 
         try {
@@ -150,6 +154,14 @@ public class PearlDiver {
             state = CANCELLED;
         }
 
+		 for (int i = 0; i < workers.length; i++) {
+            try {
+                workers[i].join();
+            } catch (final InterruptedException e) {
+                state = CANCELLED;
+            }
+        }
+		
         return state == COMPLETED;
     }
 

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -91,7 +91,7 @@ public class PearlDiver {
             }
         }
 
-		Thread[] workers = new Thread[numberOfThreads];
+        Thread[] workers = new Thread[numberOfThreads];
 		
         while (numberOfThreads-- > 0) {
 
@@ -142,7 +142,7 @@ public class PearlDiver {
                     }
                 }
             }));
-			workers[threadIndex] = worker;
+            workers[threadIndex] = worker;
             worker.start();
         }
 
@@ -154,7 +154,7 @@ public class PearlDiver {
             state = CANCELLED;
         }
 
-		 for (int i = 0; i < workers.length; i++) {
+        for (int i = 0; i < workers.length; i++) {
             try {
                 workers[i].join();
             } catch (final InterruptedException e) {

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -461,7 +461,7 @@ public class API {
         return GetBalancesResponse.create(elements, milestone, milestoneIndex);
     }
 
-    private AbstractResponse attachToTangleStatement(final Hash trunkTransaction, final Hash branchTransaction,
+    private synchronized AbstractResponse attachToTangleStatement(final Hash trunkTransaction, final Hash branchTransaction,
             final int minWeightMagnitude, final List<String> trytes) {
         final List<Transaction> transactions = new LinkedList<>();
 


### PR DESCRIPTION
Tests with attachToTangle for a bundle with 4 txs showed the following situation:
In 7 of 21 cases, one of the 4 nonces was returned as 999999999...

PearlDiver.search() has an IN-OUT-argument. Tracing proved that the the transactionTrits are calculated correctly - for the fault nonces as well - but after return from search(), when using the trits for building the transaction object, the nonce is 999999999... This happens most frequently when the spam loop is active and then a concurrent call to attachToTangle is made.

A further problem is created by the missing join() within the PearDiver thread structure. The worker threads have a chance to continue running when they should terminate because the creator does not care to wait for their termination.

