### PR TITLE
Fixes #534

### DIFF
--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -122,7 +122,6 @@ public class TipsManager {
                     throw new RuntimeException("starting tip failed consistency check: " + tip.toString());
                 }
             } catch (Exception e) {
-                milestone.latestSnapshot.rwlock.readLock().unlock();
                 e.printStackTrace();
                 log.error("Encountered error: " + e.getLocalizedMessage());
                 throw e;


### PR DESCRIPTION
The unlocking already happens in the getTransactionsToApproveStatement, line 619 in API.java. A fail here would try to double-unlock, causing this cryptic error.