### PR TITLE
replace java alpine to openjdk-jre version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /iri
 COPY . /iri
 RUN mvn clean package
 
-FROM java:jre-alpine
+FROM openjdk:jre-slim
 WORKDIR /iri
 COPY --from=builder /iri/target/iri-1.3.2.2.jar iri.jar
 COPY logback.xml /iri


### PR DESCRIPTION
alpine version didn't work
```Exception in thread "main" java.lang.UnsatisfiedLinkError: /tmp/librocksdbjni2898419474021443955.so: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/librocksdbjni2898419474021443955.so)```