### PR TITLE
don't load PreviousEpochsSpentAddresses on testnet 

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -110,7 +110,9 @@ public class API {
     }
 
     public void init() throws IOException {
-        readPreviousEpochsSpentAddresses();
+        if (!testNet) {
+            readPreviousEpochsSpentAddresses();
+        }
 
         final int apiPort = instance.configuration.integer(DefaultConfSettings.PORT);
         final String apiHost = instance.configuration.string(DefaultConfSettings.API_HOST);


### PR DESCRIPTION
# Description
when running on testnet PreviousEpochsSpentAddresses is not relevant, don't load it.
Fixes # [IRI-26](https://iotaledger.atlassian.net/projects/IRI/issues/IRI-26)

## Type of change

Please delete options that are not relevant.

- [ ] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- Using the shiny Travis CI in https://github.com/alon-e/iri/tree/feat/TravisCIadditions


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
