### PR TITLE
Cleanup in API.java

### DIFF
--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -2,7 +2,6 @@ package com.iota.iri.service;
 
 import java.util.*;
 
-import com.iota.iri.BundleValidator;
 import com.iota.iri.LedgerValidator;
 import com.iota.iri.TransactionValidator;
 import com.iota.iri.model.Hash;
@@ -124,7 +123,7 @@ public class TipsManager {
                 e.printStackTrace();
                 log.error("Encountered error: " + e.getLocalizedMessage());
             } finally {
-                API.incEllapsedTime_getTxToApprove(System.nanoTime() - startTime);
+                API.incElapsedTime_getTxToApprove(System.nanoTime() - startTime);
             }
         }
         return null;


### PR DESCRIPTION
- Typos, "ellapsed" -> "elapsed"
- member visibility, several static methods visibility moved to private or package
- tidy, several static counters that were declared throughout the file moved to the start
- tidy, line spacing between methods
- padTag() implementation optimized to not create unnecessary String instances with += operator using StringBuilder
- Simplified getParameterAsSet(), avoid use of stream api for sake of being cool, a simple copy HashSet constructor performs better avoiding the creation of temporary objects created with .stream().collect, also simpler easier to read/maintain.
- imports optimized

Should be warning free now.