### PR TITLE
Updated Snapshot usage to remove copious copies

### DIFF
--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -264,8 +264,9 @@ public class LedgerValidator {
         boolean isConsistent = Snapshot.isConsistent(milestone.latestSnapshot.patchedDiff(currentState));
         if (isConsistent) {
             currentState.forEach((key, value) -> {
-                diff.computeIfPresent(key, ((hash, aLong) -> value + aLong));
-                diff.putIfAbsent(key, value);
+                if(diff.computeIfPresent(key, ((hash, aLong) -> value + aLong)) == null) {
+                    diff.putIfAbsent(key, value);
+                }
             });
             approvedHashes.addAll(visitedHashes);
         }

--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -201,7 +201,7 @@ public class LedgerValidator {
     private MilestoneViewModel buildSnapshot() throws Exception {
         MilestoneViewModel consistentMilestone = null;
         StateDiffViewModel stateDiffViewModel;
-        milestone.latestSnapshot.rwlock.writeLock().lock();
+        long stamp = milestone.latestSnapshot.sl.readLock();
         try {
             MilestoneViewModel snapshotMilestone = MilestoneViewModel.firstWithSnapshot(tangle);
             while (snapshotMilestone != null) {
@@ -213,14 +213,14 @@ public class LedgerValidator {
                 }
             }
         } finally {
-            milestone.latestSnapshot.rwlock.writeLock().unlock();
+            milestone.latestSnapshot.sl.unlockRead(stamp);
         }
         return consistentMilestone;
     }
 
     public boolean updateSnapshot(MilestoneViewModel milestoneVM) throws Exception {
         TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, milestoneVM.getHash());
-        milestone.latestSnapshot.rwlock.writeLock().lock();
+        long stamp = milestone.latestSnapshot.sl.readLock();
         try {
             final int transactionSnapshotIndex = transactionViewModel.snapshotIndex();
             boolean hasSnapshot = transactionSnapshotIndex != 0;
@@ -240,7 +240,7 @@ public class LedgerValidator {
             }
             return hasSnapshot;
         } finally {
-            milestone.latestSnapshot.rwlock.writeLock().unlock();
+            milestone.latestSnapshot.sl.unlockRead(stamp);
         }
     }
 

--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -43,14 +43,14 @@ public class LedgerValidator {
      * until it reaches a transaction that is marked as a "confirmed" transaction.
      * If {milestone} is false, it will search up until it reaches a confirmed transaction, or until it finds a hash that has been
      * marked as consistent since the previous milestone.
-     * @param visitedHashes         hashes that have been visited and considered as approved
-     * @param tip                   the hash of a transaction to start the search from
-     * @param latestSnapshotIndex   index of the latest snapshot to traverse to
-     * @param milestone             marker to indicate whether to stop only at confirmed transactions
-     * @return {state}              the addresses that have a balance changed since the last diff check
+     * @param visitedNonMilestoneSubtangleHashes hashes that have been visited and considered as approved
+     * @param tip                                the hash of a transaction to start the search from
+     * @param latestSnapshotIndex                index of the latest snapshot to traverse to
+     * @param milestone                          marker to indicate whether to stop only at confirmed transactions
+     * @return {state}                           the addresses that have a balance changed since the last diff check
      * @throws Exception
      */
-    public Map<Hash,Long> getLatestDiff(final Set<Hash> visitedHashes, Hash tip, int latestSnapshotIndex, boolean milestone) throws Exception {
+    public Map<Hash,Long> getLatestDiff(final Set<Hash> visitedNonMilestoneSubtangleHashes, Hash tip, int latestSnapshotIndex, boolean milestone) throws Exception {
         Map<Hash, Long> state = new HashMap<>();
         int numberOfAnalyzedTransactions = 0;
         Set<Hash> countedTx = new HashSet<>(Collections.singleton(Hash.NULL_HASH));
@@ -58,7 +58,7 @@ public class LedgerValidator {
         final Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(tip));
         Hash transactionPointer;
         while ((transactionPointer = nonAnalyzedTransactions.poll()) != null) {
-            if (visitedHashes.add(transactionPointer)) {
+            if (visitedNonMilestoneSubtangleHashes.add(transactionPointer)) {
 
                 final TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, transactionPointer);
                 if (transactionViewModel.snapshotIndex() == 0 || transactionViewModel.snapshotIndex() > latestSnapshotIndex) {

--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -43,9 +43,11 @@ public class LedgerValidator {
      * until it reaches a transaction that is marked as a "confirmed" transaction.
      * If {milestone} is false, it will search up until it reaches a confirmed transaction, or until it finds a hash that has been
      * marked as consistent since the previous milestone.
-     * @param tip       the hash of a transaction to start the search from
-     * @param milestone marker to indicate whether to stop only at confirmed transactions
-     * @return {state}  the addresses that have a balance changed since the last diff check
+     * @param visitedHashes         hashes that have been visited and considered as approved
+     * @param tip                   the hash of a transaction to start the search from
+     * @param latestSnapshotIndex   index of the latest snapshot to traverse to
+     * @param milestone             marker to indicate whether to stop only at confirmed transactions
+     * @return {state}              the addresses that have a balance changed since the last diff check
      * @throws Exception
      */
     public Map<Hash,Long> getLatestDiff(final Set<Hash> visitedHashes, Hash tip, int latestSnapshotIndex, boolean milestone) throws Exception {

--- a/src/main/java/com/iota/iri/Snapshot.java
+++ b/src/main/java/com/iota/iri/Snapshot.java
@@ -153,8 +153,9 @@ public class Snapshot {
         }
         long stamp = sl.writeLock();
         patch.entrySet().stream().forEach(hashLongEntry -> {
-            state.computeIfPresent(hashLongEntry.getKey(), (hash, aLong) -> hashLongEntry.getValue() + aLong);
-            state.putIfAbsent(hashLongEntry.getKey(), hashLongEntry.getValue());
+            if (state.computeIfPresent(hashLongEntry.getKey(), (hash, aLong) -> hashLongEntry.getValue() + aLong) == null) {
+                state.putIfAbsent(hashLongEntry.getKey(), hashLongEntry.getValue());
+            }
         });
         index = newIndex;
         sl.unlockWrite(stamp);

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -399,7 +399,7 @@ public class API {
         }
 
         if (state) {
-            instance.milestone.latestSnapshot.rwlock.readLock().lock();
+            long stamp = instance.milestone.latestSnapshot.sl.readLock();
             try {
 
                 if (!instance.ledgerValidator.checkConsistency(transactions)) {
@@ -407,7 +407,7 @@ public class API {
                     info = "tails are not consistent (would lead to inconsistent ledger state)";
                 }
             } finally {
-                instance.milestone.latestSnapshot.rwlock.readLock().unlock();
+                instance.milestone.latestSnapshot.sl.unlockRead(stamp);
             }
         }
 
@@ -536,7 +536,7 @@ public class API {
             }
         }
 
-        instance.milestone.latestSnapshot.rwlock.readLock().lock();
+        long stamp = instance.milestone.latestSnapshot.sl.readLock();
         try {
             Set<Hash> visitedHashes = new HashSet<>();
             Map<Hash, Long> diff = new HashMap<>();
@@ -560,7 +560,7 @@ public class API {
                 return tips;
             }
         } finally {
-            instance.milestone.latestSnapshot.rwlock.readLock().unlock();
+            instance.milestone.latestSnapshot.sl.unlockRead(stamp);
         }
         throw new RuntimeException("inconsistent tips pair selected");
     }
@@ -808,7 +808,7 @@ public class API {
                 .collect(Collectors.toCollection(LinkedList::new));
         final List<Hash> hashes;
         final Map<Hash, Long> balances = new HashMap<>();
-        instance.milestone.latestSnapshot.rwlock.readLock().lock();
+        long stamp = instance.milestone.latestSnapshot.sl.readLock();
         final int index = instance.milestone.latestSnapshot.index();
         if (tips == null || tips.size() == 0) {
             hashes = Collections.singletonList(instance.milestone.latestSolidSubtangleMilestone);
@@ -838,7 +838,7 @@ public class API {
             }
             diff.forEach((key, value) -> balances.computeIfPresent(key, (hash, aLong) -> value + aLong));
         } finally {
-            instance.milestone.latestSnapshot.rwlock.readLock().unlock();
+            instance.milestone.latestSnapshot.sl.unlockRead(stamp);
         }
 
         final List<String> elements = addresses.stream().map(address -> balances.get(address).toString())

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -3,7 +3,6 @@ package com.iota.iri.service;
 import java.util.*;
 
 import com.iota.iri.LedgerValidator;
-import com.iota.iri.Snapshot;
 import com.iota.iri.TransactionValidator;
 import com.iota.iri.model.Hash;
 import com.iota.iri.controllers.*;
@@ -125,7 +124,6 @@ public class TipsManager {
                     throw new RuntimeException("starting tip failed consistency check: " + tip.toString());
                 }
             } catch (Exception e) {
-                milestone.latestSnapshot.rwlock.readLock().unlock();
                 e.printStackTrace();
                 log.error("Encountered error: " + e.getLocalizedMessage());
                 throw e;

--- a/src/test/java/com/iota/iri/SnapshotTest.java
+++ b/src/test/java/com/iota/iri/SnapshotTest.java
@@ -36,7 +36,7 @@ public class SnapshotTest {
     }
 
     @Test
-    public void merge() throws Exception {
+    public void applyShouldFail() throws Exception {
         Snapshot latestSnapshot = Snapshot.initialSnapshot.clone();
         Map<Hash, Long> badMap = new HashMap<>();
         badMap.put(new Hash("PSRQPWWIECDGDDZEHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS"), 100L);


### PR DESCRIPTION
Two major changes:
* No more `new Snapshot` used after start
* `synchronized` snapshot object removed in favor of read write locks