### PR TITLE
separate rate limit for API

### DIFF
--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -48,6 +48,7 @@ public class Configuration {
         MAIN_DB, EXPORT, // exports transaction trytes to filesystem
         SEND_LIMIT,
         NEW_TX_LIMIT,
+        API_NEW_TX_LIMIT,
         MAX_PEERS,
         DNS_RESOLUTION_ENABLED,
         DNS_REFRESHER_ENABLED,
@@ -98,6 +99,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.EXPORT.name(), "false");
         conf.put(DefaultConfSettings.SEND_LIMIT.name(), "-1.0");
         conf.put(DefaultConfSettings.NEW_TX_LIMIT.name(), "0.0");
+        conf.put(DefaultConfSettings.API_NEW_TX_LIMIT.name(), "0.0");
         conf.put(DefaultConfSettings.MAX_PEERS.name(), "0");
         conf.put(DefaultConfSettings.DNS_REFRESHER_ENABLED.name(), "true");
         conf.put(DefaultConfSettings.DNS_RESOLUTION_ENABLED.name(), "true");

--- a/src/main/java/com/iota/iri/network/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/Neighbor.java
@@ -18,7 +18,7 @@ public abstract class Neighbor {
     private int newTransactionsCounter;
     private long newTransactionsTimer;
     private final double newTransactionsLimit;
-    public static final long newTransactionsWindow = 10 * 1000L;
+    public static final long newTransactionsWindow = 30 * 1000L;
 
     private boolean flagged = false;
     public boolean isFlagged() {


### PR DESCRIPTION
allows setting rate via API call: `setApiRateLimit`
fixes limit counter,
uses a larger rate limit window.

the limit is off by default.