### PR TITLE
Add support for 'REMOTE' configuration entry

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -182,8 +182,8 @@ public class IRI {
             configuration.put(DefaultConfSettings.TCP_RECEIVER_PORT, vrporttcp);
         }
 
-	final Boolean remoteBinding = configuration.getBooling(DefaultConfSetting.REMOTE);
-        if (parser.getOptionValue(remote) != null || remoteBinding ) {
+	final Boolean remoteBindingOption = configuration.getBooling(DefaultConfSettings.REMOTE);
+        if (parser.getOptionValue(remote) != null || remoteBindingOption ) {
             log.info("Remote access enabled. Binding API socket to listen any interface.");
             configuration.put(DefaultConfSettings.API_HOST, "0.0.0.0");
         }

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -182,7 +182,7 @@ public class IRI {
             configuration.put(DefaultConfSettings.TCP_RECEIVER_PORT, vrporttcp);
         }
 
-	final Boolean remoteBindingOption = configuration.getBooling(DefaultConfSettings.REMOTE);
+	final Boolean remoteBindingOption = configuration.booling(DefaultConfSettings.REMOTE);
         if (parser.getOptionValue(remote) != null || remoteBindingOption ) {
             log.info("Remote access enabled. Binding API socket to listen any interface.");
             configuration.put(DefaultConfSettings.API_HOST, "0.0.0.0");

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -182,7 +182,8 @@ public class IRI {
             configuration.put(DefaultConfSettings.TCP_RECEIVER_PORT, vrporttcp);
         }
 
-        if (parser.getOptionValue(remote) != null) {
+	final Boolean remoteBinding = configuration.getBooling(DefaultConfSetting.REMOTE);
+        if (parser.getOptionValue(remote) != null || remoteBinding ) {
             log.info("Remote access enabled. Binding API socket to listen any interface.");
             configuration.put(DefaultConfSettings.API_HOST, "0.0.0.0");
         }

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -32,6 +32,7 @@ public class Configuration {
         TCP_RECEIVER_PORT,
         TESTNET,
         DEBUG,
+	REMOTE,
         REMOTE_LIMIT_API,
         REMOTE_AUTH,
         NEIGHBORS,        
@@ -73,6 +74,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.TCP_RECEIVER_PORT.name(), "15600");
         conf.put(DefaultConfSettings.TESTNET.name(), "false");
         conf.put(DefaultConfSettings.DEBUG.name(), "false");
+        conf.put(DefaultConfSettings.REMOTE.name(), "false");
         conf.put(DefaultConfSettings.REMOTE_LIMIT_API.name(), "");
         conf.put(DefaultConfSettings.REMOTE_AUTH.name(), "");
         conf.put(DefaultConfSettings.NEIGHBORS.name(), "");

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -32,7 +32,7 @@ public class Configuration {
         TCP_RECEIVER_PORT,
         TESTNET,
         DEBUG,
-	REMOTE,
+        REMOTE,
         REMOTE_LIMIT_API,
         REMOTE_AUTH,
         NEIGHBORS,        


### PR DESCRIPTION
This is a simple patch to add support for a 'REMOTE' configuration entry.

REMOTE =  true

Intent was to add clarity to the config for users setting up an 'IRI' node.