### PR TITLE
Maven docker image build support, for faster builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ command line arguments.
 
 `docker run -d --net=host --name iota-node -p 14265:14265 -p 14777:14777/udp -p 15777:15777 -v iota.ini:/iri/iota.ini iotaledger/iri:latest`
 
+For development purposes you can build docker image locally by using:
+
+`mvn clean package docker:build`
+
+This will create an image locally with tags `iri:latest` and `iri:<current-version>`.
+
 ### Command Line Options 
 
 Option | Shortened version | Description | Example Input
@@ -68,7 +74,7 @@ Option | Shortened version | Description | Example Input
 `--remote-limit-api` | | Exclude certain API calls from being able to be accessed remotely | `--remote-limit-api "attachToTangle, addNeighbors"`
 `--send-limit`| | Limit the outbound bandwidth consumption. Limit is set to mbit/s | `--send-limit 1.0`
 `--max-peers` | | Limit the number of max accepted peers. Default is set to 0 (mutual tethering) | `--max-peers 8`
-`--dns-resolution-false` | | Ignores DNS resolution refreshing  | --dns-resolution-false	
+`--dns-resolution-false` | | Ignores DNS resolution refreshing  | `--dns-resolution-false`	
 ### INI File
 
 You can also provide an ini file to store all of your command line options and easily update (especially neighbors) if needed. You can enable it via the `--config` flag. Here is an example INI file:
@@ -82,4 +88,3 @@ HEADLESS = true
 DEBUG = true
 DB_PATH = db
 ```
-

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,36 @@
 <build>
     <plugins>
         <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+                <imageName>iri</imageName>
+                <imageTags>
+                    <imageTag>latest</imageTag>
+                    <imageTag>${project.version}</imageTag>
+                </imageTags>
+                <baseImage>openjdk:jre-slim</baseImage>
+                <workdir>/iri</workdir>
+                <exposes>14265</exposes>
+                <exposes>14777/udp</exposes>
+                <exposes>15777</exposes>
+                <entryPoint>["java", "-XX:+DisableAttachMechanism", "-Xmx8g", "-Xms256m", "-Dlogback.configurationFile=/iri/conf/logback.xml", "-Djava.net.preferIPv4Stack=true", "-jar", "/iri/${project.build.finalName}.jar", "-p", "14265", "-u", "14777", "-t", "15777", "--remote", "--remote-limit-api", "\"addNeighbors, removeNeighbors, getNeighbors\"", "$@"]</entryPoint>
+                <resources>
+                    <resource>
+                        <targetPath>/iri</targetPath>
+                        <directory>${project.basedir}</directory>
+                        <include>logback.xml</include>
+                    </resource>
+                    <resource>
+                        <targetPath>/iri</targetPath>
+                        <directory>${project.build.directory}</directory>
+                        <include>${project.build.finalName}.jar</include>
+                    </resource>
+                </resources>
+            </configuration>
+        </plugin>
+        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.3</version>


### PR DESCRIPTION
#478 
- Add docker image built support using `maven`'s plugin.
- Updated the readme for the changed image build process.

Reduces docker image build to from minute to seconds. No longer pulls maven dependencies and plugin each time we build the image.  Reduces development testing on docker overhead. Easy to make image, just do `mvn clean package docker:build` and within few seconds image will be available to run containers on.