### PR TITLE
Reduce PearlDiver synchronization block and arguments passed

### DIFF
--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -52,91 +52,21 @@ public class PearlDiver {
 
         final long[] midCurlStateLow = new long[CURL_STATE_LENGTH], midCurlStateHigh = new long[CURL_STATE_LENGTH];
 
-        {
-            for (int i = CURL_HASH_LENGTH; i < CURL_STATE_LENGTH; i++) {
-                midCurlStateLow[i] = HIGH_BITS;
-                midCurlStateHigh[i] = HIGH_BITS;
-            }
-
-            int offset = 0;
-            final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH], curlScratchpadHigh = new long[CURL_STATE_LENGTH];
-            for (int i = (TRANSACTION_LENGTH - CURL_HASH_LENGTH) / CURL_HASH_LENGTH; i-- > 0; ) {
-
-                for (int j = 0; j < CURL_HASH_LENGTH; j++) {
-
-                    switch (transactionTrits[offset++]) {
-                        case 0: {
-                            midCurlStateLow[j] = HIGH_BITS;
-                            midCurlStateHigh[j] = HIGH_BITS;
-
-                        }
-                        break;
-
-                        case 1: {
-                            midCurlStateLow[j] = LOW_BITS;
-                            midCurlStateHigh[j] = HIGH_BITS;
-                        }
-                        break;
-
-                        default: {
-                            midCurlStateLow[j] = HIGH_BITS;
-                            midCurlStateHigh[j] = LOW_BITS;
-                        }
-                    }
-                }
-
-                transform(midCurlStateLow, midCurlStateHigh, curlScratchpadLow, curlScratchpadHigh);
-            }
-
-            for (int i = 0; i < 162; i++) {
-
-                switch (transactionTrits[offset++]) {
-
-                    case 0: {
-
-                        midCurlStateLow[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-                        midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-
-                    } break;
-
-                    case 1: {
-
-                        midCurlStateLow[i] = 0b0000000000000000000000000000000000000000000000000000000000000000L;
-                        midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-
-                    } break;
-
-                    default: {
-
-                        midCurlStateLow[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-                        midCurlStateHigh[i] = 0b0000000000000000000000000000000000000000000000000000000000000000L;
-                    }
-                }
-            }
-
-            midCurlStateLow[162 + 0] = 0b1101101101101101101101101101101101101101101101101101101101101101L;
-            midCurlStateHigh[162 + 0] = 0b1011011011011011011011011011011011011011011011011011011011011011L;
-            midCurlStateLow[162 + 1] = 0b1111000111111000111111000111111000111111000111111000111111000111L;
-            midCurlStateHigh[162 + 1] = 0b1000111111000111111000111111000111111000111111000111111000111111L;
-            midCurlStateLow[162 + 2] = 0b0111111111111111111000000000111111111111111111000000000111111111L;
-            midCurlStateHigh[162 + 2] = 0b1111111111000000000111111111111111111000000000111111111111111111L;
-            midCurlStateLow[162 + 3] = 0b1111111111000000000000000000000000000111111111111111111111111111L;
-            midCurlStateHigh[162 + 3] = 0b0000000000111111111111111111111111111111111111111111111111111111L;
-
-        }
-
+        para(transactionTrits, midCurlStateLow, midCurlStateHigh);
+        
         int numberOfThreads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 
         Thread[] workers = new Thread[numberOfThreads];
 
         while (numberOfThreads-- > 0) {
-
             final int threadIndex = numberOfThreads;
+            
             Thread worker = (new Thread(() -> {
-
                 final long[] midCurlStateCopyLow = new long[CURL_STATE_LENGTH], midCurlStateCopyHigh = new long[CURL_STATE_LENGTH];
+                
                 System.arraycopy(midCurlStateLow, 0, midCurlStateCopyLow, 0, CURL_STATE_LENGTH);
                 System.arraycopy(midCurlStateHigh, 0, midCurlStateCopyHigh, 0, CURL_STATE_LENGTH);
+                
                 for (int i = threadIndex; i-- > 0; ) {
                     increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + CURL_HASH_LENGTH / 9,
                             162 + (CURL_HASH_LENGTH / 9) * 2);
@@ -144,43 +74,24 @@ public class PearlDiver {
                 }
 
                 final long[] curlStateLow = new long[CURL_STATE_LENGTH], curlStateHigh = new long[CURL_STATE_LENGTH];
-                final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH], curlScratchpadHigh = new long[CURL_STATE_LENGTH];
                 long mask, outMask = 1;
-                while (state == RUNNING) {
-
-                    increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + (CURL_HASH_LENGTH / 9) * 2,
-                            CURL_HASH_LENGTH);
-
-                    System.arraycopy(midCurlStateCopyLow, 0, curlStateLow, 0, CURL_STATE_LENGTH);
-                    System.arraycopy(midCurlStateCopyHigh, 0, curlStateHigh, 0, CURL_STATE_LENGTH);
-                    transform(curlStateLow, curlStateHigh, curlScratchpadLow, curlScratchpadHigh);
-
-                    mask = HIGH_BITS;
-                    for (int i = minWeightMagnitude; i-- > 0; ) {
-                        mask &= ~(curlStateLow[CURL_HASH_LENGTH - 1 - i] ^ curlStateHigh[
-                            CURL_HASH_LENGTH - 1 - i]);
-                        if (mask == 0) {
-                            break;
-                        }
-                    }
-                    if (mask == 0) {
-                        continue;
-                    }
-
-                    synchronized (syncObj) {
-                        if (state == RUNNING) {
+                
+                if ((mask = loop(midCurlStateCopyLow, midCurlStateCopyHigh, minWeightMagnitude)) != 0) {
+                    if (state == RUNNING) {
+                        synchronized (syncObj) {
                             state = COMPLETED;
+
                             while ((outMask & mask) == 0) {
                                 outMask <<= 1;
                             }
+
                             for (int i = 0; i < CURL_HASH_LENGTH; i++) {
                                 transactionTrits[TRANSACTION_LENGTH - CURL_HASH_LENGTH + i] =
                                     (midCurlStateCopyLow[i] & outMask) == 0 ? 1
-                                        : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
+                                    : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
                             }
                         }
                     }
-                    break;
                 }
             }));
             workers[threadIndex] = worker;
@@ -200,10 +111,100 @@ public class PearlDiver {
         return state == COMPLETED;
     }
 
-    private static void transform(final long[] curlStateLow, final long[] curlStateHigh,
-        final long[] curlScratchpadLow, final long[] curlScratchpadHigh) {
+    private static void para(final int[] transactionTrits, final long[] midCurlStateLow, final long[] midCurlStateHigh) {
+        
+        for (int i = CURL_HASH_LENGTH; i < CURL_STATE_LENGTH; i++) {
+            midCurlStateLow[i] = HIGH_BITS;
+            midCurlStateHigh[i] = HIGH_BITS;
+        }
+
+        int offset = 0;
+        
+        for (int i = (TRANSACTION_LENGTH - CURL_HASH_LENGTH) / CURL_HASH_LENGTH; i-- > 0; ) {
+
+            for (int j = 0; j < CURL_HASH_LENGTH; j++) {
+
+                switch (transactionTrits[offset++]) {
+                    case 0: {
+                        midCurlStateLow[j] = HIGH_BITS;
+                        midCurlStateHigh[j] = HIGH_BITS;
+                    }
+                    break;
+
+                    case 1: {
+                        midCurlStateLow[j] = LOW_BITS;
+                        midCurlStateHigh[j] = HIGH_BITS;
+                    }
+                    break;
+
+                    default: {
+                        midCurlStateLow[j] = HIGH_BITS;
+                        midCurlStateHigh[j] = LOW_BITS;
+                    }
+                }
+            }
+            transform(midCurlStateLow, midCurlStateHigh);
+        }
+
+        for (int i = 0; i < 162; i++) {
+
+            switch (transactionTrits[offset++]) {
+
+                case 0: {
+                    midCurlStateLow[i] = HIGH_BITS;
+                    midCurlStateHigh[i] = HIGH_BITS;
+                } break;
+
+                case 1: {
+                    midCurlStateLow[i] = LOW_BITS;
+                    midCurlStateHigh[i] = HIGH_BITS;
+                } break;
+
+                default: {
+                    midCurlStateLow[i] = HIGH_BITS;
+                    midCurlStateHigh[i] = LOW_BITS;
+                }
+            }
+        }
+
+        midCurlStateLow[162 + 0] = 0b1101101101101101101101101101101101101101101101101101101101101101L;
+        midCurlStateHigh[162 + 0] = 0b1011011011011011011011011011011011011011011011011011011011011011L;
+        midCurlStateLow[162 + 1] = 0b1111000111111000111111000111111000111111000111111000111111000111L;
+        midCurlStateHigh[162 + 1] = 0b1000111111000111111000111111000111111000111111000111111000111111L;
+        midCurlStateLow[162 + 2] = 0b0111111111111111111000000000111111111111111111000000000111111111L;
+        midCurlStateHigh[162 + 2] = 0b1111111111000000000111111111111111111000000000111111111111111111L;
+        midCurlStateLow[162 + 3] = 0b1111111111000000000000000000000000000111111111111111111111111111L;
+        midCurlStateHigh[162 + 3] = 0b0000000000111111111111111111111111111111111111111111111111111111L;
+    }
+
+    private long loop(final long[] midCurlStateLow, final long[] midCurlStateHigh, final int mwm) {
+        final long[] curlStateLow = new long[CURL_STATE_LENGTH], curlStateHigh = new long[CURL_STATE_LENGTH];
+        long mask = 1;
+
+        while (state == RUNNING) {
+
+            increment(midCurlStateLow, midCurlStateHigh, 162 + (CURL_HASH_LENGTH / 9) * 2, CURL_HASH_LENGTH);
+
+            System.arraycopy(midCurlStateLow, 0, curlStateLow, 0, CURL_STATE_LENGTH);
+            System.arraycopy(midCurlStateHigh, 0, curlStateHigh, 0, CURL_STATE_LENGTH);
+            transform(curlStateLow, curlStateHigh);
+
+            mask = HIGH_BITS;
+            for (int i = mwm; i-- > 0; ) {
+                mask &= ~(curlStateLow[CURL_HASH_LENGTH - 1 - i] ^ curlStateHigh[CURL_HASH_LENGTH - 1 - i]);
+                if (mask == 0) break;
+            }
+            
+            if (mask != 0) break;
+        }
+        return mask;
+    }   
+
+    private static void transform(final long[] curlStateLow, final long[] curlStateHigh) {
 
         int curlScratchpadIndex = 0;
+        final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH], curlScratchpadHigh = new long[CURL_STATE_LENGTH];
+
         for (int round = 0; round < Curl.NUMBER_OF_ROUNDSP81; round++) {
             System.arraycopy(curlStateLow, 0, curlScratchpadLow, 0, CURL_STATE_LENGTH);
             System.arraycopy(curlStateHigh, 0, curlScratchpadHigh, 0, CURL_STATE_LENGTH);

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -34,8 +34,7 @@ public class PearlDiver {
         }
     }
 
-    public synchronized boolean search(final int[] transactionTrits, final int minWeightMagnitude,
-        int numberOfThreads) {
+    public synchronized boolean search(final int[] transactionTrits, final int minWeightMagnitude) {
 
         if (transactionTrits.length != TRANSACTION_LENGTH) {
             throw new RuntimeException(
@@ -126,9 +125,7 @@ public class PearlDiver {
 
         }
 
-        if (numberOfThreads <= 0) {
-            numberOfThreads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
-        }
+        int numberOfThreads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 
         Thread[] workers = new Thread[numberOfThreads];
 

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -76,20 +76,19 @@ public class PearlDiver {
                 final long[] curlStateLow = new long[CURL_STATE_LENGTH], curlStateHigh = new long[CURL_STATE_LENGTH];
                 long mask, outMask = 1;
                 
-                if ((mask = loop(midCurlStateCopyLow, midCurlStateCopyHigh, minWeightMagnitude)) != 0) {
-                    if (state == RUNNING) {
-                        synchronized (syncObj) {
-                            state = COMPLETED;
+                if ((mask = loop(midCurlStateCopyLow, midCurlStateCopyHigh, minWeightMagnitude)) != 0 &&
+                    state == RUNNING) {
+                    synchronized (syncObj) {
+                        state = COMPLETED;
 
-                            while ((outMask & mask) == 0) {
-                                outMask <<= 1;
-                            }
+                        while ((outMask & mask) == 0) {
+                            outMask <<= 1;
+                        }
 
-                            for (int i = 0; i < CURL_HASH_LENGTH; i++) {
-                                transactionTrits[TRANSACTION_LENGTH - CURL_HASH_LENGTH + i] =
-                                    (midCurlStateCopyLow[i] & outMask) == 0 ? 1
-                                    : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
-                            }
+                        for (int i = 0; i < CURL_HASH_LENGTH; i++) {
+                            transactionTrits[TRANSACTION_LENGTH - CURL_HASH_LENGTH + i] =
+                                (midCurlStateCopyLow[i] & outMask) == 0 ? 1
+                                : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
                         }
                     }
                 }

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -29,7 +29,6 @@ public class PearlDiver {
     public void cancel() {
         synchronized (syncObj) {
             state = CANCELLED;
-            syncObj.notifyAll();
         }
     }
 
@@ -178,7 +177,6 @@ public class PearlDiver {
                                     (midCurlStateCopyLow[i] & outMask) == 0 ? 1
                                         : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
                             }
-                            syncObj.notifyAll();
                         }
                     }
                     break;
@@ -186,18 +184,6 @@ public class PearlDiver {
             }));
             workers[threadIndex] = worker;
             worker.start();
-        }
-
-        try {
-            synchronized (syncObj) {
-                if (state == RUNNING) {
-                    syncObj.wait();
-                }
-            }
-        } catch (final InterruptedException e) {
-            synchronized (syncObj) {
-                state = CANCELLED;
-            }
         }
 
         for (Thread worker : workers) {

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -27,8 +27,10 @@ public class PearlDiver {
     private final Object syncObj = new Object();
 
     public void cancel() {
-        synchronized (syncObj) {
-            state = CANCELLED;
+        if (state == RUNNING) {
+            synchronized (syncObj) {
+                state = CANCELLED;
+            }
         }
     }
 
@@ -43,6 +45,8 @@ public class PearlDiver {
             throw new RuntimeException("Invalid min weight magnitude: " + minWeightMagnitude);
         }
 
+        // state still needs protected, because it is 
+        // possible that another thread calls cancel()
         synchronized (syncObj) {
             state = RUNNING;
         }

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -957,7 +957,7 @@ public class API {
                 Converter.copyTrits(MAX_TIMESTAMP_VALUE,transactionTrits,TransactionViewModel.ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_OFFSET,
                         TransactionViewModel.ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_SIZE);
 
-                if (!pearlDiver.search(transactionTrits, minWeightMagnitude, 0)) {
+                if (!pearlDiver.search(transactionTrits, minWeightMagnitude)) {
                     transactionViewModels.clear();
                     break;
                 }

--- a/src/test/java/com/iota/iri/hash/PearlDiverTest.java
+++ b/src/test/java/com/iota/iri/hash/PearlDiverTest.java
@@ -16,7 +16,6 @@ public class PearlDiverTest {
 
     private static final int TRYTE_LENGTH = 2673;
     private static final int MIN_WEIGHT_MAGNITUDE = 9;
-    private static final int NUM_CORES = -1; // use n-1 cores
 
     private PearlDiver pearlDiver;
     private int[] hashTrits;
@@ -41,12 +40,12 @@ public class PearlDiverTest {
 
     @Test(expected = RuntimeException.class)
     public void testInvalidMagnitude() {
-        pearlDiver.search(new int[8019], -1, NUM_CORES);
+        pearlDiver.search(new int[8019], -1);
     }
 
     @Test(expected = RuntimeException.class)
     public void testInvalidTritsLength() {
-        pearlDiver.search(new int[0], MIN_WEIGHT_MAGNITUDE, NUM_CORES);
+        pearlDiver.search(new int[0], MIN_WEIGHT_MAGNITUDE);
     }
 
     @Test
@@ -54,7 +53,7 @@ public class PearlDiverTest {
     public void testNoRandomFail() {
         for (int i = 0; i < 10000; i++) {
             int[] trits = TransactionViewModelTest.getRandomTransactionTrits();
-            pearlDiver.search(trits, MIN_WEIGHT_MAGNITUDE, NUM_CORES);
+            pearlDiver.search(trits, MIN_WEIGHT_MAGNITUDE);
             Hash hash = Hash.calculate(SpongeFactory.Mode.CURLP81, trits);
             for (int j = Hash.SIZE_IN_TRITS - 1; j > Hash.SIZE_IN_TRITS - MIN_WEIGHT_MAGNITUDE; j--) {
                 assertEquals(hash.trits()[j], 0);
@@ -69,7 +68,7 @@ public class PearlDiverTest {
         Sponge curl = new Curl(SpongeFactory.Mode.CURLP81);
         int[] myTrits = Converter.allocateTritsForTrytes(trytes.length());
         Converter.trits(trytes, myTrits, 0);
-        pearlDiver.search(myTrits, MIN_WEIGHT_MAGNITUDE, NUM_CORES);
+        pearlDiver.search(myTrits, MIN_WEIGHT_MAGNITUDE);
         curl.absorb(myTrits, 0, myTrits.length);
         curl.squeeze(hashTrits, 0, Curl.HASH_LENGTH);
         curl.reset();


### PR DESCRIPTION
- There is no need for main thread to wait() until one of other threads calls notifyAll(), because main thread would call join() for other threads finally.
- ```PearlDiver.cancel()``` may kill completed PoW task
- Number of threads to do PoW is fixed (num_cpu - 1), so there is no need to pass ```numberOfThreads``` to ```PearlDiver.search()```. Test case is also modified.
- Simplify ```PearlDiver.search()``` to maintain readability