### PR TITLE
Added ability to perform sonar analysis on sonarcloud.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ DEBUG = true
 DB_PATH = db
 ```
 
+### Running sonar analysis on sonarcloud.io
+To generate a new analysis, run the following:
+```
+$ mvn clean install sonar:sonar -Psonar-coverage -Dsonar.login=<the token provided by sonarcloud.io>  -Dsonar.organization=<org on sonarcloud.io>  -Dsonar.projectKey=<project key sonarcloud.io>
+```
+Last code analysis (February 18, 2018): https://sonarcloud.io/dashboard?id=iota
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
         <java-version>1.8</java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <undertow.version>1.4.6.Final</undertow.version>
+        <sonar.java.codeCoveragePlugin>jacoco</sonar.java.codeCoveragePlugin>
+        <sonar.sources>${project.basedir}/src/main/</sonar.sources>
+        <sonar.tests>${project.basedir}/src/test/</sonar.tests>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <repositories>
@@ -404,13 +408,60 @@
             </plugins>
         </build>
     </profile>
+    <profile>
+        <id>sonar-coverage</id>
+        <activation>
+            <activeByDefault>false</activeByDefault>
+        </activation>
+        <build>
+            <pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.7.9</version>
+                    </plugin>
+                </plugins>
+            </pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <configuration>
+                        <append>true</append>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>agent-for-ut</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>agent-for-it</id>
+                            <goals>
+                                <goal>prepare-agent-integration</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>jacoco-site</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
 </profiles>
 <reporting>
     <plugins>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.17</version>
+            <version>2.13</version>
             <reportSets>
                 <reportSet>
                     <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.17</version>
             <reportSets>
                 <reportSet>
                     <reports>


### PR DESCRIPTION
Hi All,

This PR maybe of interest as it adds the ability to perform sonar analysis on the codebase.  See the current report at https://sonarcloud.io/dashboard?id=iota

- added sonar-coverage profile which contains jacoco coverage plugin needed for sonar analysis / added sonar properties
- update version of checkstyle plugin
- added details on running sonar analysis on sonarcloud.io

To Run the analysis:
mvn clean install sonar:sonar -Psonar-coverage -Dsonar.login=<the token provided by sonarcloud.io>  -Dsonar.organization=<org on sonarcloud.io>  -Dsonar.projectKey=<project key sonarcloud.io>
