### PR TITLE
Fix remote api limit to allow localhost

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -4,6 +4,7 @@ import static io.undertow.Handlers.path;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -96,11 +97,11 @@ public class API {
 
         final long beginningTime = System.currentTimeMillis();
         final String body = IOUtils.toString(cis, StandardCharsets.UTF_8);
-        final AbstractResponse response = process(body);
+        final AbstractResponse response = process(body, exchange.getSourceAddress());
         sendResponse(exchange, response, beginningTime);
     }
 
-    private AbstractResponse process(final String requestString) throws UnsupportedEncodingException {
+    private AbstractResponse process(final String requestString, InetSocketAddress sourceAddress) throws UnsupportedEncodingException {
 
         try {
 
@@ -114,7 +115,8 @@ public class API {
                 return ErrorResponse.create("COMMAND parameter has not been specified in the request.");
             }
 
-            if (Configuration.string(DefaultConfSettings.REMOTEAPILIMIT).contains(command)) {
+            if (Configuration.string(DefaultConfSettings.REMOTEAPILIMIT).contains(command) &&
+                    sourceAddress.equals(InetAddress.getByName("localhost"))) {
                 return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
             }
 

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -116,7 +116,7 @@ public class API {
             }
 
             if (Configuration.string(DefaultConfSettings.REMOTEAPILIMIT).contains(command) &&
-                    !sourceAddress.equals(InetAddress.getByName("localhost"))) {
+                    !sourceAddress.getAddress().equals(InetAddress.getByName("localhost"))) {
                 return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
             }
 

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -116,7 +116,7 @@ public class API {
             }
 
             if (Configuration.string(DefaultConfSettings.REMOTEAPILIMIT).contains(command) &&
-                    sourceAddress.equals(InetAddress.getByName("localhost"))) {
+                    !sourceAddress.equals(InetAddress.getByName("localhost"))) {
                 return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
             }
 


### PR DESCRIPTION
When using --remote-limit-api option, there was no check to confirm the source, so it just performed a pure API limitation. These changes introduced allow source address-based limiting.