### PR TITLE
Node.java cleanup

### DIFF
--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSourceProcessor.java
@@ -1,5 +1,11 @@
 package com.iota.iri.network.replicator;
 
+import com.iota.iri.network.Neighbor;
+import com.iota.iri.network.Node;
+import com.iota.iri.network.TCPNeighbor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -7,17 +13,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.zip.CRC32;
-
-import com.iota.iri.network.TCPNeighbor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.iota.iri.network.Neighbor;
-import com.iota.iri.conf.Configuration;
-import com.iota.iri.hash.Curl;
-import com.iota.iri.model.Hash;
-import com.iota.iri.network.Node;
-import com.iota.iri.controllers.TransactionViewModel;
 
 class ReplicatorSourceProcessor implements Runnable {
 
@@ -77,7 +72,7 @@ class ReplicatorSourceProcessor implements Runnable {
                 int maxPeersAllowed = maxPeers;
                 if (!testnet || Neighbor.getNumPeers() >= maxPeersAllowed) {
                     String hostAndPort = inet_socket_address.getHostName() + ":" + String.valueOf(inet_socket_address.getPort());
-                    if (Node.rejectedAddresses.add(inet_socket_address.getHostName())) {
+                    if (node.rejectedAddresses.add(inet_socket_address.getHostName())) {
                         String sb = "***** NETWORK ALERT ***** Got connected from unknown neighbor tcp://"
                             + hostAndPort
                             + " (" + inet_socket_address.getAddress().getHostAddress() + ") - closing connection";                    


### PR DESCRIPTION
- moved permanent settings from init() to constructor and made final.
- Removed static modifier for instance variables and moved all static vars to top
- re-timed threads for ongoing tasks
- used direct Threads with Daemon status to jobs (no need for executor)
- added locking on separate FINAL mutex fields.
- cleaned up parsing of neighbor's configuration and allowed for multiple spaces and also handling for commas if present.
- added P_DROP check to see if property warrants doing a call to rnd.nextDouble().
- added some commenting to datagram copy and send routines.
- and a few minor things.
-removed static modifier on Node.rejectedAddresses since neighbors is instance level, so should rejected addresses. *required one change in Replicator to make a ref use instance of Node instead of static method.