### PR TITLE
Remove deprecated HEADLESS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you notice any issues or irregularities in this release. Please make sure to 
 You have two options, the preferred option is that you compile yourself. The second option is that you utilize the provided jar, which is released regularly (when new updates occur) here: [Github Releases](https://github.com/iotaledger/iri/releases).
 
 
-### Compiling yourself  
+### Compiling yourself
 
 Make sure to have Maven and Java 8 installed on your computer.
 
@@ -32,9 +32,9 @@ $ mvn clean compile
 $ mvn package
 ```
 
-This will create a `target` directory in which you will find the executable jar file that you can use for the 
+This will create a `target` directory in which you will find the executable jar file that you can use for the
 
-### How to run IRI 
+### How to run IRI
 
 Running IRI is pretty simple, and you don't even have to run it under admin rights. Below is a list of command line options. Here is an example script:
 
@@ -43,10 +43,10 @@ java -jar iri.jar -p 14265
 ```
 
 
-### Command Line Options 
+### Command Line Options
 
 Option | Shortened version | Description | Example Input
---- | --- | --- | --- 
+--- | --- | --- | ---
 `--port` | `-p` | This is a *mandatory* option that defines the port to be used to send API commands to your node | `-p 14800`
 `--neighbors` | `-n` | Neighbors that you are connected with will be added via this option. | `-n "udp://148.148.148.148:14265 udp://[2001:db8:a0b:12f0::1]:14265"`
 `--config` | `-c` | Config INI file that can be used instead of CLI options. See more below | `-c iri.ini`
@@ -68,7 +68,6 @@ PORT = 14700
 UDP_RECEIVER_PORT = 14700
 NEIGHBORS = udp://my.favorite.com:15600
 IXI_DIR = ixi
-HEADLESS = true
 DEBUG = true
 #TESTNET = false
 DB_PATH = db


### PR DESCRIPTION
The `headless` option cannot be found anywhere in the code, but is mentioned in the README, which can be confusing.