### PR TITLE
revert NEW_TX_LIMIT and API_NEW_TX_LIMIT

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -214,10 +214,6 @@ public class IRI {
         if (vsendLimit != null) {
             configuration.put(DefaultConfSettings.SEND_LIMIT, vsendLimit);
         }
-        if (parser.getOptionValue(sync) != null) {
-            configuration.put(DefaultConfSettings.NEW_TX_LIMIT, "0.0");
-        }
-
 
         final String vmaxPeers = parser.getOptionValue(maxPeers);
         if (vmaxPeers != null) {

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -47,8 +47,6 @@ public class Configuration {
         P_PROPAGATE_REQUEST,
         MAIN_DB, EXPORT, // exports transaction trytes to filesystem
         SEND_LIMIT,
-        NEW_TX_LIMIT,
-        API_NEW_TX_LIMIT,
         MAX_PEERS,
         DNS_RESOLUTION_ENABLED,
         DNS_REFRESHER_ENABLED,
@@ -98,8 +96,6 @@ public class Configuration {
         conf.put(DefaultConfSettings.MAIN_DB.name(), "rocksdb");
         conf.put(DefaultConfSettings.EXPORT.name(), "false");
         conf.put(DefaultConfSettings.SEND_LIMIT.name(), "-1.0");
-        conf.put(DefaultConfSettings.NEW_TX_LIMIT.name(), "0.0");
-        conf.put(DefaultConfSettings.API_NEW_TX_LIMIT.name(), "0.0");
         conf.put(DefaultConfSettings.MAX_PEERS.name(), "0");
         conf.put(DefaultConfSettings.DNS_REFRESHER_ENABLED.name(), "true");
         conf.put(DefaultConfSettings.DNS_RESOLUTION_ENABLED.name(), "true");

--- a/src/main/java/com/iota/iri/network/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/Neighbor.java
@@ -15,11 +15,6 @@ public abstract class Neighbor {
     private long randomTransactionRequests;
     private long numberOfSentTransactions;
 
-    private int newTransactionsCounter;
-    private long newTransactionsTimer;
-    private final double newTransactionsLimit;
-    public static final long newTransactionsWindow = 30 * 1000L;
-
     private boolean flagged = false;
     public boolean isFlagged() {
         return flagged;
@@ -51,14 +46,6 @@ public abstract class Neighbor {
         this.address = address;
         this.hostAddress = address.getAddress().getHostAddress();
         this.flagged = isConfigured;
-        this.newTransactionsLimit = 0;
-    }
-
-    public Neighbor(final InetSocketAddress address, boolean isConfigured, double limit) {
-        this.address = address;
-        this.hostAddress = address.getAddress().getHostAddress();
-        this.flagged = isConfigured;
-        this.newTransactionsLimit = (limit * newTransactionsWindow) / 1000;
     }
 
     public abstract void send(final DatagramPacket packet);
@@ -86,22 +73,7 @@ public abstract class Neighbor {
     
     void incNewTransactions() {
     	numberOfNewTransactions++;
-        newTransactionsCounter++;
     }
-
-    public boolean isBelowNewTransactionLimit() {
-        if (newTransactionsLimit == 0) {
-            return true;
-        }
-
-        long now = System.currentTimeMillis();
-        if ((now - newTransactionsTimer) > newTransactionsWindow) {
-            newTransactionsCounter = 0;
-            newTransactionsTimer = now;
-        }
-        return (newTransactionsCounter < newTransactionsLimit);
-    }
-
 
     void incRandomTransactionRequests() {
         randomTransactionRequests++;

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -79,8 +79,6 @@ public class Node {
     private static AtomicLong sendPacketsCounter = new AtomicLong(0L);
     private static AtomicLong sendPacketsTimer = new AtomicLong(0L);
 
-    private static double newTxLimit;
-
     public static final ConcurrentSkipListSet<String> rejectedAddresses = new ConcurrentSkipListSet<String>();
     private DatagramSocket udpSocket;
 
@@ -109,7 +107,6 @@ public class Node {
         P_REPLY_RANDOM_TIP = configuration.doubling(Configuration.DefaultConfSettings.P_REPLY_RANDOM_TIP.name());
         P_PROPAGATE_REQUEST = configuration.doubling(Configuration.DefaultConfSettings.P_PROPAGATE_REQUEST.name());
         sendLimit = (long) ((configuration.doubling(Configuration.DefaultConfSettings.SEND_LIMIT.name()) * 1000000) / (TRANSACTION_PACKET_SIZE * 8));
-        newTxLimit = configuration.doubling(Configuration.DefaultConfSettings.NEW_TX_LIMIT.name());
         debug = configuration.booling(Configuration.DefaultConfSettings.DEBUG);
 
         BROADCAST_QUEUE_SIZE = RECV_QUEUE_SIZE = REPLY_QUEUE_SIZE = configuration.integer(Configuration.DefaultConfSettings.Q_SIZE_NODE);
@@ -372,9 +369,7 @@ public class Node {
 
         //store new transaction
         try {
-            if (neighbor.isBelowNewTransactionLimit()) {
-                stored = receivedTransactionViewModel.store(tangle);
-            }
+            stored = receivedTransactionViewModel.store(tangle);
         } catch (Exception e) {
             log.error("Error accessing persistence store.", e);
             neighbor.incInvalidTransactions();
@@ -679,10 +674,10 @@ public class Node {
     public Neighbor newNeighbor(final URI uri, boolean isConfigured) {
         if (isUriValid(uri)) {
             if (uri.getScheme().equals("tcp")) {
-                return new TCPNeighbor(new InetSocketAddress(uri.getHost(), uri.getPort()), isConfigured, newTxLimit);
+                return new TCPNeighbor(new InetSocketAddress(uri.getHost(), uri.getPort()), isConfigured);
             }
             if (uri.getScheme().equals("udp")) {
-                return new UDPNeighbor(new InetSocketAddress(uri.getHost(), uri.getPort()), udpSocket, isConfigured, newTxLimit);
+                return new UDPNeighbor(new InetSocketAddress(uri.getHost(), uri.getPort()), udpSocket, isConfigured);
             }
         }
         throw new RuntimeException(uri.toString());

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -22,8 +22,8 @@ public class TCPNeighbor extends Neighbor {
     private final ArrayBlockingQueue<ByteBuffer> sendQueue = new ArrayBlockingQueue<>(10);
     private boolean stopped = false;
 
-    public TCPNeighbor(InetSocketAddress address, boolean isConfigured, final double limit) {
-        super(address, isConfigured, limit);
+    public TCPNeighbor(InetSocketAddress address, boolean isConfigured) {
+        super(address, isConfigured);
         this.tcpPort = address.getPort();
     }
 

--- a/src/main/java/com/iota/iri/network/UDPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/UDPNeighbor.java
@@ -16,8 +16,8 @@ public class UDPNeighbor extends Neighbor {
 
     private DatagramSocket socket;
 
-    public UDPNeighbor(final InetSocketAddress address, final DatagramSocket socket, final boolean isConfigured, final double limit) {
-        super(address, isConfigured, limit);
+    public UDPNeighbor(final InetSocketAddress address, final DatagramSocket socket, final boolean isConfigured) {
+        super(address, isConfigured);
         this.socket = socket;
     }
 

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
@@ -92,7 +92,7 @@ class ReplicatorSourceProcessor implements Runnable {
                     connection.close();
                     return;
                 } else {
-                    final TCPNeighbor fresh_neighbor = new TCPNeighbor(inet_socket_address, false, 0);
+                    final TCPNeighbor fresh_neighbor = new TCPNeighbor(inet_socket_address, false);
                     node.getNeighbors().add(fresh_neighbor);
                     neighbor = fresh_neighbor;
                     Neighbor.incNumPeers();


### PR DESCRIPTION
These 2 components, NewTransactionLimit for neighbors & API calls, were added to IRI and disabled by default.
however, they require more research and testing before making it to the reference implementation.