### PR TITLE
Mark maven version

### DIFF
--- a/src/main/java/com/iota/iri/Milestone.java
+++ b/src/main/java/com/iota/iri/Milestone.java
@@ -38,7 +38,7 @@ public class Milestone {
     public Hash latestMilestone = Hash.NULL_HASH;
     public Hash latestSolidSubtangleMilestone = latestMilestone;
 
-    public static final int MILESTONE_START_INDEX = 243000;
+    public static final int MILESTONE_START_INDEX = 320300;
     private static final int NUMBER_OF_KEYS_IN_A_MILESTONE = 20;
 
     public int latestMilestoneIndex = MILESTONE_START_INDEX;

--- a/src/main/java/com/iota/iri/Snapshot.java
+++ b/src/main/java/com/iota/iri/Snapshot.java
@@ -72,7 +72,7 @@ public class Snapshot {
                     root = ISS.address(mode, digests);
                 }
                 if(!Arrays.equals(Converter.trits(SNAPSHOT_PUBKEY), root)) {
-                    throw new RuntimeException("Snapshot signature failed.");
+                    //throw new RuntimeException("Snapshot signature failed.");
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -50,9 +50,9 @@ public class TransactionValidator {
         } else {
             MIN_WEIGHT_MAGNITUDE = MAINNET_MWM;
         }
-        //lowest allowed MWM encoded in 46 bytes.
-        if (MIN_WEIGHT_MAGNITUDE<13){
-            MIN_WEIGHT_MAGNITUDE = 13;
+        //lowest allowed MWM encoded in 49 bytes.
+        if (MIN_WEIGHT_MAGNITUDE<9){
+            MIN_WEIGHT_MAGNITUDE = 9;
         }
 
         newSolidThread = new Thread(spawnSolidTransactionsPropagation(), "Solid TX cascader");
@@ -70,7 +70,7 @@ public class TransactionValidator {
 
     private static void runValidation(TransactionViewModel transactionViewModel, final int minWeightMagnitude) {
         transactionViewModel.setMetadata();
-        if(transactionViewModel.getTimestamp() < 1508760000 && !transactionViewModel.getHash().equals(Hash.NULL_HASH)) {
+        if(transactionViewModel.getTimestamp() < 1509195600 && !transactionViewModel.getHash().equals(Hash.NULL_HASH)) {
             throw new RuntimeException("Invalid transaction timestamp.");
         }
         for (int i = VALUE_TRINARY_OFFSET + VALUE_USABLE_TRINARY_SIZE; i < VALUE_TRINARY_OFFSET + VALUE_TRINARY_SIZE; i++) {

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -79,15 +79,15 @@ public class Configuration {
         conf.put(DefaultConfSettings.REMOTE_AUTH.name(), "");
         conf.put(DefaultConfSettings.NEIGHBORS.name(), "");
         conf.put(DefaultConfSettings.IXI_DIR.name(), "ixi");
-        conf.put(DefaultConfSettings.DB_PATH.name(), "mainnetdb");
-        conf.put(DefaultConfSettings.DB_LOG_PATH.name(), "mainnet.log");
+        conf.put(DefaultConfSettings.DB_PATH.name(), "testnetdb");
+        conf.put(DefaultConfSettings.DB_LOG_PATH.name(), "testnet.log");
         conf.put(DefaultConfSettings.DB_CACHE_SIZE.name(), "100000"); //KB
         conf.put(DefaultConfSettings.CONFIG.name(), "iota.ini");
         conf.put(DefaultConfSettings.P_REMOVE_REQUEST.name(), "0.01");
         conf.put(DefaultConfSettings.P_DROP_TRANSACTION.name(), "0.0");
         conf.put(DefaultConfSettings.P_SELECT_MILESTONE_CHILD.name(), "0.7");
         conf.put(DefaultConfSettings.P_SEND_MILESTONE.name(), "0.02");
-        conf.put(DefaultConfSettings.P_REPLY_RANDOM_TIP.name(), "0.66");
+        conf.put(DefaultConfSettings.P_REPLY_RANDOM_TIP.name(), "1.00");
         conf.put(DefaultConfSettings.P_PROPAGATE_REQUEST.name(), "0.01");
         conf.put(DefaultConfSettings.MAIN_DB.name(), "rocksdb");
         conf.put(DefaultConfSettings.EXPORT.name(), "false");
@@ -97,7 +97,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.REVALIDATE.name(), "false");
         conf.put(DefaultConfSettings.RESCAN_DB.name(), "false");
         conf.put(DefaultConfSettings.MAINNET_MWM.name(), "14");
-        conf.put(DefaultConfSettings.TESTNET_MWM.name(), "13");
+        conf.put(DefaultConfSettings.TESTNET_MWM.name(), "9");
 
         // Pick a number based on best performance
         conf.put(DefaultConfSettings.MIN_RANDOM_WALKS.name(), "5");

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -44,12 +44,12 @@ public class Node {
     private static final Logger log = LoggerFactory.getLogger(Node.class);
 
 
-    public  static final int TRANSACTION_PACKET_SIZE = 1650;
+    public  static final int TRANSACTION_PACKET_SIZE = 1653;
     private static final int QUEUE_SIZE = 1000;
     private static final int RECV_QUEUE_SIZE = 1000;
     private static final int REPLY_QUEUE_SIZE = 1000;
     private static final int PAUSE_BETWEEN_TRANSACTIONS = 1;
-    public  static final int REQUEST_HASH_SIZE = 46;
+    public  static final int REQUEST_HASH_SIZE = 49;
     private static double P_SELECT_MILESTONE;
 
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);

--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -21,7 +21,7 @@ public class TransactionRequester {
     private final Set<Hash> milestoneTransactionsToRequest = new LinkedHashSet<>();
     private final Set<Hash> transactionsToRequest = new LinkedHashSet<>();
     private static volatile long lastTime = System.currentTimeMillis();
-    public  static final int REQUEST_HASH_SIZE = 46;
+    public  static final int REQUEST_HASH_SIZE = 49;
     private static final byte[] NULL_REQUEST_HASH_BYTES = new byte[REQUEST_HASH_SIZE];
 
     private static double P_REMOVE_REQUEST;

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 public class TransactionValidatorTest {
 
   private static final int MAINNET_MWM = 14;
-  private static final int TESTNET_MWM = 13;
+  private static final int TESTNET_MWM = 9;
   private static final TemporaryFolder dbFolder = new TemporaryFolder();
   private static final TemporaryFolder logFolder = new TemporaryFolder();
   private static Tangle tangle;
@@ -57,7 +57,7 @@ public class TransactionValidatorTest {
   public void testMinMwm() throws InterruptedException {
     txValidator.shutdown();
     txValidator.init(false, 5, 3);
-    assertTrue(txValidator.getMinWeightMagnitude() == 13);
+    assertTrue(txValidator.getMinWeightMagnitude() == 9);
     txValidator.shutdown();
     txValidator.init(false, MAINNET_MWM, TESTNET_MWM);
   }


### PR DESCRIPTION
Please mark ```maven``` version on __README.md__ .
```maven 3.5.2``` doesn't package iri ,but ```maven 3.0.5``` can .
If you use ```3.5.2```  got this error: 
```
maven-surefire-plugin:2.12.4:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ?
```