### PR TITLE
Removed root access from loop-back devices

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -185,8 +185,7 @@ public class API {
                 return ErrorResponse.create("COMMAND parameter has not been specified in the request.");
             }
 
-            if (instance.configuration.string(DefaultConfSettings.REMOTE_LIMIT_API).contains(command) &&
-                    !sourceAddress.getAddress().isLoopbackAddress()) {
+            if (instance.configuration.string(DefaultConfSettings.REMOTE_LIMIT_API).contains(command)) {
                 return AccessLimitedResponse.create("COMMAND " + command + " is not available on this node");
             }
 


### PR DESCRIPTION
This line was giving unlimited access to IRI remote commands like adding nodes or hosts to spam TCP/UDP packets