### PR TITLE
add --dns-resolution-false flag to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Option | Shortened version | Description | Example Input
 `--remote-limit-api` | | Exclude certain API calls from being able to be accessed remotely | `--remote-limit-api "attachToTangle, addNeighbors"`
 `--send-limit`| | Limit the outbound bandwidth consumption. Limit is set to mbit/s | `--send-limit 1.0`
 `--max-peers` | | Limit the number of max accepted peers. Default is set to 0 (mutual tethering) | `--max-peers 8`
-
+`--dns-resolution-false` | | Ignores DNS resolution refreshing  | --dns-resolution-false	
 ### INI File
 
 You can also provide an ini file to store all of your command line options and easily update (especially neighbors) if needed. You can enable it via the `--config` flag. Here is an example INI file:


### PR DESCRIPTION
- Appended --dns-resolution-false Command line option description to the readme.