### PR TITLE
Solid Milestone initialization fix

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,6 +9,9 @@ If you have general questions on IOTA you can go to https://iota.stackexchange.c
 ### Bug description
 A general description of the bug.
 
+### Hardware Spec
+On what hardware is the node running on?
+
 ### Steps To Reproduce
 1. 
 2. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,9 @@
 Hints for a successful PR:
 1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
 This way you may get inputs and discover parallel PRs to the one you want to submit.
-2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process
-3. It will be helpful if you make additional comments on the code via github PR review to explain the chooices you made
+2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
+3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be splitted to several PRs!!!!!
+4. It will be helpful if you make additional comments on the code via github PR review to explain the choices you made
 -->
 
 # Description

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create an iota.ini file with all of your configuration variables set in it.
 Any that you don't provide in here will be assumed to be default or taken from
 command line arguments.
 
-`docker run -d --net=host --name iota-node -p 14265:14265 -p 14777:14777/udp -p 15777:15777 -v iota.ini:/iri/iota.ini iotaledger/iri:latest`
+`docker run -d --net=host --name iota-node -v iota.ini:/iri/iota.ini iotaledger/iri:latest`
 
 ### Command Line Options 
 

--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -190,6 +190,8 @@ public class LedgerValidator {
     protected void init() throws Exception {
         MilestoneViewModel latestConsistentMilestone = buildSnapshot();
         if(latestConsistentMilestone != null) {
+            log.info("Loaded consistent milestone: #" + latestConsistentMilestone.index());
+
             milestone.latestSolidSubtangleMilestone = latestConsistentMilestone.getHash();
             milestone.latestSolidSubtangleMilestoneIndex = latestConsistentMilestone.index();
         }
@@ -204,17 +206,30 @@ public class LedgerValidator {
      */
     private MilestoneViewModel buildSnapshot() throws Exception {
         MilestoneViewModel consistentMilestone = null;
-        StateDiffViewModel stateDiffViewModel;
         milestone.latestSnapshot.rwlock.writeLock().lock();
         try {
-            MilestoneViewModel snapshotMilestone = MilestoneViewModel.firstWithSnapshot(tangle);
-            while (snapshotMilestone != null) {
-                stateDiffViewModel = StateDiffViewModel.load(tangle, snapshotMilestone.getHash());
-                if (Snapshot.isConsistent(milestone.latestSnapshot.patchedDiff(stateDiffViewModel.getDiff()))) {
-                    milestone.latestSnapshot.apply(stateDiffViewModel.getDiff(), snapshotMilestone.index());
-                    consistentMilestone = snapshotMilestone;
-                    snapshotMilestone = snapshotMilestone.nextWithSnapshot(tangle);
+            MilestoneViewModel candidateMilestone = MilestoneViewModel.first(tangle);
+            while (candidateMilestone != null) {
+                if (log.isDebugEnabled() && candidateMilestone.index() % 10000 == 0) {
+                    StringBuilder logMessage = new StringBuilder();
+
+                    logMessage.append("Building snapshot... Consistent: #");
+                    logMessage.append(consistentMilestone != null ? consistentMilestone.index() : -1);
+                    logMessage.append(", Candidate: #");
+                    logMessage.append(candidateMilestone.index());
+
+                    log.debug(logMessage.toString());
                 }
+                if (StateDiffViewModel.maybeExists(tangle, candidateMilestone.getHash())) {
+                    StateDiffViewModel stateDiffViewModel = StateDiffViewModel.load(tangle, candidateMilestone.getHash());
+
+	                if (stateDiffViewModel != null && !stateDiffViewModel.isEmpty() && 
+                        Snapshot.isConsistent(milestone.latestSnapshot.patchedDiff(stateDiffViewModel.getDiff()))) {
+	                    milestone.latestSnapshot.apply(stateDiffViewModel.getDiff(), candidateMilestone.index());
+	                    consistentMilestone = candidateMilestone;
+	                }
+	            }
+	            candidateMilestone = candidateMilestone.next(tangle);
             }
         } finally {
             milestone.latestSnapshot.rwlock.writeLock().unlock();

--- a/src/main/java/com/iota/iri/Milestone.java
+++ b/src/main/java/com/iota/iri/Milestone.java
@@ -77,12 +77,14 @@ public class Milestone {
         this.ledgerValidator = ledgerValidator;
         AtomicBoolean ledgerValidatorInitialized = new AtomicBoolean(false);
         (new Thread(() -> {
+            log.info("Waiting for Ledger Validator initialization...");
             while(!ledgerValidatorInitialized.get()) {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
                 }
             }
+            log.info("Tracker started.");
             while (!shuttingDown) {
                 long scanTime = System.currentTimeMillis();
 
@@ -118,14 +120,12 @@ public class Milestone {
                     }
 
                     if (previousLatestMilestoneIndex != latestMilestoneIndex) {
-
                         messageQ.publish("lmi %d %d", previousLatestMilestoneIndex, latestMilestoneIndex);
                         log.info("Latest milestone has changed from #" + previousLatestMilestoneIndex
                                 + " to #" + latestMilestoneIndex);
                     }
 
                     Thread.sleep(Math.max(1, RESCAN_INTERVAL - (System.currentTimeMillis() - scanTime)));
-
                 } catch (final Exception e) {
                     log.error("Error during Latest Milestone updating", e);
                 }
@@ -133,13 +133,14 @@ public class Milestone {
         }, "Latest Milestone Tracker")).start();
 
         (new Thread(() -> {
-
+            log.info("Initializing Ledger Validator...");
             try {
                 ledgerValidator.init();
                 ledgerValidatorInitialized.set(true);
             } catch (Exception e) {
                 log.error("Error initializing snapshots. Skipping.", e);
             }
+            log.info("Tracker started.");
             while (!shuttingDown) {
                 long scanTime = System.currentTimeMillis();
 

--- a/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
@@ -86,22 +86,6 @@ public class MilestoneViewModel {
         return null;
     }
 
-    public MilestoneViewModel nextWithSnapshot(Tangle tangle) throws Exception {
-        MilestoneViewModel milestoneViewModel = next(tangle);
-        while(milestoneViewModel !=null && !StateDiffViewModel.exists(tangle, milestoneViewModel.getHash())) {
-            milestoneViewModel = milestoneViewModel.next(tangle);
-        }
-        return milestoneViewModel;
-    }
-
-    public static MilestoneViewModel firstWithSnapshot(Tangle tangle) throws Exception {
-        MilestoneViewModel milestoneViewModel = first(tangle);
-        while(milestoneViewModel !=null && !StateDiffViewModel.exists(tangle, milestoneViewModel.getHash())) {
-            milestoneViewModel = milestoneViewModel.next(tangle);
-        }
-        return milestoneViewModel;
-    }
-
     public static MilestoneViewModel findClosestPrevMilestone(Tangle tangle, int index) throws Exception {
         Pair<Indexable, Persistable> milestonePair = tangle.previous(Milestone.class, new IntegerIndex(index));
         if(milestonePair != null && milestonePair.hi != null) {
@@ -119,14 +103,6 @@ public class MilestoneViewModel {
             return new MilestoneViewModel((Milestone) milestonePair.hi);
         }
         return null;
-    }
-
-    public static MilestoneViewModel latestWithSnapshot(Tangle tangle) throws Exception {
-        MilestoneViewModel milestoneViewModel = latest(tangle);
-        while(milestoneViewModel !=null && !StateDiffViewModel.exists(tangle, milestoneViewModel.getHash())) {
-            milestoneViewModel = milestoneViewModel.previous(tangle);
-        }
-        return milestoneViewModel;
     }
 
     public boolean store(Tangle tangle) throws Exception {

--- a/src/main/java/com/iota/iri/controllers/StateDiffViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/StateDiffViewModel.java
@@ -24,13 +24,17 @@ public class StateDiffViewModel {
         this.stateDiff.state = state;
     }
 
-    public static boolean exists(Tangle tangle, Hash hash) throws Exception {
+    public static boolean maybeExists(Tangle tangle, Hash hash) throws Exception {
         return tangle.maybeHas(StateDiff.class, hash);
     }
 
     StateDiffViewModel(final StateDiff diff, final Hash hash) {
         this.hash = hash;
         this.stateDiff = diff == null || diff.state == null ? new StateDiff(): diff;
+    }
+
+    public boolean isEmpty() {
+        return stateDiff == null || stateDiff.state == null || stateDiff.state.size() == 0;
     }
 
     public Hash getHash() {


### PR DESCRIPTION
### Bug
LedgerValidator initializes wrong consistent milestone after restart when node is not fully synced.

### Symptoms
When node is synced to solid milestone X and latest milestone is Y, after restart solid milestone is incorrectly initialized to Z (usually very close to Y).

### Cause
Method LedgerValidator.buildSnapshot() is responsible for building the most recent consistent milestone. It uses MilestoneViewModel.firstWithSnapshot() and MilestoneViewModel.nextWithSnapshot() to iterate on every milestone with snapshot then gets the state differences and patches them to the current snapshot. These methods deterministically rely on StateDiffViewModel.exists() which internally uses tangle.maybeHas(). The problem is that tangle.maybeHas() can only guarantee when entry is not present, but does not guarantee if entry is present. This leads to MilestoneViewModel.firstWithSnapshot() and MilestoneViewModel.nextWithSnapshot() sometimes returning milestone without snapshot or more precise milestone without StateDiff. This incorrect behaviour is also supported by the fact that StateDiffViewModel.load() returns an object even if StateDiff is not present. This leads to latestSnapshot being patched with no state differences and incorrect milestone index.

### Problems
When node is initialized with wrong solid milestone this may lead to solid milestone tracker appearing frozen while it is trying to solidify next milestone or compute state diff with both operations involving huge number of transactions. Sometimes wrong solid milestone index may lead to "Transaction resolves to incorrect ledger balance" errors (bug: #460).

### Proposed fix
Method StateDiffViewModel.isEmpty() is introduced to check if current state difference is empty. LedgerValidator.buildSnapshot() now iterates on every candidate milestone and patches latestSnapshot only with nonempty state differences. This guarantees that initialized consistent milestone is solid.