### PR TITLE
Rocks db test - split values over keys

### DIFF
--- a/src/main/java/com/iota/iri/model/Hash.java
+++ b/src/main/java/com/iota/iri/model/Hash.java
@@ -119,9 +119,8 @@ public class Hash implements Serializable, Indexable {
 
 	private void fullRead(byte[] bytes, int offset, int size) {
         this.bytes = new byte[SIZE_IN_BYTES];
-        System.arraycopy(bytes, offset, this.bytes, 0, size - offset > bytes.length ? bytes.length-offset: size);
+        System.arraycopy(bytes, offset, this.bytes, 0, bytes.length - offset < size ? bytes.length-offset: size);
         hashCode = Arrays.hashCode(this.bytes);
-
     }
 
     @Override
@@ -139,7 +138,6 @@ public class Hash implements Serializable, Indexable {
         return null;
     }
 
-    @Override
     public int compareTo(Indexable indexable) {
         Hash hash = new Hash(indexable.bytes());
         if (this.equals(hash)) {

--- a/src/main/java/com/iota/iri/model/Hashes.java
+++ b/src/main/java/com/iota/iri/model/Hashes.java
@@ -3,28 +3,41 @@ package com.iota.iri.model;
 import com.iota.iri.storage.Persistable;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.Serializable;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import javax.naming.OperationNotSupportedException;
+import java.util.*;
 
 /**
  * Created by paul on 3/8/17 for iri.
  */
 public class Hashes implements Persistable {
     public Set<Hash> set = new LinkedHashSet<>();
-    private static final byte delimiter = ",".getBytes()[0];
+    public static final byte DELIMITER = ",".getBytes()[0];
 
     public byte[] bytes() {
-        return set.parallelStream()
-                .map(Hash::bytes)
-                .reduce((a,b) -> ArrayUtils.addAll(ArrayUtils.add(a, delimiter), b))
-                .orElse(new byte[0]);
+        //I assume this is the maximal size of the array
+        int setSize = set.size();
+        int numOfBytes = setSize == 0 ? 0 : (Hash.SIZE_IN_BYTES + 1) * setSize - 1;
+        byte[] bytes = new byte[numOfBytes];
+
+        int i = 0;
+        for (Hash hash : set) {
+            byte[] hashBytes = hash.bytes();
+            System.arraycopy(hashBytes, 0, bytes, i * (hashBytes.length + 1), hashBytes.length);
+            int delimiterIndex = ++i*(hashBytes.length + 1) - 1;
+            //do not include last delimiter
+            if (delimiterIndex < bytes.length){
+                bytes[delimiterIndex] = DELIMITER;
+            }
+        }
+        return bytes;
     }
 
     public void read(byte[] bytes) {
-        if(bytes != null) {
-            set = new LinkedHashSet<>(bytes.length / (1 + Hash.SIZE_IN_BYTES) + 1);
+        if (bytes != null) {
+            // read will do an append operation
+            if (set == null) {
+                set = new LinkedHashSet<>(bytes.length / (1 + Hash.SIZE_IN_BYTES) + 1);
+            }
             for (int i = 0; i < bytes.length; i += 1 + Hash.SIZE_IN_BYTES) {
                 set.add(new Hash(bytes, i, Hash.SIZE_IN_BYTES));
             }
@@ -44,5 +57,73 @@ public class Hashes implements Persistable {
     @Override
     public boolean merge() {
         return true;
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return true;
+    }
+
+    @Override
+    public List<byte[]> splitBytes(int maxByteLength) throws OperationNotSupportedException {
+        //TODO if average hashes size is known you can precalculate List size and decrease memory reallocations
+        List<byte[]> serializedBytes = new ArrayList<>();
+        byte[] bytes = new byte[maxByteLength];
+        int currPos = 0;
+        for (Hash hash : set) {
+            byte[] hashBytes = hash.bytes();
+            if (currPos + hashBytes.length <= maxByteLength) {
+                currPos = addHashToBytesArray(bytes, currPos, hashBytes);
+            } else {
+                serializedBytes = addBytesToList(serializedBytes, bytes, currPos);
+                //reinitialize
+                bytes = new byte[maxByteLength];
+                currPos = addHashToBytesArray(bytes, 0, hashBytes);
+            }
+        }
+        //--currPos to delete delimiter
+        serializedBytes = addBytesToList(serializedBytes, bytes, --currPos);
+        return serializedBytes;
+    }
+
+    private List<byte[]> addBytesToList(List<byte[]> serializedBytes, byte[] bytes, int currPos) {
+        //truncate array
+        bytes = ArrayUtils.subarray(bytes,0, currPos);
+        //add to list
+        serializedBytes.add(bytes);
+
+        return serializedBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Hashes)) {
+            return false;
+        }
+        Hashes hashes = (Hashes) o;
+        return Objects.equals(set, hashes.set);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Hashes{");
+        sb.append("set=").append(set);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(set);
+    }
+
+    private int addHashToBytesArray(byte[] bytes, int currPos, byte[] hashBytes) {
+        System.arraycopy(hashBytes, 0, bytes, currPos, hashBytes.length);
+        currPos += hashBytes.length;
+        bytes[currPos] = DELIMITER;
+        return ++currPos;
     }
 }

--- a/src/main/java/com/iota/iri/model/Milestone.java
+++ b/src/main/java/com/iota/iri/model/Milestone.java
@@ -4,9 +4,8 @@ import com.iota.iri.storage.Persistable;
 import com.iota.iri.utils.Serializer;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.Serializable;
-import java.nio.ByteBuffer;
-import java.util.Map;
+import javax.naming.OperationNotSupportedException;
+import java.util.List;
 
 /**
  * Created by paul on 4/11/17.
@@ -39,5 +38,15 @@ public class Milestone implements Persistable {
     @Override
     public boolean merge() {
         return false;
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return false;
+    }
+
+    @Override
+    public List<byte[]> splitBytes(int maxByteLength) throws OperationNotSupportedException {
+        throw new OperationNotSupportedException();
     }
 }

--- a/src/main/java/com/iota/iri/model/StateDiff.java
+++ b/src/main/java/com/iota/iri/model/StateDiff.java
@@ -4,9 +4,10 @@ import com.iota.iri.storage.Persistable;
 import com.iota.iri.utils.Serializer;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.Serializable;
+import javax.naming.OperationNotSupportedException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -44,5 +45,15 @@ public class StateDiff implements Persistable {
     @Override
     public boolean merge() {
         return false;
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return false;
+    }
+
+    @Override
+    public List<byte[]> splitBytes(int maxByteLength) throws OperationNotSupportedException {
+        throw new OperationNotSupportedException();
     }
 }

--- a/src/main/java/com/iota/iri/model/Transaction.java
+++ b/src/main/java/com/iota/iri/model/Transaction.java
@@ -4,7 +4,9 @@ import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.utils.Serializer;
 
+import javax.naming.OperationNotSupportedException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 /**
  * Created by paul on 3/2/17 for iri.
@@ -45,7 +47,7 @@ public class Transaction implements Persistable {
     }
 
     public void read(byte[] bytes) {
-        if(bytes != null) {
+        if (bytes != null) {
             this.bytes = new byte[SIZE];
             System.arraycopy(bytes, 0, this.bytes, 0, SIZE);
             this.type = TransactionViewModel.FILLED_SLOT;
@@ -90,7 +92,7 @@ public class Transaction implements Persistable {
     @Override
     public void readMetadata(byte[] bytes) {
         int i = 0;
-        if(bytes != null) {
+        if (bytes != null) {
             address = new Hash(bytes, i, Hash.SIZE_IN_BYTES);
             i += Hash.SIZE_IN_BYTES;
             bundle = new Hash(bytes, i, Hash.SIZE_IN_BYTES);
@@ -147,5 +149,15 @@ public class Transaction implements Persistable {
     @Override
     public boolean merge() {
         return false;
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return false;
+    }
+
+    @Override
+    public List<byte[]> splitBytes(int maxByteLength) throws OperationNotSupportedException {
+        throw new OperationNotSupportedException();
     }
 }

--- a/src/main/java/com/iota/iri/storage/Persistable.java
+++ b/src/main/java/com/iota/iri/storage/Persistable.java
@@ -1,6 +1,8 @@
 package com.iota.iri.storage;
 
+import javax.naming.OperationNotSupportedException;
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Created by paul on 5/6/17.
@@ -11,4 +13,16 @@ public interface Persistable extends Serializable {
     byte[] metadata();
     void readMetadata(byte[] bytes);
     boolean merge();
+
+    /**
+     * @return true if the {@link Persistable} object can be splitBytes to multiple byte arrays.
+     */
+    boolean isSplittable();
+
+    /**
+     * @return a list of byte arrays that represent the serialized object.
+     * @throws OperationNotSupportedException if {@link #isSplittable()} returns false.
+     * @param maxByteLength
+     */
+    List<byte[]> splitBytes(int maxByteLength) throws OperationNotSupportedException;
 }

--- a/src/main/java/com/iota/iri/storage/PersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/PersistenceProvider.java
@@ -1,10 +1,8 @@
 package com.iota.iri.storage;
 
-import com.iota.iri.model.*;
 import com.iota.iri.utils.Pair;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -44,5 +42,6 @@ public interface PersistenceProvider {
     boolean saveBatch(List<Pair<Indexable, Persistable>> models) throws Exception;
 
     void clear(Class<?> column) throws Exception;
+
     void clearMetadata(Class<?> column) throws Exception;
 }

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -4,13 +4,17 @@ import com.iota.iri.model.*;
 import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.storage.PersistenceProvider;
+import com.iota.iri.utils.IotaUtils;
 import com.iota.iri.utils.Pair;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.rocksdb.*;
 import org.rocksdb.util.SizeUnit;
 import org.slf4j.LoggerFactory;
 
+import javax.naming.OperationNotSupportedException;
 import java.io.File;
+import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.*;
@@ -22,9 +26,20 @@ import java.util.stream.Collectors;
  */
 public class RocksDBPersistenceProvider implements PersistenceProvider {
 
+    /**
+     * Split values that are above this byte length
+     */
+    //TODO current value is arbitrary, make configurable. Change only the multiplier so no unit test will fail.
+    //size of Hash + 1 byte because of the delimiter
+    public static final int BYTE_LENGTH_SPLIT = (Hash.SIZE_IN_BYTES + 1)*20;
+    /**
+     * The maximal byte size a value in a key-value pair will not be above
+     * {@code BYTE_LENGTH_SPLIT} * ({@code MAX_BYTE_RATIO} + 1)
+     */
+    //TODO current value is arbitrary. please change or make configurable
+    public static final double MAX_BYTE_RATIO = 0.75;
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(RocksDBPersistenceProvider.class);
     private static final int BLOOM_FILTER_BITS_PER_KEY = 10;
-
     private final List<String> columnFamilyNames = Arrays.asList(
             new String(RocksDB.DEFAULT_COLUMN_FAMILY),
             "transaction",
@@ -39,7 +54,9 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     private final String dbPath;
     private final String logPath;
     private final int cacheSize;
-
+    private final AtomicReference<Map<Class<?>, ColumnFamilyHandle>> classTreeMap = new AtomicReference<>();
+    private final AtomicReference<Map<Class<?>, ColumnFamilyHandle>> metadataReference = new AtomicReference<>();
+    private final SecureRandom seed = new SecureRandom();
     private ColumnFamilyHandle transactionHandle;
     private ColumnFamilyHandle transactionMetadataHandle;
     private ColumnFamilyHandle milestoneHandle;
@@ -48,14 +65,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     private ColumnFamilyHandle approveeHandle;
     private ColumnFamilyHandle bundleHandle;
     private ColumnFamilyHandle tagHandle;
-
     private List<ColumnFamilyHandle> transactionGetList;
-
-    private final AtomicReference<Map<Class<?>, ColumnFamilyHandle>> classTreeMap = new AtomicReference<>();
-    private final AtomicReference<Map<Class<?>, ColumnFamilyHandle>> metadataReference = new AtomicReference<>();
-
-    private final SecureRandom seed = new SecureRandom();
-
     private RocksDB db;
     private DBOptions options;
     private BloomFilter bloomFilter;
@@ -114,19 +124,73 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     }
 
     @Override
-    public boolean save(Persistable thing, Indexable index) throws Exception {
-        ColumnFamilyHandle handle = classTreeMap.get().get(thing.getClass());
+    public boolean save(Persistable model, Indexable index) throws OperationNotSupportedException, RocksDBException {
+        ColumnFamilyHandle handle = classTreeMap.get().get(model.getClass());
         /*
         if( !db.keyMayExist(handle, index.bytes(), new StringBuffer()) ) {
             counts.put(thing.getClass(), counts.get(thing.getClass()) + 1);
         }
         */
-        db.put(handle, index.bytes(), thing.bytes());
-        ColumnFamilyHandle referenceHandle = metadataReference.get().get(thing.getClass());
-        if(referenceHandle != null) {
-            db.put(referenceHandle, index.bytes(), thing.metadata());
+
+        if (model.isSplittable()) {
+            try (WriteBatch writeBatch = new WriteBatch();
+                 WriteOptions writeOptions = new WriteOptions()) {
+                saveSplittable(model, index, handle, writeBatch);
+                db.write(writeOptions, writeBatch);
+            }
+        } else {
+            db.put(handle, index.bytes(), model.bytes());
+        }
+        //TODO should metadata be only on the first index in case of splitBytes?
+        ColumnFamilyHandle referenceHandle = metadataReference.get().get(model.getClass());
+        if (referenceHandle != null) {
+            db.put(referenceHandle, index.bytes(), model.metadata());
         }
         return true;
+    }
+
+    private void saveSplittable(Persistable model, Indexable index, ColumnFamilyHandle handle, WriteBatch writeBatch) throws OperationNotSupportedException {
+        byte[] startIndexBytes = createSplitIndexBytes(index, 0);
+        List<Pair<byte[], byte[]>> splitModelAndIndexPairs = createSplitModelAndIndexPairs(model, startIndexBytes);
+
+        Set<byte[]> newIndexes = splitModelAndIndexPairs.stream()
+                .map(pair -> pair.hi)
+                .collect(Collectors.toSet());
+        List<byte[]> oldIndexes = listKeyBytesThatHoldSplitValue(model.getClass(), index);
+        Set<byte[]> oldBytes = oldIndexes.stream()
+                .filter(oldIndex -> !IotaUtils.containsArray(newIndexes, oldIndex) )
+                .collect(Collectors.toSet());
+
+        for (byte[] oldByte : oldBytes) {
+            writeBatch.remove(handle, oldByte);
+        }
+        for (Pair<byte[], byte[]> pair : splitModelAndIndexPairs) {
+            writeBatch.put(handle, pair.hi, pair.low);
+        }
+    }
+
+    private List<Pair<byte[], byte[]>> createSplitModelAndIndexPairs(Persistable model, byte[] startKey) throws OperationNotSupportedException {
+        int keyOffsetIndex = startKey.length - 4;
+        List<byte[]> splitModelBytes = model.splitBytes(BYTE_LENGTH_SPLIT);
+        int size = splitModelBytes.size();
+        ByteBuffer byteBuffer = ByteBuffer.wrap(startKey);
+        int offset = byteBuffer.getInt(keyOffsetIndex);
+        List<Pair<byte[], byte[]>> modelAndIndex = new ArrayList<>(size);
+        for (byte[] modelBytes : splitModelBytes) {
+            startKey = ArrayUtils.clone(startKey);
+            ByteBuffer.wrap(startKey)
+                    .putInt(keyOffsetIndex, offset++);
+            modelAndIndex.add(new Pair<>(modelBytes, startKey));
+        }
+        return modelAndIndex;
+    }
+
+    private byte[] createSplitIndexBytes(Indexable index, int indexOffset) {
+        byte[] bytes = index.bytes();
+        return ArrayUtils.addAll(bytes,
+                ByteBuffer.wrap(new byte[4])
+                        .putInt(indexOffset)
+                        .array());
     }
 
     @Override
@@ -136,7 +200,28 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
             counts.put(model, counts.get(model) + 1);
         }
         */
-        db.delete(classTreeMap.get().get(model), index.bytes());
+        delete((Class<? extends Persistable>) model, index, 0);
+    }
+
+    public void delete(Class<? extends Persistable> model, Indexable index, int offset) throws RocksDBException,
+            IllegalAccessException, InstantiationException {
+        ColumnFamilyHandle columnFamilyHandle = classTreeMap.get().get(model);
+        if (model.newInstance().isSplittable()) {
+            try (WriteBatch writeBatch = new WriteBatch();
+                 WriteOptions writeOptions = new WriteOptions()) {
+                List<byte[]> keyBytes = listKeyBytesThatHoldSplitValue(model, index);
+                for (int i = offset; i < keyBytes.size(); ++i) {
+                    byte[] indexBytes = keyBytes.get(i);
+                    writeBatch.remove(columnFamilyHandle, indexBytes);
+                }
+                db.write(writeOptions, writeBatch);
+                //Only good if there is a big range of deleted keys... Consider removing
+                //See https://github.com/facebook/rocksdb/wiki/Delete-A-Range-Of-Keys
+                db.compactRange(columnFamilyHandle, keyBytes.get(offset), keyBytes.get(keyBytes.size() - 1));
+            }
+        } else {
+            db.delete(classTreeMap.get().get(model), index.bytes());
+        }
     }
 
     @Override
@@ -151,13 +236,13 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         final Persistable object;
         RocksIterator iterator = db.newIterator(classTreeMap.get().get(model));
         iterator.seekToLast();
-        if(iterator.isValid()) {
+        if (iterator.isValid()) {
             object = (Persistable) model.newInstance();
             index = (Indexable) indexModel.newInstance();
             index.read(iterator.key());
             object.read(iterator.value());
             ColumnFamilyHandle referenceHandle = metadataReference.get().get(model);
-            if(referenceHandle != null) {
+            if (referenceHandle != null) {
                 object.readMetadata(db.get(referenceHandle, iterator.key()));
             }
         } else {
@@ -174,8 +259,8 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         ColumnFamilyHandle otherHandle = classTreeMap.get().get(other);
         RocksIterator iterator = db.newIterator(handle);
         Set<Indexable> indexables = new HashSet<>();
-        for(iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
-            if(db.get(otherHandle, iterator.key()) == null) {
+        for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
+            if (db.get(otherHandle, iterator.key()) == null) {
                 indexables.add(new Hash(iterator.key()));
             }
         }
@@ -185,11 +270,47 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
 
     @Override
     public Persistable get(Class<?> model, Indexable index) throws Exception {
-        Persistable object = (Persistable) model.newInstance();
-        object.read(db.get(classTreeMap.get().get(model), index == null? new byte[0]: index.bytes()));
+        return get((Class<? extends Persistable>) model, index, 0, Integer.MAX_VALUE);
+    }
+
+    /**
+     * fetch from db an object splitted over several consecutive keys. The inclusive
+     * {@code splitStart} and exclusive {@code splitEnd} will define the window from which you
+     * fetch the values
+     *
+     * @param model      the type of the returned object
+     * @param index      the start index. This is the only index the user is aware of.
+     * @param splitStart the inclusive offset from the index to start fetching from
+     * @param splitEnd   the exclusive offset from the
+     * @return a {@link Persistable} object from the db
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     * @throws RocksDBException
+     */
+    public Persistable get(Class<? extends Persistable> model, Indexable index, int splitStart, int splitEnd) throws IllegalAccessException,
+            InstantiationException, RocksDBException {
+        if (splitStart >= splitEnd) {
+            // You guys usually use "assert". However in java it is considered best practice to throw an exact exception
+            // so it can be handled correctly. Especially when it comes to checking user inputs.
+            // Besides the above, "assert" statement can be mistakenly turned off in Runtime by VM args.
+            throw new IllegalArgumentException(String.format("When fetching an object that is splitBytes over several keys," +
+                    "the start offset %d should be less than the end offset %d", splitStart, splitEnd));
+        }
+        Persistable object = model.newInstance();
+        ColumnFamilyHandle columnFamilyHandle = classTreeMap.get().get(model);
+        if (object.isSplittable()) {
+            List<byte[]> keysThatHoldSplitValue = listKeyBytesThatHoldSplitValue(model, index);
+            for (int i = splitStart; i < Math.min(keysThatHoldSplitValue.size(), splitEnd); ++i) {
+                byte[] key = keysThatHoldSplitValue.get(i);
+                byte[] bytes = db.get(columnFamilyHandle, key == null ? new byte[0] : key);
+                object.read(bytes);
+            }
+        } else {
+            object.read(db.get(columnFamilyHandle, index == null ? new byte[0] : index.bytes()));
+        }
         ColumnFamilyHandle referenceHandle = metadataReference.get().get(model);
-        if(referenceHandle != null) {
-            object.readMetadata(db.get(referenceHandle, index == null? new byte[0]: index.bytes()));
+        if (referenceHandle != null) {
+            object.readMetadata(db.get(referenceHandle, index == null ? new byte[0] : index.bytes()));
         }
         return object;
     }
@@ -216,7 +337,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     public Set<Indexable> keysStartingWith(Class<?> modelClass, byte[] value) {
         RocksIterator iterator;
         ColumnFamilyHandle handle = classTreeMap.get().get(modelClass);
-        Set<Indexable> keys = new HashSet<>();
+        Set<Indexable> keys = new LinkedHashSet<>();
         if(handle != null) {
             iterator = db.newIterator(handle);
             try {
@@ -233,13 +354,32 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         return keys;
     }
 
+    private List<byte[]> listKeyBytesThatHoldSplitValue(Class<? extends Persistable> modelClass, Indexable index) {
+        List<byte[]> keyBytes = new ArrayList<>();
+        ColumnFamilyHandle columnFamilyHandle = classTreeMap.get().get(modelClass);
+        if (columnFamilyHandle != null) {
+            byte[] indexBytes = index.bytes();
+            try (RocksIterator iterator = db.newIterator(columnFamilyHandle)) {
+                iterator.seek(indexBytes);
+                while (iterator.isValid()
+                        && Arrays.equals(Arrays.copyOf(iterator.key(), indexBytes.length), indexBytes)) {
+                    byte[] key = iterator.key();
+                    keyBytes.add(key);
+                    iterator.next();
+                }
+            }
+        }
+        return keyBytes;
+    }
+
     @Override
     public Persistable seek(Class<?> model, byte[] key) throws Exception {
         Set<Indexable> hashes = keysStartingWith(model, key);
         Indexable out;
-        if(hashes.size() == 1) {
+        if (hashes.size() == 1) {
             out = (Indexable) hashes.toArray()[0];
         } else if (hashes.size() > 1) {
+            //Is random behavior correct?
             out = (Indexable) hashes.toArray()[seed.nextInt(hashes.size())];
         } else {
             out = null;
@@ -254,13 +394,13 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         final Indexable indexable;
         iterator.seek(index.bytes());
         iterator.next();
-        if(iterator.isValid()) {
+        if (iterator.isValid()) {
             object = (Persistable) model.newInstance();
             indexable = index.getClass().newInstance();
             indexable.read(iterator.key());
             object.read(iterator.value());
             ColumnFamilyHandle referenceHandle = metadataReference.get().get(model);
-            if(referenceHandle != null) {
+            if (referenceHandle != null) {
                 object.readMetadata(db.get(referenceHandle, iterator.key()));
             }
         } else {
@@ -278,13 +418,13 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         final Indexable indexable;
         iterator.seek(index.bytes());
         iterator.prev();
-        if(iterator.isValid()) {
+        if (iterator.isValid()) {
             object = (Persistable) model.newInstance();
             object.read(iterator.value());
             indexable = (Indexable) index.getClass().newInstance();
             indexable.read(iterator.key());
             ColumnFamilyHandle referenceHandle = metadataReference.get().get(model);
-            if(referenceHandle != null) {
+            if (referenceHandle != null) {
                 object.readMetadata(db.get(referenceHandle, iterator.key()));
             }
         } else {
@@ -301,13 +441,13 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         final Persistable object;
         final Indexable indexable;
         iterator.seekToFirst();
-        if(iterator.isValid()) {
+        if (iterator.isValid()) {
             object = (Persistable) model.newInstance();
             object.read(iterator.value());
             indexable = (Indexable) index.newInstance();
             indexable.read(iterator.key());
             ColumnFamilyHandle referenceHandle = metadataReference.get().get(model);
-            if(referenceHandle != null) {
+            if (referenceHandle != null) {
                 object.readMetadata(db.get(referenceHandle, iterator.key()));
             }
         } else {
@@ -318,33 +458,93 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         return new Pair<>(indexable, object);
     }
 
+    /**
+     * Append an an entry at index. If entry is splittable add 4 bytes to the index
+     * and add with incrementing offsets.
+     *
+     * @param model model to be persisted
+     * @param index index to persist the object
+     * @return true if the data was merged with an existing entry at {@code index}
+     * @throws Exception
+     */
     public boolean merge(Persistable model, Indexable index) throws Exception {
-        boolean exists = mayExist(model.getClass(), index);
-        db.merge(classTreeMap.get().get(model.getClass()), index.bytes(), model.bytes());
+        boolean exists;
+        ColumnFamilyHandle handle = classTreeMap.get().get(model.getClass());
+        if (model.isSplittable()) {
+            try (WriteBatch writeBatch = new WriteBatch();
+                 WriteOptions writeOptions = new WriteOptions()) {
+                exists = mergeSplittable(model, index, handle, writeBatch);
+                db.write(writeOptions, writeBatch);
+            }
+        } else {
+            exists = mayExist(model.getClass(), index);
+            db.merge(handle, index.bytes(), model.bytes());
+        }
         return exists;
+    }
+
+    private boolean mergeSplittable(Persistable model, Indexable index, ColumnFamilyHandle handle, WriteBatch writeBatch) throws RocksDBException, OperationNotSupportedException {
+        List<byte[]> indexBytes = listKeyBytesThatHoldSplitValue(model.getClass(), index);
+        byte[] lastSplitKey;
+        boolean exists = false;
+        if (indexBytes.isEmpty()) {
+            byte[] bytes = index.bytes();
+            lastSplitKey = new byte[bytes.length + 4];
+            System.arraycopy(bytes,0,lastSplitKey,0 ,bytes.length);
+        }
+        else {
+            lastSplitKey = indexBytes.get(indexBytes.size() - 1);
+            exists = true;
+        }
+        lastSplitKey = determineMergeStartPoint(handle, lastSplitKey, writeBatch);
+        List<Pair<byte[], byte[]>> splitModelAndIndexPairs = createSplitModelAndIndexPairs(model, lastSplitKey);
+        for (Pair<byte[], byte[]> pair : splitModelAndIndexPairs) {
+            writeBatch.merge(handle, pair.hi, pair.low);
+        }
+        return exists;
+    }
+
+    private byte[] determineMergeStartPoint(ColumnFamilyHandle handle, byte[] lastSplitKey, WriteBatch writeBatch) throws RocksDBException {
+        byte[] dbEntry = db.get(handle, lastSplitKey);
+        if (dbEntry != null && dbEntry.length >= MAX_BYTE_RATIO * BYTE_LENGTH_SPLIT) {
+            //assume no more than 127 splits. I this isn't enough we need to make the suffix longer
+            ++lastSplitKey[lastSplitKey.length -1];
+        }
+
+        return lastSplitKey;
     }
 
     @Override
     public boolean saveBatch(List<Pair<Indexable, Persistable>> models) throws Exception {
-        WriteBatch writeBatch = new WriteBatch();
-        WriteOptions writeOptions = new WriteOptions();
-        for(Pair<Indexable, Persistable> entry: models) {
-            Indexable key = entry.low;
-            Persistable value = entry.hi;
-            ColumnFamilyHandle handle = classTreeMap.get().get(value.getClass());
-            ColumnFamilyHandle referenceHandle = metadataReference.get().get(value.getClass());
-            if(value.merge()) {
-                writeBatch.merge(handle, key.bytes(), value.bytes());
-            } else {
-                writeBatch.put(handle, key.bytes(), value.bytes());
+        try (WriteBatch writeBatch = new WriteBatch();
+             WriteOptions writeOptions = new WriteOptions()) {
+            for (Pair<Indexable, Persistable> entry : models) {
+                Indexable key = entry.low;
+                Persistable value = entry.hi;
+                ColumnFamilyHandle handle = classTreeMap.get().get(value.getClass());
+                ColumnFamilyHandle referenceHandle = metadataReference.get().get(value.getClass());
+                if (value.merge()) {
+                    if (value.isSplittable()) {
+                        mergeSplittable(value, key, handle, writeBatch);
+                    }
+                    else {
+                        writeBatch.merge(handle, key.bytes(), value.bytes());
+                    }
+                }
+                else {
+                    if (value.isSplittable()) {
+                        saveSplittable(value, key, handle, writeBatch);
+                    }
+                    else {
+                        writeBatch.put(handle, key.bytes(), value.bytes());
+                    }
+                }
+                if (referenceHandle != null) {
+                    writeBatch.put(referenceHandle, key.bytes(), value.metadata());
+                }
             }
-            if(referenceHandle != null) {
-                writeBatch.put(referenceHandle, key.bytes(), value.metadata());
-            }
+            db.write(writeOptions, writeBatch);
         }
-        db.write(writeOptions, writeBatch);
-        writeBatch.close();
-        writeOptions.close();
         return true;
     }
 
@@ -361,14 +561,14 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     private void flushHandle(ColumnFamilyHandle handle) throws RocksDBException {
         List<byte[]> itemsToDelete = new ArrayList<>();
         RocksIterator iterator = db.newIterator(handle);
-        for(iterator.seekToLast(); iterator.isValid(); iterator.prev()) {
+        for (iterator.seekToLast(); iterator.isValid(); iterator.prev()) {
             itemsToDelete.add(iterator.key());
         }
         iterator.close();
-        if(itemsToDelete.size() > 0) {
+        if (itemsToDelete.size() > 0) {
             log.info("Flushing flags. Amount to delete: " + itemsToDelete.size());
         }
-        for(byte[] itemToDelete: itemsToDelete) {
+        for (byte[] itemToDelete : itemsToDelete) {
             db.delete(handle, itemToDelete);
         }
     }
@@ -377,7 +577,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     @Override
     public boolean update(Persistable thing, Indexable index, String item) throws Exception {
         ColumnFamilyHandle referenceHandle = metadataReference.get().get(thing.getClass());
-        if(referenceHandle != null) {
+        if (referenceHandle != null) {
             db.put(referenceHandle, index.bytes(), thing.metadata());
         }
         return false;
@@ -407,7 +607,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         backupableDBOptions = new BackupableDBOptions(path);
         backupEngine = BackupEngine.open(env, backupableDBOptions);
         shutdown();
-        try(final RestoreOptions restoreOptions = new RestoreOptions(false)){
+        try (final RestoreOptions restoreOptions = new RestoreOptions(false)) {
             backupEngine.restoreDbFromLatestBackup(path, logPath, restoreOptions);
         } finally {
             backupEngine.close();
@@ -420,8 +620,8 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
     private void initDB(String path, String logPath) throws Exception {
         try {
             RocksDB.loadLibrary();
-        } catch(Exception e) {
-            if(SystemUtils.IS_OS_WINDOWS) {
+        } catch (Exception e) {
+            if (SystemUtils.IS_OS_WINDOWS) {
                 log.error("Error loading RocksDB library. " +
                         "Please ensure that " +
                         "Microsoft Visual C++ 2015 Redistributable Update 3 " +
@@ -432,13 +632,13 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         Thread.yield();
 
         File pathToLogDir = Paths.get(logPath).toFile();
-        if(!pathToLogDir.exists() || !pathToLogDir.isDirectory()) {
+        if (!pathToLogDir.exists() || !pathToLogDir.isDirectory()) {
             pathToLogDir.mkdir();
         }
 
         RocksEnv.getDefault()
-                .setBackgroundThreads(Runtime.getRuntime().availableProcessors()/2, RocksEnv.FLUSH_POOL)
-                .setBackgroundThreads(Runtime.getRuntime().availableProcessors()/2, RocksEnv.COMPACTION_POOL)
+                .setBackgroundThreads(Runtime.getRuntime().availableProcessors() / 2, RocksEnv.FLUSH_POOL)
+                .setBackgroundThreads(Runtime.getRuntime().availableProcessors() / 2, RocksEnv.COMPACTION_POOL)
         /*
                 .setBackgroundThreads(Runtime.getRuntime().availableProcessors())
         */
@@ -452,6 +652,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
                 .setMaxManifestFileSize(SizeUnit.MB)
                 .setMaxOpenFiles(10000)
                 .setMaxBackgroundCompactions(1)
+
                 /*
                 .setBytesPerSync(4 * SizeUnit.MB)
                 .setMaxTotalWalSize(16 * SizeUnit.MB)
@@ -495,8 +696,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
                 /*
                 .setCompactionStyle(CompactionStyle.UNIVERSAL)
                 .setCompressionType(CompressionType.SNAPPY_COMPRESSION)
-                */
-                ;
+                */;
         //columnFamilyOptions.setMemTableConfig(hashSkipListMemTableConfig);
 
         List<ColumnFamilyHandle> familyHandles = new ArrayList<>();
@@ -506,7 +706,6 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         List<ColumnFamilyDescriptor> columnFamilyDescriptors = columnFamilyNames.stream().map(name -> new ColumnFamilyDescriptor(name.getBytes(), columnFamilyOptions)).collect(Collectors.toList());
         //fillMissingColumns(columnFamilyDescriptors, familyHandles, path);
         db = RocksDB.open(options, path, columnFamilyDescriptors, familyHandles);
-        db.enableFileDeletions(true);
 
         fillmodelColumnHandles(familyHandles);
     }
@@ -524,35 +723,16 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         tagHandle = familyHandles.get(++i);
         //hashesHandle = familyHandles.get(++i);
 
-        for(; ++i < familyHandles.size();) {
+        for (; ++i < familyHandles.size(); ) {
             db.dropColumnFamily(familyHandles.get(i));
         }
 
         transactionGetList = new ArrayList<>();
-        for(i = 1; i < 5; i ++) {
+        for (i = 1; i < 5; i++) {
             transactionGetList.add(familyHandles.get(i));
         }
     }
 
-    @FunctionalInterface
-    private interface MyFunction<T, R> {
-        R apply(T t) throws Exception;
-    }
-
-    @FunctionalInterface
-    private interface IndexFunction<T> {
-        void apply(T t) throws Exception;
-    }
-
-    @FunctionalInterface
-    private interface DoubleFunction<T, I> {
-        void apply(T t, I i) throws Exception;
-    }
-
-    @FunctionalInterface
-    private interface MyRunnable<R> {
-        R run() throws Exception;
-    }
     private void fillMissingColumns(List<ColumnFamilyDescriptor> familyDescriptors, List<ColumnFamilyHandle> familyHandles, String path) throws Exception {
         List<ColumnFamilyDescriptor> columnFamilies = RocksDB.listColumnFamilies(new Options().setCreateIfMissing(true), path)
                 .stream()
@@ -581,4 +761,24 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         assert (columnFamilyHandle != null);
     }
 
+    @FunctionalInterface
+    private interface MyFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface IndexFunction<T> {
+        void apply(T t) throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface DoubleFunction<T, I> {
+        void apply(T t, I i) throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface MyRunnable<R> {
+        R run() throws Exception;
+
+    }
 }

--- a/src/main/java/com/iota/iri/utils/IotaUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaUtils.java
@@ -1,0 +1,17 @@
+package com.iota.iri.utils;
+
+import java.util.Arrays;
+
+public class IotaUtils {
+    public static boolean containsArray(Iterable<byte[]> collectionOfArrays, byte[] array){
+        if (collectionOfArrays == null)
+            return false;
+
+        for (byte[] arr: collectionOfArrays) {
+            if (Arrays.equals(arr, array)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/iota/iri/model/HashesTest.java
+++ b/src/test/java/com/iota/iri/model/HashesTest.java
@@ -1,0 +1,59 @@
+package com.iota.iri.model;
+
+import org.apache.commons.lang3.ArrayUtils;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.List;
+
+public class HashesTest {
+
+    private static final int SPLIT_LENGTH = 127;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    public void bytesTest() {
+        Hashes hashes = TestModelUtils.createAddresses(0);
+        assertArrayEquals("Should serialize to an empty array",
+                new byte[0], hashes.bytes());
+
+
+        hashes = TestModelUtils.createAddresses(3 * Hash.SIZE_IN_BYTES);
+        byte[] serializedBytes = hashes.bytes();
+        log.debug("current bytes serialization is {}", serializedBytes);
+        byte[] legacySerialization = legacySerializeBytes(hashes);
+        log.debug("legacy bytes serialization is {}", legacySerialization);
+        assertArrayEquals("hashes isn't being serialized as expected",
+                legacySerialization, serializedBytes);
+    }
+
+    @Test
+    public void splitTest() throws OperationNotSupportedException {
+        Hashes hashes = TestModelUtils.createAddresses(16 * SPLIT_LENGTH);
+        List<byte[]> splitHashes = hashes.splitBytes(SPLIT_LENGTH);
+        //Test can break if the value of Hash.SIZE_IN_BYTES changes
+        assertEquals("The list of splitBytes hashes does not have the expected size",
+                21 , splitHashes.size());
+
+        byte[] serializedSplitBytes = splitHashes.stream()
+                .reduce((a, b) -> ArrayUtils.addAll(a, b))
+                .orElse(new byte[0]);
+        log.debug("serialized splitBytes: {}", serializedSplitBytes);
+
+        byte[] bytes = hashes.bytes();
+        log.debug("serialized bytes: {}", bytes);
+
+        assertArrayEquals("splitHashes do not serialize to the same output as as hashes",
+                bytes, serializedSplitBytes);
+    }
+
+    private byte[] legacySerializeBytes (Hashes hashes) {
+        return hashes.set.parallelStream()
+                .map(Hash::bytes)
+                .reduce((a,b) -> ArrayUtils.addAll(ArrayUtils.add(a, Hashes.DELIMITER), b))
+                .orElse(new byte[0]);
+    }
+}

--- a/src/test/java/com/iota/iri/model/TestModelUtils.java
+++ b/src/test/java/com/iota/iri/model/TestModelUtils.java
@@ -1,0 +1,25 @@
+package com.iota.iri.model;
+
+public class TestModelUtils {
+
+    public static Address createAddresses(int numOfBytes) {
+        Address hashes = new Address();
+        byte[] bytes = generateBytes(numOfBytes);
+        hashes.read(bytes);
+        return  hashes;
+    }
+
+    private static byte[] generateBytes(int numOfBytes) {
+        byte[] bytes = new byte[numOfBytes];
+        for (int i = 0; i < bytes.length; i++) {
+            if (i != 0 && i % (Hash.SIZE_IN_BYTES + i) == 0) {
+                bytes[i] = Hashes.DELIMITER;
+            }
+            else {
+                bytes[i] = (byte) (i % 127);
+            }
+        }
+        return bytes;
+    }
+
+}

--- a/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
+++ b/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
@@ -1,20 +1,120 @@
 package com.iota.iri.storage.rocksDB;
 
-import com.iota.iri.conf.Configuration;
-import com.iota.iri.model.Hash;
-import com.iota.iri.model.Transaction;
-import com.iota.iri.storage.Tangle;
-import com.iota.iri.network.TransactionRequester;
-import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.*;
+import com.iota.iri.storage.Indexable;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.utils.Pair;
 import org.junit.*;
-import org.junit.rules.TemporaryFolder;
 
-import java.util.Arrays;
+import java.util.*;
 
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionTrits;
+import static org.junit.Assert.*;
 
 /**
  * Created by paul on 3/4/17 for iri.
  */
 public class RocksDBPersistenceProviderTest {
+
+    private static final RocksDBPersistenceProvider rocksDBPersistenceProvider = new RocksDBPersistenceProvider(
+            "mainnetdb", "mainnet.log", 100000);
+
+    private final List<Pair<Indexable, Persistable>> dbEntries;
+
+    public RocksDBPersistenceProviderTest() {
+        dbEntries = createEntries();
+    }
+
+    @BeforeClass
+    public static void initializeDb() throws Exception {
+        rocksDBPersistenceProvider.init();
+    }
+
+    @AfterClass
+    public static void shutDownDb() {
+        rocksDBPersistenceProvider.shutdown();
+    }
+
+    @Before
+    public void populateDb() throws Exception {
+        rocksDBPersistenceProvider.saveBatch(dbEntries);
+    }
+
+    @After
+    public void clearDb() throws Exception {
+        rocksDBPersistenceProvider.clear(Address.class);
+    }
+
+    private List<Pair<Indexable, Persistable>> createEntries() {
+        List<Pair<Indexable, Persistable>> entries = new ArrayList<>(3);
+        Hashes hashes1 = TestModelUtils.createAddresses(20);
+        Hashes hashes2 = TestModelUtils.createAddresses(40);
+        Address hashes3 = TestModelUtils.createAddresses(30);
+        entries.add(new Pair<>(new Hash(new byte[]{1},0, 8), hashes1));
+        entries.add(new Pair<>(new Hash(new byte[]{2},0, 8), hashes2));
+        entries.add(new Pair<>(new Hash(new byte[]{3},0, 8), hashes3));
+
+
+        return entries;
+    }
+
+
+    @Test
+    public void testSaveAndGetSplittable() throws Exception {
+        Address hashes = TestModelUtils.createAddresses(RocksDBPersistenceProvider.BYTE_LENGTH_SPLIT * 5);
+        byte[] ind = new byte[]{4};
+        Indexable index = new Hash(ind, 0, ind.length);
+        assertTrue("save 1 failed",
+                rocksDBPersistenceProvider.save(hashes, index));
+
+        Address hashesFromDb = (Address) rocksDBPersistenceProvider.get(Address.class, index);
+        assertEquals("The saved Hashes is different than the fetched Hashes", hashes, hashesFromDb);
+
+        hashes = TestModelUtils.createAddresses(RocksDBPersistenceProvider.BYTE_LENGTH_SPLIT *6);
+        assertTrue("save 2 failed",
+                rocksDBPersistenceProvider.save(hashes, index));
+        hashesFromDb = (Address) rocksDBPersistenceProvider.get(Address.class, index);
+        assertEquals("The saved Hashes is different than the fetched Hashes, old data",
+                hashes, hashesFromDb);
+
+    }
+
+    @Test
+    public void testMergeAndGetSplittable() throws Exception {
+        Address hashes = TestModelUtils.createAddresses(5 * RocksDBPersistenceProvider.BYTE_LENGTH_SPLIT);
+        byte[] ind = new byte[]{3};
+        Indexable index = new Hash(ind, 0, 8);
+        rocksDBPersistenceProvider.merge(hashes, index);
+
+        Address hashesFromDb = (Address) rocksDBPersistenceProvider.get(Address.class, index);
+
+        Address hashes3 = (Address) dbEntries.get(2).hi;
+        List<Hash> expected = new ArrayList<>(hashes3.set.size() + hashes.set.size());
+        expected.addAll(hashes3.set);
+        expected.addAll(hashes.set);
+
+        List<Hash> actual = new ArrayList<>(hashesFromDb.set.size());
+        actual.addAll(hashesFromDb.set);
+
+        assertEquals("The saved Hashes is different than the fetched Hashes", expected, actual);
+    }
+
+    @Test
+    public void testSplitDelete() throws Exception {
+        Indexable index = dbEntries.get(0).low;
+        rocksDBPersistenceProvider.delete(Address.class, index);
+        Address address = (Address) rocksDBPersistenceProvider.get(Address.class, index);
+        assertTrue("entry was not deleted", address == null || address.set.isEmpty());
+
+        Persistable hashes = TestModelUtils.createAddresses(RocksDBPersistenceProvider.BYTE_LENGTH_SPLIT * 4);
+        byte[] ind = new byte[]{4};
+        index = new Hash(ind, 0, ind.length);
+        assertTrue("save failed",
+                rocksDBPersistenceProvider.save(hashes, index));
+
+        rocksDBPersistenceProvider.delete(Address.class, index, 2);
+
+        Address expectedHashes = TestModelUtils.createAddresses(RocksDBPersistenceProvider.BYTE_LENGTH_SPLIT * 2);
+        Persistable hashesFromDb = rocksDBPersistenceProvider.get(Address.class, index);
+        assertEquals("The saved Hashes is different than the fetched Hashes", expectedHashes, hashesFromDb);
+    }
 }


### PR DESCRIPTION
RocksDb can now save long values over many key pairs.
Every value that is splittable now has a 4 byte suffix added to its key.
This suffix indicates the offset from the start key.

The value is split when it exceeds `BYTE_LENGTH_SPLIT`. A key can't hold a value that is larger than `BYTE_LENGTH_SPLIT(1+MAX_BYTE_RATIO)` .
Those values are now hard coded but should be made configurable on later commits.

This change by itself imo will probably not improve performance by much, but it does supply us with a new `get` method that can query partial values.