### PR TITLE
Move zmq publish operation for tx items to a new ZmqPublishProvider.

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -13,6 +13,7 @@ import com.iota.iri.storage.FileExportProvider;
 import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.ZmqPublishProvider;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import com.iota.iri.utils.Pair;
 import org.apache.commons.lang3.NotImplementedException;
@@ -198,6 +199,9 @@ public class Iota {
         }
         if (configuration.booling(Configuration.DefaultConfSettings.EXPORT)) {
             tangle.addPersistenceProvider(new FileExportProvider());
+        }
+        if (configuration.booling(Configuration.DefaultConfSettings.ZMQ_ENABLED)) {
+            tangle.addPersistenceProvider(new ZmqPublishProvider(messageQ));
         }
     }
 }

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -1,6 +1,13 @@
 package com.iota.iri.network;
 
-import java.net.*;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -20,21 +27,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.iota.iri.Milestone;
-import com.iota.iri.TransactionValidator;
-import com.iota.iri.utils.Converter;
-import com.iota.iri.zmq.MessageQ;
-import com.iota.iri.storage.Tangle;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.iota.iri.Milestone;
+import com.iota.iri.TransactionValidator;
 import com.iota.iri.conf.Configuration;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.zmq.MessageQ;
 
 /**
  * The class node is responsible for managing Thread's connection.
@@ -391,18 +397,6 @@ public class Node {
             } else {
                 //if not, store tx. & update recentSeenHashes
                 stored = receivedTransactionViewModel.store(tangle);
-                messageQ.publish("tx %s %s %d %s %d %d %d %s %s %s",
-                        receivedTransactionViewModel.getHash(),
-                        receivedTransactionViewModel.getAddressHash(),
-                        receivedTransactionViewModel.value(),
-                        receivedTransactionViewModel.getTagValue(),
-                        receivedTransactionViewModel.getTimestamp(),
-                        receivedTransactionViewModel.getCurrentIndex(),
-                        receivedTransactionViewModel.lastIndex(),
-                        receivedTransactionViewModel.getBundleHash(),
-                        receivedTransactionViewModel.getTrunkTransactionHash(),
-                        receivedTransactionViewModel.getBranchTransactionHash()
-                );
                 synchronized (recentSeenHashes) {
                     recentSeenHashes.set(receivedTransactionViewModel.getHash(), true);
                 }

--- a/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
+++ b/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
@@ -1,0 +1,128 @@
+package com.iota.iri.storage;
+
+import java.util.List;
+import java.util.Set;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.Transaction;
+import com.iota.iri.utils.Pair;
+import com.iota.iri.zmq.MessageQ;
+
+public class ZmqPublishProvider implements PersistenceProvider {
+
+    private final MessageQ messageQ;
+    
+    public ZmqPublishProvider( MessageQ messageQ ) {
+        this.messageQ = messageQ;
+    }
+    
+    @Override
+    public void init() throws Exception {
+        
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+
+    @Override
+    public void shutdown() {
+        
+    }
+
+    @Override
+    public boolean save(Persistable model, Indexable index) throws Exception {
+        return false;
+    }
+
+    @Override
+    public void delete(Class<?> model, Indexable index) throws Exception {
+        
+    }
+
+    @Override
+    public boolean update(Persistable model, Indexable index, String item) throws Exception {
+        if (model instanceof Transaction) {
+            Transaction transaction = ((Transaction) model);
+            if (item.contains("sender")) {
+                TransactionViewModel transactionViewModel = new TransactionViewModel(transaction, (Hash)index);
+                messageQ.publish("tx %s %s %d %s %d %d %d %s %s %s", 
+                        transactionViewModel.getHash(),
+                        transactionViewModel.getAddressHash(), 
+                        transactionViewModel.value(),
+                        transactionViewModel.getTagValue(), 
+                        transactionViewModel.getTimestamp(),
+                        transactionViewModel.getCurrentIndex(), 
+                        transactionViewModel.lastIndex(),
+                        transactionViewModel.getBundleHash(), 
+                        transactionViewModel.getTrunkTransactionHash(),
+                        transactionViewModel.getBranchTransactionHash());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean exists(Class<?> model, Indexable key) throws Exception {
+        return false;
+    }
+
+    @Override
+    public Pair<Indexable, Persistable> latest(Class<?> model, Class<?> indexModel) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Set<Indexable> keysWithMissingReferences(Class<?> modelClass, Class<?> otherClass) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Persistable get(Class<?> model, Indexable index) throws Exception {
+        return null;
+    }
+
+    @Override
+    public boolean mayExist(Class<?> model, Indexable index) throws Exception {
+        return false;
+    }
+
+    @Override
+    public long count(Class<?> model) throws Exception {
+        return 0;
+    }
+
+    @Override
+    public Set<Indexable> keysStartingWith(Class<?> modelClass, byte[] value) {
+        return null;
+    }
+
+    @Override
+    public Persistable seek(Class<?> model, byte[] key) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Pair<Indexable, Persistable> next(Class<?> model, Indexable index) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Pair<Indexable, Persistable> previous(Class<?> model, Indexable index) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Pair<Indexable, Persistable> first(Class<?> model, Class<?> indexModel) throws Exception {
+        return null;
+    }
+
+    @Override
+    public boolean saveBatch(List<Pair<Indexable, Persistable>> models) throws Exception {
+        return false;
+    }
+
+}


### PR DESCRIPTION
Previously, the txs stored by API serivce where not published directly but only on arrival of a broadcast echo from a peer node.