### PR TITLE
Project-wide fix needed - InterruptExceptions ignored and not reset

### DIFF
--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -2,7 +2,6 @@ package com.iota.iri;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.iota.iri.hash.ISS;
 import com.iota.iri.service.CallableRequest;
 import com.iota.iri.service.dto.AbstractResponse;
 import com.sun.nio.file.SensitivityWatchEventModifier;
@@ -20,7 +19,10 @@ import java.io.Reader;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
-import java.util.*;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -86,7 +88,9 @@ public class IXI {
             try {
                 key = watcher.poll(1000, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
-                log.error("Watcher interrupted: ", e);
+                log.error("interrupted", e);
+                Thread.currentThread().interrupt();
+                break;
             }
             if (key == null) {
                 continue;
@@ -276,10 +280,15 @@ public class IXI {
         ixiLifetime.remove(moduleName);
     }
 
-    public void shutdown() throws InterruptedException, IOException {
+    public void shutdown()  {
         if(dirWatchThread != null) {
             shutdown = true;
-            dirWatchThread.join();
+            try {
+                dirWatchThread.join();
+            } catch (InterruptedException e) {
+                log.info("interrupted",e);
+                Thread.currentThread().interrupt();
+            }
             ixiAPI.keySet().forEach(this::detach);
             ixiAPI.clear();
             ixiLifetime.clear();

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 
 import java.security.SecureRandom;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Created by paul on 3/14/17 for iri-testnet.
@@ -21,13 +20,13 @@ public class TipsViewModel {
     private SecureRandom seed = new SecureRandom();
     public final Object sync = new Object();
 
-    public boolean addTipHash (Hash hash) throws ExecutionException, InterruptedException {
+    public boolean addTipHash (Hash hash) {
         synchronized (sync) {
             return tips.add(hash);
         }
     }
 
-    public boolean removeTipHash (Hash hash) throws ExecutionException, InterruptedException {
+    public boolean removeTipHash (Hash hash) {
         synchronized (sync) {
             if(!tips.remove(hash)) {
                 return solidTips.remove(hash);

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -1,8 +1,6 @@
 package com.iota.iri.hash;
 
-import static com.iota.iri.hash.PearlDiver.State.CANCELLED;
-import static com.iota.iri.hash.PearlDiver.State.COMPLETED;
-import static com.iota.iri.hash.PearlDiver.State.RUNNING;
+import static com.iota.iri.hash.PearlDiver.State.*;
 
 /**
  * (c) 2016 Come-from-Beyond
@@ -195,6 +193,7 @@ public class PearlDiver {
                 }
             }
         } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
             synchronized (syncObj) {
                 state = CANCELLED;
             }
@@ -204,6 +203,7 @@ public class PearlDiver {
             try {
                 worker.join();
             } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
                 synchronized (syncObj) {
                     state = CANCELLED;
                 }

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -645,9 +645,14 @@ public class Node {
         }
     }
 
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         shuttingDown.set(true);
-        executor.awaitTermination(6, TimeUnit.SECONDS);
+        try {
+            executor.awaitTermination(6, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.info("interrupted");
+            Thread.currentThread().interrupt();
+        }
     }
 
     // helpers methods

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -100,7 +100,7 @@ public class TCPNeighbor extends Neighbor {
     }
 
     public ByteBuffer getNextMessage() throws InterruptedException {
-        return (this.sendQueue.poll(10000, TimeUnit.MILLISECONDS));
+        return sendQueue.poll(10000, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/com/iota/iri/network/UDPReceiver.java
+++ b/src/main/java/com/iota/iri/network/UDPReceiver.java
@@ -23,7 +23,7 @@ public class UDPReceiver {
     private static final Logger log = LoggerFactory.getLogger(UDPReceiver.class);
 
     private final DatagramPacket receivingPacket = new DatagramPacket(new byte[TRANSACTION_PACKET_SIZE],
-            TRANSACTION_PACKET_SIZE);
+        TRANSACTION_PACKET_SIZE);
 
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
     private final int port;
@@ -31,11 +31,11 @@ public class UDPReceiver {
 
     private DatagramSocket socket;
 
-    private final int PROCESSOR_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors() * 4 );
+    private final int PROCESSOR_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors() * 4);
 
     private final ExecutorService processor = new ThreadPoolExecutor(PROCESSOR_THREADS, PROCESSOR_THREADS, 5000L,
-                                            TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(PROCESSOR_THREADS, true),
-                                             new ThreadPoolExecutor.AbortPolicy());
+        TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(PROCESSOR_THREADS, true),
+        new ThreadPoolExecutor.AbortPolicy());
 
     private Thread receivingThread;
 
@@ -68,7 +68,7 @@ public class UDPReceiver {
             while (!shuttingDown.get()) {
 
                 if (((processed + dropped) % 50000 == 0)) {
-                    log.info("Receiver thread processed/dropped ratio: "+processed+"/"+dropped);
+                    log.info("Receiver thread processed/dropped ratio: " + processed + "/" + dropped);
                     processed = 0;
                     dropped = 0;
                 }
@@ -111,15 +111,15 @@ public class UDPReceiver {
         }
     }
 
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         shuttingDown.set(true);
         processor.shutdown();
-        processor.awaitTermination(6, TimeUnit.SECONDS);
         try {
+            processor.awaitTermination(6, TimeUnit.SECONDS);
             receivingThread.join(6000L);
-        }
-        catch (Exception e) {
-            // ignore
+        } catch (Exception e) {
+            log.info("interrupted");
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/com/iota/iri/network/replicator/Replicator.java
+++ b/src/main/java/com/iota/iri/network/replicator/Replicator.java
@@ -25,7 +25,7 @@ public class Replicator {
         log.info("Started ReplicatorSourcePool");
     }
     
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         // TODO
         replicatorSourcePool.shutdown();
         replicatorSinkPool.shutdown();

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSourcePool.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSourcePool.java
@@ -1,18 +1,15 @@
 package com.iota.iri.network.replicator;
 
+import com.iota.iri.network.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import com.iota.iri.network.Node;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.iota.iri.conf.Configuration;
-import com.iota.iri.conf.Configuration.DefaultConfSettings;
 
 public class ReplicatorSourcePool implements Runnable {
 
@@ -70,11 +67,16 @@ public class ReplicatorSourcePool implements Runnable {
         }
     }
 
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         shutdown = true;
         //notify();
         pool.shutdown();
-        pool.awaitTermination(6, TimeUnit.SECONDS);
+        try {
+            pool.awaitTermination(6, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.info("interrupted");
+            Thread.currentThread().interrupt();
+        }
     }
 
     public ReplicatorSourcePool init(int port) {

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -1,18 +1,18 @@
 package com.iota.iri.service;
 
-import java.util.*;
-
 import com.iota.iri.LedgerValidator;
-import com.iota.iri.Snapshot;
+import com.iota.iri.Milestone;
 import com.iota.iri.TransactionValidator;
+import com.iota.iri.controllers.MilestoneViewModel;
+import com.iota.iri.controllers.TipsViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.controllers.*;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.zmq.MessageQ;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.iota.iri.Milestone;
+import java.util.*;
 
 public class TipsManager {
 
@@ -69,6 +69,8 @@ public class TipsManager {
                     Thread.sleep(RESCAN_TX_TO_REQUEST_INTERVAL);
                 } catch (InterruptedException e) {
                     log.error("Solidity rescan interrupted.");
+                    Thread.currentThread().interrupt();
+                    break;
                 }
             }
         }, "Tip Solidity Rescan");
@@ -91,7 +93,7 @@ public class TipsManager {
         }
     }
 
-    public void shutdown() throws InterruptedException {
+    public void shutdown() {
         shuttingDown = true;
         try {
             if (solidityRescanHandle != null && solidityRescanHandle.isAlive()) {
@@ -99,8 +101,8 @@ public class TipsManager {
             }
         } catch (Exception e) {
             log.error("Error in shutdown", e);
+            Thread.currentThread().interrupt();
         }
-
     }
 
     Hash transactionToApprove(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash reference, final Hash extraTip, int depth, final int iterations, Random seed) throws Exception {

--- a/src/main/java/com/iota/iri/zmq/MessageQ.java
+++ b/src/main/java/com/iota/iri/zmq/MessageQ.java
@@ -49,6 +49,7 @@ public class MessageQ {
             publisherService.awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             LOG.error("Publisher service shutdown failed.", e);
+            Thread.currentThread().interrupt();
         }
 
         publisher.close();

--- a/src/test/java/com/iota/iri/NodeIntegrationTests.java
+++ b/src/test/java/com/iota/iri/NodeIntegrationTests.java
@@ -1,8 +1,6 @@
 package com.iota.iri;
 
 import com.iota.iri.conf.Configuration;
-
-import static com.iota.iri.controllers.TransactionViewModel.*;
 import com.iota.iri.hash.Curl;
 import com.iota.iri.hash.Sponge;
 import com.iota.iri.hash.SpongeFactory;
@@ -20,6 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+
+import static com.iota.iri.controllers.TransactionViewModel.*;
 
 /**
  * Created by paul on 5/19/17.
@@ -102,7 +102,9 @@ public class NodeIntegrationTests {
             try {
                 Thread.sleep(20000);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                System.err.println(this + ": interrupted");
+                e.printStackTrace(System.err);
+                Thread.currentThread().interrupt();
             }
             shutdown.set(true);
             synchronized (waitObj) {
@@ -123,7 +125,10 @@ public class NodeIntegrationTests {
                 try {
                     Thread.sleep(spacing);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    System.err.println(this + ": interrupted");
+                    e.printStackTrace(System.err);
+                    Thread.currentThread().interrupt();
+                    return;
                 }
                 try {
                     sendMilestone(api, index++);

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionTrits;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -54,7 +53,7 @@ public class TransactionValidatorTest {
   }
 
   @Test
-  public void testMinMwm() throws InterruptedException {
+  public void testMinMwm() {
     txValidator.shutdown();
     txValidator.init(false, 5, 3);
     assertTrue(txValidator.getMinWeightMagnitude() == 13);

--- a/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
@@ -5,9 +5,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.ExecutionException;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by paul on 5/2/17.
@@ -74,7 +72,7 @@ public class TipsViewModelTest {
     }
 
     @Test
-    public void nonsolidCapacityLimited() throws ExecutionException, InterruptedException {
+    public void nonsolidCapacityLimited()  {
         TipsViewModel tipsVM = new TipsViewModel();
         int capacity = TipsViewModel.MAX_TIPS;
         //fill tips list
@@ -87,7 +85,7 @@ public class TipsViewModelTest {
     }
 
     @Test
-    public void solidCapacityLimited() throws ExecutionException, InterruptedException {
+    public void solidCapacityLimited() {
         TipsViewModel tipsVM = new TipsViewModel();
         int capacity = TipsViewModel.MAX_TIPS;
         //fill tips list
@@ -101,7 +99,7 @@ public class TipsViewModelTest {
     }
 
     @Test
-    public void totalCapacityLimited() throws ExecutionException, InterruptedException {
+    public void totalCapacityLimited() {
         TipsViewModel tipsVM = new TipsViewModel();
         int capacity = TipsViewModel.MAX_TIPS;
         //fill tips list


### PR DESCRIPTION
… sleeps, waits, and joins (and interrupts from blocking IO operations) need to be attended instead of ignored, and the thread Interrupt status needs to be reset to prevent further blockages.

Unless the interrupt is accidental (99% never the case), then all InterruptedExceptions need to be handled by resetting the interrupt status and then issuing a break/return/shutdown.

If this is not done, than any further blocking operations will continue to block and never return.
If an operation is 'shutdown' and may be in a blocking state, then a 'shutdown' flag change should also be accompanied by 'Thread.currentThread().interrupt();'

Reference: https://www.javaspecialists.eu/archive/Issue056.html

)

```
try {
   blocking op that can throw interruptExceptionm
} catch (final InterruptedException e) {
   Thread.currentThread().interrupt();
   (break or return or whatever)
}
```