### PR TITLE
add optional reference tips to get transactions to approve

### DIFF
--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -69,6 +69,7 @@ public class Configuration {
         Q_SIZE_NODE,
         P_DROP_CACHE_ENTRY,
         CACHE_SIZE_BYTES,
+        MAX_REFERENCE_TIPS,
     }
 
     {
@@ -109,6 +110,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.MAX_RANDOM_WALKS.name(), "27");
         // Pick a milestone depth number depending on risk model
         conf.put(DefaultConfSettings.MAX_DEPTH.name(), "15");
+        conf.put(DefaultConfSettings.MAX_REFERENCE_TIPS.name(), "100");
 
         conf.put(DefaultConfSettings.MAX_FIND_TRANSACTIONS.name(), "100000");
         conf.put(DefaultConfSettings.MAX_REQUESTS_LIST.name(), "1000");

--- a/src/test/java/com/iota/iri/NodeIntegrationTests.java
+++ b/src/test/java/com/iota/iri/NodeIntegrationTests.java
@@ -135,7 +135,7 @@ public class NodeIntegrationTests {
     }
 
     private void sendMilestone(API api, long index) throws Exception {
-        newMilestone(api, api.getTransactionToApproveStatement(10, null, 1), index);
+        newMilestone(api, api.getTransactionToApproveStatement(10, null, 1, new ArrayList<>()), index);
     }
 
     private void newMilestone(API api, Hash[] tips, long index) throws Exception {


### PR DESCRIPTION
I think that larger bundles should reference more than just the two first tx, to be able to merge subtangles equally with small tx expanding them.

This allows to run getTxToApprove multiple times (i,e. throughout the PoW phase), each time giving the previous tips used.