### PR TITLE
Accelerate rating calculation

### DIFF
--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -243,8 +243,8 @@ public class TipsManager {
                 long tipRating = ratings.get(tip);
                 for (int i = 0; i < tips.length; i++) {
                     //transition probability = ((Hx-Hy)^-3)/maxRating
-                	long rating = tipRating - ratings.getOrDefault(tips[i],0L);
-                	double divisior = (double) rating * rating * rating;
+                    long rating = tipRating - ratings.getOrDefault(tips[i],0L);
+                    double divisior = (double) rating * rating * rating;
                     walkRatings[i] = 1.0 / divisior;
                     maxRating += walkRatings[i];
                 }

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -243,7 +243,9 @@ public class TipsManager {
                 long tipRating = ratings.get(tip);
                 for (int i = 0; i < tips.length; i++) {
                     //transition probability = ((Hx-Hy)^-3)/maxRating
-                    walkRatings[i] = Math.pow(tipRating - ratings.getOrDefault(tips[i],0L), -3);
+                	long rating = tipRating - ratings.getOrDefault(tips[i],0L);
+                	double divisior = (double) rating * rating * rating;
+                    walkRatings[i] = 1.0 / divisior;
                     maxRating += walkRatings[i];
                 }
                 ratingWeight = rnd.nextDouble() * maxRating;


### PR DESCRIPTION
I know it's not a hot spot, but with increasing number of tips and incoming transactions even milliseconds add up. I propose to replace the call to the general and quite expensive `Math.pow()` method with simple multiplication and division which are faster by a factor of >20.