### PR TITLE
Optimize neighbor operations

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -7,15 +7,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -56,7 +54,7 @@ public class Node {
 
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
 
-    private final Collection<Neighbor> neighbors = Collections.synchronizedSet(new HashSet<Neighbor>());
+    private final Collection<Neighbor> neighbors = ConcurrentHashMap.newKeySet();
     private final ConcurrentSkipListSet<TransactionViewModel> broadcastQueue = weightQueue();
     private final ConcurrentSkipListSet<Pair<TransactionViewModel,Neighbor>> receiveQueue = weightQueueTxPair();
     private final ConcurrentSkipListSet<Pair<Hash,Neighbor>> replyQueue = weightQueueHashPair();

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkPool.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkPool.java
@@ -3,7 +3,7 @@ package com.iota.iri.network.replicator;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.Socket;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +40,7 @@ public class ReplicatorSinkPool  implements Runnable {
         
         sinkPool = Executors.newFixedThreadPool(Replicator.NUM_THREADS);
         {           
-            List<Neighbor> neighbors = node.getNeighbors();
+            Collection<Neighbor> neighbors = node.getNeighbors();
             // wait until list is populated
             int loopcnt = 10;
             while ((loopcnt-- > 0) && neighbors.size() == 0) {
@@ -62,7 +62,7 @@ public class ReplicatorSinkPool  implements Runnable {
             } catch (InterruptedException e) {
                 log.debug("Interrupted: ", e);
             }
-            List<Neighbor> neighbors = node.getNeighbors();
+            Collection<Neighbor> neighbors = node.getNeighbors();
             neighbors.stream()
                     .filter(n -> n instanceof TCPNeighbor && n.isFlagged())
                     .map(n -> ((TCPNeighbor) n))

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.util.List;
+import java.util.Collection;
 import java.util.zip.CRC32;
 
 import com.iota.iri.network.TCPNeighbor;
@@ -62,7 +62,7 @@ class ReplicatorSourceProcessor implements Runnable {
             InetSocketAddress inet_socket_address = (InetSocketAddress) address;
 
             existingNeighbor = false;
-            List<Neighbor> neighbors = node.getNeighbors();
+            Collection<Neighbor> neighbors = node.getNeighbors();
             neighbors.stream().filter(n -> n instanceof TCPNeighbor)
                     .map(n -> ((TCPNeighbor) n))
                     .forEach(n -> {

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -1,6 +1,6 @@
 package com.iota.iri.service.dto;
 
-import java.util.List;
+import java.util.Collection;
 
 public class GetNeighborsResponse extends AbstractResponse {
 
@@ -54,7 +54,7 @@ public class GetNeighborsResponse extends AbstractResponse {
         }
     }
 
-    public static AbstractResponse create(final List<com.iota.iri.network.Neighbor> elements) {
+    public static AbstractResponse create(final Collection<com.iota.iri.network.Neighbor> elements) {
         GetNeighborsResponse res = new GetNeighborsResponse();
         res.neighbors = new Neighbor[elements.size()];
         int i = 0;


### PR DESCRIPTION
This changes the neighbor data structure to be a `HashSet` instead of an `ArrayList`. This optimizes operations like `add`, `remove`, `contains`, etc. This PR also abstracts how neighbors are stored in the `Node` class as well as public views of it, `getNeighbors()`.