### PR TITLE
Fixed neighbor list if clients are using dynamic dns service.

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -179,6 +179,7 @@ public class Node {
                                 } else {
                                     if (configuration.booling(Configuration.DefaultConfSettings.DNS_REFRESHER_ENABLED)) {
                                         log.info("IP CHANGED for {}! Updating...", hostname);
+                                        log.info("IP CHANGED from '{}' to '{}'", neighborAddress,ip);
                                         messageQ.publish("dnscu %s", hostname);
                                         String protocol = (n instanceof TCPNeighbor) ? "tcp://" : "udp://";
                                         String port = ":" + n.getAddress().getPort();
@@ -186,8 +187,9 @@ public class Node {
                                         uri(protocol + hostname + port).ifPresent(uri -> {
                                             removeNeighbor(uri, n.isFlagged());
 
-                                            uri(protocol + ip + port).ifPresent(nuri -> {
-                                                Neighbor neighbor = newNeighbor(nuri, n.isFlagged());
+                                            uri(protocol + neighborAddress + port).ifPresent(nuri -> {
+                                                removeNeighbor(nuri,n.isFlagged());
+                                                Neighbor neighbor = newNeighbor(uri, n.isFlagged());
                                                 addNeighbor(neighbor);
                                                 neighborIpCache.put(hostname, ip);
                                             });


### PR DESCRIPTION
 - Added log stmt for ip change
 - Ensure existing neighbor 'proto://<address>:<port>' is removed from list
 - Added neighbor as 'proto://<hostname>:<port>'