### PR TITLE
Added REMOTE_API_LIMIT_MODE Support

### DIFF
--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -33,6 +33,7 @@ public class Configuration {
         TESTNET,
         DEBUG,
         REMOTE_LIMIT_API,
+        REMOTE_LIMIT_API_MODE,
         REMOTE_AUTH,
         NEIGHBORS,        
         IXI_DIR,
@@ -74,6 +75,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.TESTNET.name(), "false");
         conf.put(DefaultConfSettings.DEBUG.name(), "false");
         conf.put(DefaultConfSettings.REMOTE_LIMIT_API.name(), "");
+        conf.put(DefaultConfSettings.REMOTE_LIMIT_API_MODE.name(), "INCLUDE");
         conf.put(DefaultConfSettings.REMOTE_AUTH.name(), "");
         conf.put(DefaultConfSettings.NEIGHBORS.name(), "");
         conf.put(DefaultConfSettings.IXI_DIR.name(), "ixi");

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -173,9 +173,17 @@ public class API {
                 return ErrorResponse.create("COMMAND parameter has not been specified in the request.");
             }
 
-            if (instance.configuration.string(DefaultConfSettings.REMOTE_LIMIT_API).contains(command) &&
-                    !sourceAddress.getAddress().isLoopbackAddress()) {
-                return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
+            final String commandMode = instance.configuration.string(DefaultConfSettings.REMOTE_LIMIT_API_MODE);
+            final Boolean commandModeInclude = ((commandMode != null) && commandMode.toLowerCase().contains("include")) ? true : false;
+            final Boolean commandFound = instance.configuration.string(DefaultConfSettings.REMOTE_LIMIT_API).contains(command);
+
+            if (!sourceAddress.getAddress().isLoopbackAddress()) {
+                if(commandFound && !commandModeInclude) {
+                    return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
+                }
+                if(!commandFound && commandModeInclude) {
+                    return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
+                }
             }
 
             log.debug("# {} -> Requesting command '{}'", counter.incrementAndGet(), command);


### PR DESCRIPTION
The default behavior if merged, is to force user to specify the methods to expose remotely.

REMOTE_API_LIMIT_MODE="include" (default)
REMOTE_API_LIMIT = "<methods to expose remotely>"

A user can switch to previous behavior by setting value to "exclude"

REMOTE_API_LIMIT_MODE="exclude"
REMOTE_API_LIMIT = "<methods to not expose remotely>"

All methods are still available via loopback address.