### PR TITLE
Travis Enhancements: caching, multiple jdks, integration and jar sanity tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ jdk:
   - oraclejdk9
 
 cache:
+  apt: true
   directories:
     - $HOME/.m2
 
 sudo: required
+
+addons:
+  apt:
+    packages:
+    - jq
 
 matrix:
   allow_failures:
@@ -23,7 +29,12 @@ script:
   - mkdir iri
   - cp -rf ../target iri/target
   - bash run_all_stable_tests.sh
+  - cd ..
 
+after_success:
+  #codacy-coverage send report
+  - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && wget -O codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
+  - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && java -jar codacy-coverage-reporter-assembly-latest.jar report -l Java -r target/site/jacoco/jacoco.xml
 
 deploy:
 - provider: releases


### PR DESCRIPTION
# Description

Travis Enhancements: 

- caching maven installation files

- jdk matrix - runs on 

  1. `oraclejdk8`
  2. `openjdk8` 
  3. ` oraclejdk9` (but allowed to fail)

- integration tests are ran (requires #620 & #607 to pass successfully).
- jar sanity tests are ran (requires #607 to pass successfully).
- jacoco results sent to codacy (requires #620 to pass successfully).

* currently points to a personal public repo - https://github.com/alon-e/iri-regression

## Type of change

Please delete options that are not relevant.

- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Using the shiny Travis CI in https://github.com/alon-e/iri/tree/feat/TravisCIadditions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
