### PR TITLE
Added IXI

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -48,6 +48,7 @@ public class IRI {
             Node.instance().init();
             TipsManager.instance().init();
             API.instance().init();
+            IXI.instance().init();
 
         } catch (final Exception e) {
             log.error("Exception during IOTA node initialisation: ", e);
@@ -167,6 +168,7 @@ public class IRI {
             log.info("Shutting down IOTA node, please hold tight...");
             try {
 
+                IXI.instance().shutdown();
                 API.instance().shutDown();
                 TipsManager.instance().shutDown();
                 Node.instance().shutdown();

--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -20,9 +20,11 @@ import static java.nio.file.StandardWatchEventKinds.*;
 
 public class IXI {
 
-    //private static final ScriptEngine scriptEngine = (new ScriptEngineManager()).getEngineByName("JavaScript");
+    private static final ScriptEngine scriptEngine = (new ScriptEngineManager()).getEngineByName("JavaScript");
+    /*
     private static final ScriptEngine scriptEngine = (new NashornScriptEngineFactory()).getScriptEngine((classname) ->
             !"com.iota.iri.IXI".equals(classname));
+    */
     private static final Map<String, Map<String, CallableRequest<AbstractResponse>>> ixiAPI = new HashMap<>();
     private static final Map<String, Map<String, Runnable>> ixiLifetime = new HashMap<>();
     private static final Map<WatchKey, Path> watchKeys = new HashMap<>();

--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -1,0 +1,200 @@
+package com.iota.iri;
+
+import com.iota.iri.conf.Configuration;
+import com.iota.iri.conf.Configuration.DefaultConfSettings;
+import com.iota.iri.service.CallableRequest;
+import com.iota.iri.service.dto.AbstractResponse;
+import com.iota.iri.service.dto.ErrorResponse;
+import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+
+import javax.script.*;
+import java.io.*;
+import java.nio.file.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static com.sun.jmx.mbeanserver.Util.cast;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import static java.nio.file.StandardWatchEventKinds.*;
+
+public class IXI {
+
+    //private static final ScriptEngine scriptEngine = (new ScriptEngineManager()).getEngineByName("JavaScript");
+    private static final ScriptEngine scriptEngine = (new NashornScriptEngineFactory()).getScriptEngine((classname) ->
+            !"com.iota.iri.IXI".equals(classname));
+    private static final Map<String, Map<String, CallableRequest<AbstractResponse>>> ixiAPI = new HashMap<>();
+    private static final Map<String, Map<String, Runnable>> ixiLifetime = new HashMap<>();
+    private static final Map<WatchKey, Path> watchKeys = new HashMap<>();
+    private static WatchService watcher;
+    private static Thread dirWatchThread;
+    private static boolean watchingThread;
+
+    /*
+    TODO: get configuration variable for directory to watch
+    TODO: initialize directory listener
+    TODO: create events for target added/changed/removed
+     */
+    public static void init() throws Exception {
+        watcher = FileSystems.getDefault().newWatchService();
+        Path path = Paths.get(Configuration.string(DefaultConfSettings.IXI_DIR));
+        String s = path.toAbsolutePath().toString();
+        register(path);
+        watchingThread = true;
+        dirWatchThread = (new Thread(IXI::processEvents));
+        dirWatchThread.start();
+    }
+
+    public static void shutdown() {
+        watchingThread = false;
+        try {
+            dirWatchThread.join();
+        } catch(InterruptedException e) {
+            e.printStackTrace();
+        }
+        Object[] keys = ixiAPI.keySet().toArray();
+        for (Object key : keys) {
+            detach((String)key);
+        }
+    }
+
+    private  static void register (Path dir) throws IOException {
+        WatchKey key = dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        watchKeys.put(key, dir);
+        // TODO: Add existing files
+        addFiles(dir);
+    }
+
+    private static void addFiles (Path dir) throws IOException {
+        Files.walk(dir).forEach(filePath -> {
+            if(!filePath.equals(dir))
+                if(Files.isDirectory(filePath, NOFOLLOW_LINKS)) {
+                    try {
+                        System.out.format("Searching: %s \n", filePath.toString());
+                        addFiles(filePath);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    System.out.format("File: %s\n", filePath.toString());
+                    try {
+                        attach(new FileReader(filePath.toFile()), filePath.getFileName().toString().replaceFirst("[.][^.]+$", ""));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+        });
+    }
+
+    public static AbstractResponse processCommand(final String command, Map<String, Object> request) {
+        try {
+            Map<String, CallableRequest<AbstractResponse>> ixiMap;
+            AbstractResponse res;
+            for (String key :
+                    ixiAPI.keySet()) {
+                if(command.substring(0, key.length()).equals(key)) {
+                    String subCmd = command.substring(key.length()+1);
+                    ixiMap = ixiAPI.get(key);
+                    CallableRequest<AbstractResponse> c = ixiMap.get(subCmd);
+                    res = c.call(request);
+                    if(res != null) return res;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return ErrorResponse.create("Command [" + command + "] is unknown");
+    }
+
+    private static void processEvents() {
+        while(watchingThread) {
+            WatchKey key;
+            try {
+                key = watcher.take();
+            } catch (InterruptedException ex) {
+                return;
+            }
+
+            pollEvents(key, watchKeys.get(key));
+        }
+    }
+
+    private static void pollEvents(WatchKey key, Path dir) {
+        for (WatchEvent<?> event: key.pollEvents()) {
+            WatchEvent.Kind kind = event.kind();
+
+            if(kind == OVERFLOW) {
+                continue;
+            }
+
+            WatchEvent<Path> ev = cast(event);
+            Path name = ev.context();
+            Path child = dir.resolve(name);
+
+            executeEvents(kind, child);
+
+            if (!key.reset()) {
+                watchKeys.remove(key);
+                if (watchKeys.isEmpty()) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void executeEvents(WatchEvent.Kind kind, Path child) {
+        if (kind == ENTRY_MODIFY || kind == ENTRY_DELETE) {
+
+            System.out.format("detach child: %s \n", child);
+            detach(child.toString().replaceFirst("[.][^.]+$", ""));
+        }
+        if (kind == ENTRY_CREATE || kind == ENTRY_MODIFY) {
+            try {
+                if (Files.isDirectory(child, NOFOLLOW_LINKS)) {
+                    //registerAll(child);
+                    System.out.format("child: %s \n", child);
+                } else {
+                    //Files.isRegularFile(child)
+                    System.out.format("load child: %s \n", child);
+                    attach(new FileReader(child.toFile()), child.getFileName().toString().replaceFirst("[.][^.]+$", ""));
+                }
+            } catch (Exception x) {
+                // ignore to keep sample readable
+            }
+        }
+    }
+
+    private static void attach(final Reader ixi, final String filename) {
+        try {
+            Map<String, CallableRequest<AbstractResponse>> ixiMap = new HashMap<>();
+            Map<String, Runnable> startStop = new HashMap<>();
+            Bindings bindings = scriptEngine.createBindings();
+
+            bindings.put("API", ixiMap);
+            bindings.put("IXICycle", startStop);
+            ixiAPI.put(filename, ixiMap);
+            ixiLifetime.put(filename, startStop);
+            scriptEngine.eval(ixi, bindings);
+
+        } catch (final ScriptException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void detach(String fileName) {
+        Map<String, Runnable> ixiMap = ixiLifetime.get(fileName);
+        if(ixiMap != null) {
+            Runnable stop = ixiMap.get("shutdown");
+            if (stop != null) stop.run();
+        }
+        ixiAPI.remove(fileName);
+        ixiLifetime.remove(fileName);
+    }
+
+    private static final IXI instance = new IXI();
+
+    public static IXI instance() {
+        return instance;
+    }
+
+}

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -26,6 +26,7 @@ public class Configuration {
         REMOTEAPILIMIT,
         NEIGHBORS,
         DEBUG,
+        IXI_DIR,
         EXPERIMENTAL // experimental features.
     }
 
@@ -39,6 +40,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.HEADLESS.name(), "false");
         conf.put(DefaultConfSettings.DEBUG.name(), "false");
         conf.put(DefaultConfSettings.REMOTEAPILIMIT.name(), "");
+        conf.put(DefaultConfSettings.IXI_DIR.name(), "ixi");
         conf.put(DefaultConfSettings.EXPERIMENTAL.name(), "false");
     }
 

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import com.iota.iri.*;
 import com.iota.iri.service.dto.*;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -31,10 +32,6 @@ import org.xnio.streams.ChannelInputStream;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.iota.iri.IRI;
-import com.iota.iri.Milestone;
-import com.iota.iri.Neighbor;
-import com.iota.iri.Snapshot;
 import com.iota.iri.conf.Configuration;
 import com.iota.iri.conf.Configuration.DefaultConfSettings;
 import com.iota.iri.hash.Curl;
@@ -207,7 +204,7 @@ public class API {
                     return storeTransactionStatement(trytes);
                 }
                 default:
-                    return ErrorResponse.create("Command [" + command + "] is unknown");
+                    return IXI.instance().processCommand(command, request);
             }
 
         } catch (final Exception e) {

--- a/src/main/java/com/iota/iri/service/CallableRequest.java
+++ b/src/main/java/com/iota/iri/service/CallableRequest.java
@@ -1,0 +1,9 @@
+package com.iota.iri.service;
+
+import com.iota.iri.service.dto.AbstractResponse;
+
+import java.util.Map;
+
+public interface CallableRequest<V> {
+    public V call(Map<String, Object> request);
+}

--- a/src/test/java/com/iota/iri/IXITest.java
+++ b/src/test/java/com/iota/iri/IXITest.java
@@ -1,0 +1,63 @@
+package com.iota.iri;
+
+import com.iota.iri.conf.Configuration;
+import com.iota.iri.service.dto.AbstractResponse;
+import org.junit.Test;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static org.junit.Assert.*;
+
+/**
+ * Created by paul on 1/4/17.
+ */
+public class IXITest {
+    @Test
+    public void init() throws Exception {
+        final String ixiPath = Configuration.string(Configuration.DefaultConfSettings.IXI_DIR);
+        final File ixiDir = new File(ixiPath);
+        if(!ixiDir.exists()) ixiDir.mkdir();
+
+        IXI.instance().init();
+
+        final String testJs =
+                "var Callable = Java.type(\"java.util.concurrent.Callable\");\n" +
+                        "var Response = Java.type(\"com.iota.iri.service.dto.AbstractResponse\");\n" +
+                        "var MyRes = Java.extend(Response, {\n" +
+                        "text: \"FOO\"\n" +
+                        "});\n" +
+                        "API.put(\"getParser\", new Callable({\n" +
+                        "call: function() {\n" +
+                        "return new MyRes();\n" +
+                        "}\n" +
+                        "}));\n";
+
+        final File testFile = new File(ixiPath + "/test.js");
+        testFile.createNewFile();
+        try (OutputStream out = new BufferedOutputStream(
+                Files.newOutputStream(testFile.toPath(), CREATE))) {
+            out.write(testJs.getBytes());
+        }
+        Map<String, Object> request = new HashMap<>();
+        AbstractResponse response = IXI.processCommand("test.getParser", request);
+
+        testFile.delete();
+
+        IXI.shutdown();
+    }
+
+    @Test
+    public void processCommand() throws Exception {
+
+    }
+
+}


### PR DESCRIPTION
Javascript files can be created in a folder, defaulted to "./ixi/", subject to javax.script.scriptengine constraints. Currently, they are automatically loaded into the IRI, and have full access to all classes, except the IXI class itself.

A script can register a "shutdown" function, so that it can be cleanly removed at the call of the IRI shutdown.

API endpoints can be registered, and are callable by <script name>.<name of registered command>.