### PR TITLE
Fixed double WatchKey event bug

### DIFF
--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -30,6 +30,7 @@ public class IXI {
     private final Map<String, Map<String, Runnable>> ixiLifetime = new HashMap<>();
     private final Map<WatchKey, Path> watchKeys = new HashMap<>();
     private final Map<Path, List<Path>> extensions = new HashMap<>();
+    private final Map<Path, Long> lastModifiedTimes = new HashMap<>();
     private final Set<Path> visitedPaths = new TreeSet<>();
     private WatchService watcher;
     private Thread dirWatchThread;
@@ -176,6 +177,14 @@ public class IXI {
 
     //private void executeEvents(WatchEvent.Kind kind, Path child) throws IOException, ScriptException {
     private void executeEvents(Map.Entry<Path, List<WatchEvent.Kind>> pathListEntry) {
+        try {
+            if (Files.exists(pathListEntry.getKey(), NOFOLLOW_LINKS) && wasModifiedRecently(pathListEntry.getKey())) {
+                log.info("*********** ICH GEH RAUS");
+                return;
+            }
+        } catch (IOException e) {
+            log.error("Error checking last file modification time.");
+        }
         if(pathListEntry.getValue().contains(ENTRY_DELETE) || pathListEntry.getValue().contains(ENTRY_MODIFY)) {
             unloadExtension(pathListEntry.getKey());
         }
@@ -202,6 +211,17 @@ public class IXI {
                 log.debug("Done.");
             }
         }
+    }
+
+    private boolean wasModifiedRecently(Path path) throws IOException {
+        boolean modifiedRecently = false;
+        long lastModified = Files.getLastModifiedTime(path.toAbsolutePath(), NOFOLLOW_LINKS).toMillis();
+        if (lastModified - lastModifiedTimes.getOrDefault(path, 0L) < 50L) {
+            modifiedRecently = true;
+        } else {
+            lastModifiedTimes.put(path, lastModified);
+        }
+        return modifiedRecently;
     }
 
     private void attach(final Reader ixi, String name) throws ScriptException {


### PR DESCRIPTION
This bug should fix https://github.com/iotaledger/iri/issues/182

Root cause: When files are edited, Java creates at least two or more WatchKey events of type MODIFY. One for editing the file content and one for modifying the timestamp of the file.

Fix: Comparing the latest modified time of the file with the current timestamp of the file. It should be greater than 50 milliseconds, otherwise we're omitting the handling request.