### PR TITLE
updateDiff - check consistency on currentState including diff

### DIFF
--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -265,13 +265,14 @@ public class LedgerValidator {
         Set<Hash> visitedHashes = new HashSet<>(approvedHashes);
         Map<Hash, Long> currentState = getLatestDiff(visitedHashes, tip, milestone.latestSnapshot.index(), false);
         if (currentState == null) return false;
+        diff.forEach((key, value) -> {
+            if(currentState.computeIfPresent(key, ((hash, aLong) -> value + aLong)) == null) {
+                currentState.putIfAbsent(key, value);
+            }
+        });
         boolean isConsistent = Snapshot.isConsistent(milestone.latestSnapshot.patchedDiff(currentState));
         if (isConsistent) {
-            currentState.forEach((key, value) -> {
-                if(diff.computeIfPresent(key, ((hash, aLong) -> value + aLong)) == null) {
-                    diff.putIfAbsent(key, value);
-                }
-            });
+            diff.putAll(currentState);
             approvedHashes.addAll(visitedHashes);
         }
         return isConsistent;


### PR DESCRIPTION
`Snapshot.isConsistent` check is executed on `latestSnapshot.patchedDiff(currentState)` which means that the current snapshot is patched w/ the `currentState`, which is the result of `getLatestDiff`.

however, `getLatestDiff` result is effected by `visitedHashes` - stopping traversal if hash already visited. so the related `diff` needs to be applied as well:

currently: `snapshot -> getLatestDiff`
PR: `snapshot -> diff -> getLatestDiff`