### PR TITLE
usage: port is mandatory

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -229,8 +229,8 @@ public class IRI {
 
     private static void printUsage() {
         log.info("Usage: java -jar {}-{}.jar " +
+                "{-p,--port} 14600 " +
                 "[{-n,--neighbors} '<list of neighbors>'] " +
-                "[{-p,--port} 14600] " +                
                 "[{-c,--config} 'config-file-name'] " +
                 "[{-u,--udp-receiver-port} 14600] " +
                 "[{-t,--tcp-receiver-port} 15600] " +


### PR DESCRIPTION
fix notation for users that rely on the info output.