### PR TITLE
Retry if bundle not complete.

### DIFF
--- a/src/main/java/com/iota/iri/Milestone.java
+++ b/src/main/java/com/iota/iri/Milestone.java
@@ -33,6 +33,7 @@ public class Milestone {
     public static int latestSolidSubtangleMilestoneIndex = MILESTONE_START_INDEX;
 
     private static final Set<Long> analyzedMilestoneCandidates = new HashSet<>();
+    private static final Set<Long> analyzedMilestoneRetryCandidates = new HashSet<>();
     private static final Map<Integer, Hash> milestones = new ConcurrentHashMap<>();
 
     public static void updateLatestMilestone() { // refactor
@@ -48,47 +49,54 @@ public class Milestone {
                     if (index > latestMilestoneIndex) {
 
                         final Bundle bundle = new Bundle(transaction.bundle);
-                        for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
+                        if (bundle.getTransactions().size() == 0) {
+                            // Refactor: do not retry indefinitly.
+                            analyzedMilestoneRetryCandidates.add(pointer);
+                        }
+                        else {
+                            for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
 
-                            if (bundleTransactions.get(0).pointer == transaction.pointer) {
+                                if (bundleTransactions.get(0).pointer == transaction.pointer) {
 
-                                final Transaction transaction2 = StorageTransactions.instance().loadTransaction(transaction.trunkTransactionPointer);
-                                if (transaction2.type == AbstractStorage.FILLED_SLOT
-                                        && transaction.branchTransactionPointer == transaction2.trunkTransactionPointer) {
+                                    final Transaction transaction2 = StorageTransactions.instance().loadTransaction(transaction.trunkTransactionPointer);
+                                    if (transaction2.type == AbstractStorage.FILLED_SLOT
+                                            && transaction.branchTransactionPointer == transaction2.trunkTransactionPointer) {
 
-                                    final int[] trunkTransactionTrits = new int[Transaction.TRUNK_TRANSACTION_TRINARY_SIZE];
-                                    Converter.getTrits(transaction.trunkTransaction, trunkTransactionTrits);
-                                    final int[] signatureFragmentTrits = Arrays.copyOfRange(transaction.trits(), Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_OFFSET, Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_OFFSET + Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_SIZE);
+                                        final int[] trunkTransactionTrits = new int[Transaction.TRUNK_TRANSACTION_TRINARY_SIZE];
+                                        Converter.getTrits(transaction.trunkTransaction, trunkTransactionTrits);
+                                        final int[] signatureFragmentTrits = Arrays.copyOfRange(transaction.trits(), Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_OFFSET, Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_OFFSET + Transaction.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_SIZE);
 
-                                    final int[] hash = ISS.address(ISS.digest(Arrays.copyOf(ISS.normalizedBundle(trunkTransactionTrits), ISS.NUMBER_OF_FRAGMENT_CHUNKS), signatureFragmentTrits));
+                                        final int[] hash = ISS.address(ISS.digest(Arrays.copyOf(ISS.normalizedBundle(trunkTransactionTrits), ISS.NUMBER_OF_FRAGMENT_CHUNKS), signatureFragmentTrits));
 
-                                    int indexCopy = index;
-                                    for (int i = 0; i < 20; i++) {
+                                        int indexCopy = index;
+                                        for (int i = 0; i < 20; i++) {
 
-                                        final Curl curl = new Curl();
-                                        if ((indexCopy & 1) == 0) {
-                                            curl.absorb(hash, 0, hash.length);
-                                            curl.absorb(transaction2.trits(), i * Curl.HASH_LENGTH, Curl.HASH_LENGTH);
-                                        } else {
-                                            curl.absorb(transaction2.trits(), i * Curl.HASH_LENGTH, Curl.HASH_LENGTH);
-                                            curl.absorb(hash, 0, hash.length);
+                                            final Curl curl = new Curl();
+                                            if ((indexCopy & 1) == 0) {
+                                                curl.absorb(hash, 0, hash.length);
+                                                curl.absorb(transaction2.trits(), i * Curl.HASH_LENGTH, Curl.HASH_LENGTH);
+                                            } else {
+                                                curl.absorb(transaction2.trits(), i * Curl.HASH_LENGTH, Curl.HASH_LENGTH);
+                                                curl.absorb(hash, 0, hash.length);
+                                            }
+                                            curl.squeeze(hash, 0, hash.length);
+
+                                            indexCopy >>= 1;
                                         }
-                                        curl.squeeze(hash, 0, hash.length);
 
-                                        indexCopy >>= 1;
-                                    }
+                                        if ((new Hash(hash)).equals(COORDINATOR)) {
 
-                                    if ((new Hash(hash)).equals(COORDINATOR)) {
-
-                                        latestMilestone = new Hash(transaction.hash, 0, Transaction.HASH_SIZE);
-                                        latestMilestoneIndex = index;
+                                            latestMilestone = new Hash(transaction.hash, 0, Transaction.HASH_SIZE);
+                                            latestMilestoneIndex = index;
                                         
-                                        milestones.put(latestMilestoneIndex, latestMilestone);
+                                            milestones.put(latestMilestoneIndex, latestMilestone);
+                                        }
                                     }
+                                    break;
                                 }
-                                break;
                             }
                         }
+                        
                     }
                 }
             }


### PR DESCRIPTION
If the bundle information (transaction list) was not available for a new milestone, then no retry was attempted to validate the new milestone.
Tests show that the bundle information is complete with high probability in the next call to 'updateLatesMilestone()'. That function is called every 5000 ms by the 'Latest Milestone Tracker' thread.

The logic suggested in this fix could be improved by counting the number of retries. If the bundle is not complete after some time - let's say 1 minute - there is little chance that it will ever be complete.