### PR TITLE
allows "recently seen" caches to forget failed transaction stores

### DIFF
--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -69,7 +69,6 @@ public class Configuration {
         ZMQ_THREADS,
         Q_SIZE_NODE,
         P_DROP_CACHE_ENTRY,
-        CACHE_SIZE_HASHES,
         CACHE_SIZE_BYTES,
     }
 
@@ -124,7 +123,6 @@ public class Configuration {
 
         conf.put(DefaultConfSettings.Q_SIZE_NODE.name(), "1000");
         conf.put(DefaultConfSettings.P_DROP_CACHE_ENTRY.name(), "0.02");
-        conf.put(DefaultConfSettings.CACHE_SIZE_HASHES.name(), "5000");
         conf.put(DefaultConfSettings.CACHE_SIZE_BYTES.name(), "15000");
 
     }

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -68,8 +68,9 @@ public class Configuration {
         ZMQ_IPC,
         ZMQ_THREADS,
         Q_SIZE_NODE,
-        LRU_SIZE_HASHES,
-        LRU_SIZE_BYTES,
+        P_DROP_CACHE_ENTRY,
+        CACHE_SIZE_HASHES,
+        CACHE_SIZE_BYTES,
     }
 
     {
@@ -122,8 +123,9 @@ public class Configuration {
         conf.put(DefaultConfSettings.ZMQ_THREADS.name(), "2");
 
         conf.put(DefaultConfSettings.Q_SIZE_NODE.name(), "1000");
-        conf.put(DefaultConfSettings.LRU_SIZE_HASHES.name(), "5000");
-        conf.put(DefaultConfSettings.LRU_SIZE_BYTES.name(), "15000");
+        conf.put(DefaultConfSettings.P_DROP_CACHE_ENTRY.name(), "0.02");
+        conf.put(DefaultConfSettings.CACHE_SIZE_HASHES.name(), "5000");
+        conf.put(DefaultConfSettings.CACHE_SIZE_BYTES.name(), "15000");
 
     }
 

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -758,10 +758,7 @@ public class Node {
 
         public V get(K key) {
             V value = this.map.get(key);
-            if (value == null) {
-                return null;
-            }
-            if (rnd.nextDouble() < this.dropRate) {
+            if (value != null && (rnd.nextDouble() < this.dropRate)) {
                 this.map.remove(key);
                 return null;
             }


### PR DESCRIPTION
modifies Node caches from LRU to FIFO, 
with additional probabilistic drop cache entry - `P_DROP_CACHE_ENTRY`.

fixes #428 - credit does to @Pomyk that found the bug and offered a workaround (#455)!
this fixes the issue where storing a transaction would fail, but the "recently seen" cache would still hold a copy.

the difference from #455 is that the probabilistic solution has a much smaller memory and comp. footprint.
so not harming the common case, while still allowing the cache to refresh itself and recover from the rare case of failed store.