### PR TITLE
Extracted System.exit() from printUsage()

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -2,6 +2,7 @@ package com.iota.iri;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -181,13 +182,11 @@ public class IRI {
     }
 
     private static void showIotaLogo() {
-        final String charset = "UTF8";
-
         try {
             final Path path = Paths.get("logo.utf8.ans");
-            Files.readAllLines(path, Charset.forName(charset)).forEach(log::info);
+            Files.readAllLines(path, StandardCharsets.UTF_8).forEach(log::info);
         } catch (IOException e) {
-            log.error("Impossible to display logo. Charset {} not supported by terminal.", charset);
+            log.error("Impossible to display logo. Charset {} not supported by terminal.", StandardCharsets.UTF_8);
         }
     }
 }

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -61,6 +61,7 @@ public class IRI {
         if (args == null || args.length < 2) {
             log.error("Invalid arguments list. Provide Api port number (i.e. '-p 14265').");
             printUsage();
+            System.exit(0);
         }
 
         final CmdLineParser parser = new CmdLineParser();
@@ -89,12 +90,14 @@ public class IRI {
         if (cport == null) {
             log.error("Invalid arguments list. Provide at least 1 neighbor with -n or --neighbors '<list>'");
             printUsage();
+            System.exit(0);
         }
         Configuration.put(DefaultConfSettings.API_PORT, cport);
 
         // optional flags
         if (parser.getOptionValue(help) != null) {
             printUsage();
+            System.exit(0);
         }
 
         String cns = parser.getOptionValue(neighbors);
@@ -158,7 +161,6 @@ public class IRI {
                 "[{--remote}]" +
                 // + "[{-t,--testnet} false] " // -> TBDiscussed (!)
                 "[{-n,--neighbors} '<list of neighbors>'] ", NAME, VERSION);
-        System.exit(0);
     }
 
     private static void shutdownHook() {


### PR DESCRIPTION
Otherwise method should be called printUsageAndExit. But the major reason is, that System.exit(2) (some lines before) would be never reached.