### PR TITLE
Kerl.java absorb now 😈 666% faster 😈 - plus 🍦 cleaner and 🍦 simplified code

### DIFF
--- a/src/main/java/com/iota/iri/hash/Kerl.java
+++ b/src/main/java/com/iota/iri/hash/Kerl.java
@@ -6,17 +6,22 @@ import org.bouncycastle.jcajce.provider.digest.Keccak;
 import java.math.BigInteger;
 import java.security.DigestException;
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
-public class Kerl implements Sponge {
+public final class Kerl implements Sponge {
+
     public static final int BIT_HASH_LENGTH = 384;
     public static final int BYTE_HASH_LENGTH = BIT_HASH_LENGTH / 8;
 
-    private byte[] byte_state;
-    private int[] trit_state;
+    // radix constant conversion for fast math
+    public static final BigInteger RADIX = BigInteger.valueOf(Converter.RADIX);
+    private static final BigInteger[] RADIX_POWERS = IntStream.range(0, Sponge.HASH_LENGTH + 1).mapToObj(RADIX::pow).toArray(BigInteger[]::new);
+
+    private final byte[] byte_state;
+    private final int[] trit_state;
     private final Keccak.Digest384 keccak;
 
     protected Kerl() {
-
         this.keccak = new Keccak.Digest384();
         this.byte_state = new byte[BYTE_HASH_LENGTH];
         this.trit_state = new int[Sponge.HASH_LENGTH];
@@ -24,125 +29,151 @@ public class Kerl implements Sponge {
 
     @Override
     public void reset() {
-
         this.keccak.reset();
     }
 
     @Override
-    public void absorb(final int[] trits, int offset, int length) {
-
+    public void absorb(final int[] trits, final int offset, final int length) {
         if (length % 243 != 0) {
             throw new RuntimeException("Illegal length: " + length);
         }
-
-        do {
+        for (int pos = offset; pos < offset + length; pos += HASH_LENGTH) {
             //copy trits[offset:offset+length]
-            System.arraycopy(trits, offset, trit_state, 0, HASH_LENGTH);
+            System.arraycopy(trits, pos, trit_state, 0, HASH_LENGTH);
 
             //convert to bits
             trit_state[HASH_LENGTH - 1] = 0;
-            bytesFromBigInt(bigIntFromTrits(trit_state, 0, HASH_LENGTH), byte_state, 0);
+            bytesFromBigInt(bigIntFromTrits(trit_state, 0, HASH_LENGTH), byte_state);
 
             //run keccak
             keccak.update(byte_state);
-            offset += HASH_LENGTH;
-
-        } while ((length -= HASH_LENGTH) > 0);
+        }
     }
 
     @Override
-    public void squeeze(final int[] trits, int offset, int length) {
-
+    public void squeeze(final int[] trits, final int offset, final int length) {
         if (length % 243 != 0) {
-            throw new RuntimeException("Illegal length: " + length);
+            throw new IllegalArgumentException("Illegal length: " + length);
         }
-
         try {
-            do {
+            for (int pos = offset; pos < offset + length; pos += HASH_LENGTH) {
                 this.keccak.digest(byte_state, 0, BYTE_HASH_LENGTH);
                 //convert to trits
                 tritsFromBigInt(bigIntFromBytes(byte_state, 0, BYTE_HASH_LENGTH), trit_state, 0, Sponge.HASH_LENGTH);
 
                 //copy with offset
                 trit_state[HASH_LENGTH - 1] = 0;
-                System.arraycopy(trit_state, 0, trits, offset, HASH_LENGTH);
+                System.arraycopy(trit_state, 0, trits, pos, HASH_LENGTH);
 
                 //calculate hash again
                 for (int i = byte_state.length; i-- > 0; ) {
-
                     byte_state[i] = (byte) (byte_state[i] ^ 0xFF);
                 }
                 keccak.update(byte_state);
-                offset += HASH_LENGTH;
-
-            } while ((length -= HASH_LENGTH) > 0);
+            }
         } catch (DigestException e) {
-            e.printStackTrace();
+            e.printStackTrace(System.err);
             throw new RuntimeException(e);
         }
     }
 
     public static BigInteger bigIntFromTrits(final int[] trits, final int offset, final int size) {
-
-        BigInteger value = BigInteger.ZERO;
-
-        for (int i = size; i-- > 0; ) {
-
-            value = value.multiply(BigInteger.valueOf(Converter.RADIX)).add(BigInteger.valueOf(trits[offset + i]));
+        for (int i = offset; i < offset + size; i++) {
+            if (trits[i] < -1 || trits[i] > 1) {
+                throw new IllegalArgumentException("not a trit: " + trits[i]);
+            }
         }
+        BigInteger value = BigInteger.ZERO;
+        long num;
+        int power = 0;
+        int n = offset + size - 1;
+        for (; n > offset + 1; n--) {
+            switch (trits[n]) {
+                case 0: // a * b
+                    power++;
+                    break;
+                case 1: // a * b + 1
+                    num = 9 + (trits[--n] * 3) + trits[--n];
+                    for (int count = 0; n > offset && count <= 36; count++, power++) {
+                        num = 3 * num + trits[--n];
+                    }
+                    value = value.multiply(RADIX_POWERS[power + 3]).add(BigInteger.valueOf(num));
+                    power = 0;
+                    break;
+                case -1: // a * b - 1
+                    num = 9 - (trits[--n] * 3) - trits[--n];
+                    for (int count = 0; n > offset && count <= 36; count++, power++) {
+                        num = 3 * num - trits[--n];
+                    }
+                    value = value.multiply(RADIX_POWERS[power + 3]).subtract(BigInteger.valueOf(num));
+                    power = 0;
+                    break;
 
+                default:
+                    throw new RuntimeException("unreachable");
+            }
+        }
+        for (; n >= offset; n--) {
+            switch (trits[n]) {
+                case 0:
+                    power++;
+                    break;
+                case 1:
+                    value = value.multiply(RADIX_POWERS[power + 1]).add(BigInteger.ONE);
+                    power = 0;
+                    break;
+                case -1:
+                    value = value.multiply(RADIX_POWERS[power + 1]).subtract(BigInteger.ONE);
+                    power = 0;
+                    break;
+                default:
+                    throw new RuntimeException("unreachable");
+            }
+        }
+        // do leftover pow
+        if (power > 0) {
+            value = value.multiply(RADIX_POWERS[power]);
+        }
         return value;
     }
 
     public static BigInteger bigIntFromBytes(final byte[] bytes, final int offset, final int size) {
-
-        return new BigInteger(Arrays.copyOfRange(bytes, offset, offset + size));
+        return (bytes.length == offset + size) ? new BigInteger(bytes)
+            : new BigInteger(Arrays.copyOfRange(bytes, offset, offset + size));
     }
 
-    public static void tritsFromBigInt(final BigInteger value, int[] destination, int offset, int size) {
+    public static void tritsFromBigInt(final BigInteger value, final int[] destination, final int offset, final int size) {
 
         if (destination.length - offset < size) {
             throw new IllegalArgumentException("Destination array has invalid size");
         }
-
-        BigInteger absoluteValue = value.compareTo(BigInteger.ZERO) < 0 ? value.negate() : value;
+        final int signum = value.signum();
+        if (signum == 0) {
+            Arrays.fill(destination, offset, size, 0);
+            return;
+        }
+        BigInteger absoluteValue = value.abs();
         for (int i = 0; i < size; i++) {
-
-            BigInteger[] divRemainder = absoluteValue.divideAndRemainder(BigInteger.valueOf(Converter.RADIX));
-            int remainder = divRemainder[1].intValue();
+            BigInteger[] divRemainder = absoluteValue.divideAndRemainder(RADIX);
             absoluteValue = divRemainder[0];
 
+            int remainder = divRemainder[1].intValue();
             if (remainder > Converter.MAX_TRIT_VALUE) {
-
                 remainder = Converter.MIN_TRIT_VALUE;
                 absoluteValue = absoluteValue.add(BigInteger.ONE);
             }
-            destination[offset + i] = remainder;
-        }
-
-        if (value.compareTo(BigInteger.ZERO) < 0) {
-
-            for (int i = 0; i < size; i++) {
-
-                destination[offset + i] = -destination[offset + i];
-            }
+            destination[offset + i] = signum < 0 ? -remainder : remainder;
         }
     }
 
-    public static void bytesFromBigInt(final BigInteger value, byte[] destination, int offset) {
-        if (destination.length - offset < BYTE_HASH_LENGTH) {
+    public static void bytesFromBigInt(final BigInteger value, final byte[] destination) {
+        if (destination.length < BYTE_HASH_LENGTH) {
             throw new IllegalArgumentException("Destination array has invalid size.");
         }
-
-        final byte[] bytes = value.toByteArray();
-        int i = 0;
-        while (i + bytes.length < BYTE_HASH_LENGTH) {
-
-            destination[i++] = (byte) (bytes[0] < 0 ? -1 : 0);
-        }
-        for (int j = bytes.length; j-- > 0; ) {
-
-            destination[i++] = bytes[bytes.length - 1 - j];
+        int start = BYTE_HASH_LENGTH - (value.bitLength() / 8 + 1);
+        Arrays.fill(destination, 0, start, (byte) (value.signum() < 0 ? -1 : 0));
+        for (final byte aByte : value.toByteArray()) {
+            destination[start++] = aByte;
         }
     }
 }

--- a/src/main/java/com/iota/iri/hash/Kerl.java
+++ b/src/main/java/com/iota/iri/hash/Kerl.java
@@ -14,7 +14,7 @@ public final class Kerl implements Sponge {
     public static final int BYTE_HASH_LENGTH = BIT_HASH_LENGTH / 8;
 
     public static final BigInteger RADIX = BigInteger.valueOf(Converter.RADIX);
-    private static final int MAX_POWERS_LONG = 40;
+    public static final int MAX_POWERS_LONG = 40;
     private static final BigInteger[] RADIX_POWERS = IntStream.range(0, MAX_POWERS_LONG + 1).mapToObj(RADIX::pow).toArray(BigInteger[]::new);
 
     private final Keccak.Digest384 keccak;

--- a/src/main/java/com/iota/iri/hash/Kerl.java
+++ b/src/main/java/com/iota/iri/hash/Kerl.java
@@ -58,24 +58,24 @@ public class Kerl implements Sponge {
         }
 
         try {
-          do {
-              this.keccak.digest(byte_state, 0, BYTE_HASH_LENGTH);
-              //convert to trits
-              tritsFromBigInt(bigIntFromBytes(byte_state, 0, BYTE_HASH_LENGTH), trit_state, 0, Sponge.HASH_LENGTH);
+            do {
+                this.keccak.digest(byte_state, 0, BYTE_HASH_LENGTH);
+                //convert to trits
+                tritsFromBigInt(bigIntFromBytes(byte_state, 0, BYTE_HASH_LENGTH), trit_state, 0, Sponge.HASH_LENGTH);
 
-              //copy with offset
-              trit_state[HASH_LENGTH - 1] = 0;
-              System.arraycopy(trit_state, 0, trits, offset, HASH_LENGTH);
+                //copy with offset
+                trit_state[HASH_LENGTH - 1] = 0;
+                System.arraycopy(trit_state, 0, trits, offset, HASH_LENGTH);
 
-              //calculate hash again
-              for (int i = byte_state.length; i-- > 0; ) {
+                //calculate hash again
+                for (int i = byte_state.length; i-- > 0; ) {
 
-                  byte_state[i] = (byte) (byte_state[i] ^ 0xFF);
-              }
-              keccak.update(byte_state);
-              offset += HASH_LENGTH;
+                    byte_state[i] = (byte) (byte_state[i] ^ 0xFF);
+                }
+                keccak.update(byte_state);
+                offset += HASH_LENGTH;
 
-          } while ((length -= HASH_LENGTH) > 0);
+            } while ((length -= HASH_LENGTH) > 0);
         } catch (DigestException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
@@ -101,7 +101,7 @@ public class Kerl implements Sponge {
 
     public static void tritsFromBigInt(final BigInteger value, int[] destination, int offset, int size) {
 
-        if(destination.length - offset < size) {
+        if (destination.length - offset < size) {
             throw new IllegalArgumentException("Destination array has invalid size");
         }
 
@@ -117,7 +117,7 @@ public class Kerl implements Sponge {
                 remainder = Converter.MIN_TRIT_VALUE;
                 absoluteValue = absoluteValue.add(BigInteger.ONE);
             }
-            destination[offset  + i] = remainder;
+            destination[offset + i] = remainder;
         }
 
         if (value.compareTo(BigInteger.ZERO) < 0) {
@@ -128,8 +128,9 @@ public class Kerl implements Sponge {
             }
         }
     }
+
     public static void bytesFromBigInt(final BigInteger value, byte[] destination, int offset) {
-        if(destination.length - offset < BYTE_HASH_LENGTH) {
+        if (destination.length - offset < BYTE_HASH_LENGTH) {
             throw new IllegalArgumentException("Destination array has invalid size.");
         }
 

--- a/src/main/java/com/iota/iri/hash/Kerl.java
+++ b/src/main/java/com/iota/iri/hash/Kerl.java
@@ -110,7 +110,7 @@ public final class Kerl implements Sponge {
                     break;
 
                 default:
-                    throw new RuntimeException("unreachable");
+                    throw new IllegalStateException("unreachable");
             }
         }
         for (; n >= offset; n--) {
@@ -127,7 +127,7 @@ public final class Kerl implements Sponge {
                     power = 0;
                     break;
                 default:
-                    throw new RuntimeException("unreachable");
+                    throw new IllegalStateException("unreachable");
             }
         }
         // do leftover pow

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -88,11 +88,9 @@ public class KerlTest {
 
     @Test
     public void limitBigIntFromTrits() {
-        // this confirms that the limit we set using long math works for any size input
-        int[] trits = new int[2048];
+        // this confirms that the long math does not produce an overflow.
+        int[] trits = new int[Kerl.MAX_POWERS_LONG];
         Arrays.fill(trits, 1);
-        Kerl.bigIntFromTrits(trits, 0, trits.length);
-        Arrays.fill(trits, -1);
         Kerl.bigIntFromTrits(trits, 0, trits.length);
     }
 

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -100,7 +100,7 @@ public class KerlTest {
             expected = expected.multiply(BigInteger.valueOf(Converter.RADIX)).add(BigInteger.valueOf(trits[i]));
         }
         
-        Assert.equals(expected,result,"Overflow in long math");
+        Assert.assertTrue(expected.equals(result),"Overflow in long math");
     }
 
     //@Test

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -36,8 +36,8 @@ public class KerlTest {
         int byte_size = 48;
         BigInteger bigInteger = new BigInteger("13190295509826637194583200125168488859623001289643321872497025844241981297292953903419783680940401133507992851240799");
         byte[] outBytes = new byte[Kerl.BYTE_HASH_LENGTH];
-        Kerl.bytesFromBigInt(bigInteger,outBytes, 0);
-        BigInteger out_bigInteger = Kerl.bigIntFromBytes(outBytes,0,outBytes.length);
+        Kerl.bytesFromBigInt(bigInteger, outBytes, 0);
+        BigInteger out_bigInteger = Kerl.bigIntFromBytes(outBytes, 0, outBytes.length);
         Assert.assertTrue(bigInteger.equals(out_bigInteger));
     }
 
@@ -49,16 +49,16 @@ public class KerlTest {
         byte[] inBytes = new byte[byte_size];
         int[] trits = new int[Kerl.HASH_LENGTH];
         byte[] outBytes = new byte[Kerl.BYTE_HASH_LENGTH];
-        for (int i = 0; i<10_000; i++) {
+        for (int i = 0; i < 10_000; i++) {
             seed.nextBytes(inBytes);
-            BigInteger in_bigInteger = Kerl.bigIntFromBytes(inBytes,0,inBytes.length);
+            BigInteger in_bigInteger = Kerl.bigIntFromBytes(inBytes, 0, inBytes.length);
             Kerl.tritsFromBigInt(in_bigInteger, trits, 0, trit_size);
             BigInteger out_bigInteger = Kerl.bigIntFromTrits(trits, 0, trit_size);
-            Kerl.bytesFromBigInt(out_bigInteger,outBytes, 0);
-            if(i % 1_000 == 0) {
-                System.out.println(String.format("%d iteration: %s",i, in_bigInteger ));
+            Kerl.bytesFromBigInt(out_bigInteger, outBytes, 0);
+            if (i % 1_000 == 0) {
+                System.out.println(String.format("%d iteration: %s", i, in_bigInteger));
             }
-            Assert.assertTrue(String.format("bigInt that failed: %s",in_bigInteger),Arrays.equals(inBytes,outBytes));
+            Assert.assertTrue(String.format("bigInt that failed: %s", in_bigInteger), Arrays.equals(inBytes, outBytes));
         }
     }
 
@@ -70,26 +70,26 @@ public class KerlTest {
         int[] inTrits;
         byte[] bytes = new byte[Kerl.BYTE_HASH_LENGTH];
         int[] outTrits = new int[Kerl.HASH_LENGTH];
-        for (int i = 0; i<10_000; i++) {
+        for (int i = 0; i < 10_000; i++) {
             inTrits = getRandomTrits(trit_size);
             inTrits[242] = 0;
 
             BigInteger in_bigInteger = Kerl.bigIntFromTrits(inTrits, 0, trit_size);
-            Kerl.bytesFromBigInt(in_bigInteger,bytes,0);
-            BigInteger out_bigInteger = Kerl.bigIntFromBytes(bytes,0,bytes.length);
+            Kerl.bytesFromBigInt(in_bigInteger, bytes, 0);
+            BigInteger out_bigInteger = Kerl.bigIntFromBytes(bytes, 0, bytes.length);
             Kerl.tritsFromBigInt(out_bigInteger, outTrits, 0, trit_size);
 
-            if(i % 1_000 == 0) {
-                System.out.println(String.format("%d iteration: %s",i, in_bigInteger ));
+            if (i % 1_000 == 0) {
+                System.out.println(String.format("%d iteration: %s", i, in_bigInteger));
             }
-            Assert.assertTrue(String.format("bigInt that failed: %s",in_bigInteger),Arrays.equals(inTrits,outTrits));
+            Assert.assertTrue(String.format("bigInt that failed: %s", in_bigInteger), Arrays.equals(inTrits, outTrits));
         }
     }
 
     //@Test
     public void generateBytesFromBigInt() throws Exception {
         System.out.println("bigInteger,ByteArray");
-        for (int i = 0; i<100_000; i++) {
+        for (int i = 0; i < 100_000; i++) {
             int byte_size = 48;
             byte[] outBytes = new byte[byte_size];
             seed.nextBytes(outBytes);
@@ -104,12 +104,12 @@ public class KerlTest {
         int i;
         Hash hash;
         long start, diff;
-        long maxdiff=0, sumdiff = 0, subSumDiff = 0;
+        long maxdiff = 0, sumdiff = 0, subSumDiff = 0;
         int max = 100;// was 10000;
         int interval = 1000;
 
         String test = "curl";
-        for (i = 0; i++ < max;) {
+        for (i = 0; i++ < max; ) {
             //pre
             int size = 8019;
             int[] in_trits = getRandomTrits(size);
@@ -133,21 +133,22 @@ public class KerlTest {
             String out_trytes = Converter.trytes(hash_trits);
 
             sumdiff += diff;
-            subSumDiff +=diff;
-            if (diff>maxdiff) {
+            subSumDiff += diff;
+            if (diff > maxdiff) {
                 maxdiff = diff;
             }
-            if(i % interval == 0) {
+            if (i % interval == 0) {
                 //log.info("{}", new String(new char[(int) ((diff / 10000))]).replace('\0', '|'));
             }
-            if(i % interval == 0) {
+            if (i % interval == 0) {
                 log.info("Run time for {}: {} us.\tInterval Time: {} us.\tMax time per iter: {} us. \tAverage: {} us.\t Total time: {} us.", i,
-                        (diff / 1000) , subSumDiff/1000, (maxdiff/ 1000), sumdiff/i/1000, sumdiff/1000 );
+                    (diff / 1000), subSumDiff / 1000, (maxdiff / 1000), sumdiff / i / 1000, sumdiff / 1000);
                 subSumDiff = 0;
                 maxdiff = 0;
             }
         }
     }
+
     @Test
     public void kerlOneAbsorb() throws Exception {
         int[] initial_value = Converter.allocatingTritsFromTrytes("EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJFGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH");
@@ -182,7 +183,7 @@ public class KerlTest {
     }
 
     public static int[] getRandomTrits(int length) {
-        return Arrays.stream(new int[length]).map(i -> seed.nextInt(3)-1).toArray();
+        return Arrays.stream(new int[length]).map(i -> seed.nextInt(3) - 1).toArray();
     }
 
     public static Hash getRandomTransactionHash() {
@@ -192,7 +193,7 @@ public class KerlTest {
     //@Test
     public void generateTrytesAndHashes() throws Exception {
         System.out.println("trytes,Kerl_hash");
-        for (int i = 0; i< 10000 ; i++) {
+        for (int i = 0; i < 10000; i++) {
             Hash trytes = getRandomTransactionHash();
             int[] initial_value = trytes.trits();
             Sponge k = SpongeFactory.create(SpongeFactory.Mode.KERL);
@@ -200,14 +201,14 @@ public class KerlTest {
             int[] hash_value = new int[Curl.HASH_LENGTH];
             k.squeeze(hash_value, 0, hash_value.length);
             String hash = Converter.trytes(hash_value);
-            System.out.println(String.format("%s,%s",trytes,hash));
+            System.out.println(String.format("%s,%s", trytes, hash));
         }
     }
 
     //@Test
     public void generateTrytesAndMultiSqueeze() throws Exception {
         System.out.println("trytes,Kerl_squeeze1,Kerl_squeeze2,Kerl_squeeze3");
-        for (int i = 0; i< 10000 ; i++) {
+        for (int i = 0; i < 10000; i++) {
             Hash trytes = getRandomTransactionHash();
             int[] initial_value = trytes.trits();
             Sponge k = SpongeFactory.create(SpongeFactory.Mode.KERL);
@@ -219,22 +220,22 @@ public class KerlTest {
             String hash2 = Converter.trytes(hash_value);
             k.squeeze(hash_value, 0, hash_value.length);
             String hash3 = Converter.trytes(hash_value);
-            System.out.println(String.format("%s,%s,%s,%s",trytes,hash1,hash2,hash3));
+            System.out.println(String.format("%s,%s,%s,%s", trytes, hash1, hash2, hash3));
         }
     }
 
     //@Test
     public void generateMultiTrytesAndHash() throws Exception {
         System.out.println("multiTrytes,Kerl_hash");
-        for (int i = 0; i< 10000 ; i++) {
-            String multi = String.format("%s%s%s",getRandomTransactionHash(),getRandomTransactionHash(),getRandomTransactionHash());
+        for (int i = 0; i < 10000; i++) {
+            String multi = String.format("%s%s%s", getRandomTransactionHash(), getRandomTransactionHash(), getRandomTransactionHash());
             int[] initial_value = Converter.allocatingTritsFromTrytes(multi);
             Sponge k = SpongeFactory.create(SpongeFactory.Mode.KERL);
             k.absorb(initial_value, 0, initial_value.length);
             int[] hash_value = new int[Curl.HASH_LENGTH];
             k.squeeze(hash_value, 0, hash_value.length);
             String hash = Converter.trytes(hash_value);
-            System.out.println(String.format("%s,%s",multi,hash));
+            System.out.println(String.format("%s,%s", multi, hash));
         }
     }
 
@@ -242,7 +243,7 @@ public class KerlTest {
     //@Test
     public void generateHashes() throws Exception {
         //System.out.println("trytes,Kerl_hash");
-        for (int i = 0; i< 1_000_000 ; i++) {
+        for (int i = 0; i < 1_000_000; i++) {
             Hash trytes = getRandomTransactionHash();
             int[] initial_value = trytes.trits();
             Sponge k = SpongeFactory.create(SpongeFactory.Mode.KERL);
@@ -251,7 +252,7 @@ public class KerlTest {
             k.squeeze(hash_value, 0, hash_value.length);
             String hash = Converter.trytes(hash_value);
             //System.out.println(String.format("%s,%s",trytes,hash));
-            System.out.println(String.format("%s",hash));
+            System.out.println(String.format("%s", hash));
         }
     }
 

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -90,8 +90,17 @@ public class KerlTest {
     public void limitBigIntFromTrits() {
         // this confirms that the long math does not produce an overflow.
         int[] trits = new int[Kerl.MAX_POWERS_LONG];
+        
         Arrays.fill(trits, 1);
-        Kerl.bigIntFromTrits(trits, 0, trits.length);
+        BigInteger result = Kerl.bigIntFromTrits(trits, 0, trits.length);
+
+        Arrays.fill(trits, 1);
+        BigInteger expected = BigInteger.ZERO;
+        for (int i = trits.length; i-- > 0; ) {
+            expected = expected.multiply(BigInteger.valueOf(Converter.RADIX)).add(BigInteger.valueOf(trits[i]));
+        }
+        
+        Assert.equals(expected,result,"Overflow in long math");
     }
 
     //@Test

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -98,9 +98,8 @@ public class KerlTest {
         BigInteger expected = BigInteger.ZERO;
         for (int i = trits.length; i-- > 0; ) {
             expected = expected.multiply(BigInteger.valueOf(Converter.RADIX)).add(BigInteger.valueOf(trits[i]));
-        }
-        
-        Assert.assertTrue(expected.equals(result),"Overflow in long math");
+        }        
+        Assert.assertTrue("Overflow in long math", expected.equals(result));
     }
 
     //@Test

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -36,7 +36,7 @@ public class KerlTest {
         int byte_size = 48;
         BigInteger bigInteger = new BigInteger("13190295509826637194583200125168488859623001289643321872497025844241981297292953903419783680940401133507992851240799");
         byte[] outBytes = new byte[Kerl.BYTE_HASH_LENGTH];
-        Kerl.bytesFromBigInt(bigInteger, outBytes, 0);
+        Kerl.bytesFromBigInt(bigInteger, outBytes);
         BigInteger out_bigInteger = Kerl.bigIntFromBytes(outBytes, 0, outBytes.length);
         Assert.assertTrue(bigInteger.equals(out_bigInteger));
     }
@@ -54,7 +54,7 @@ public class KerlTest {
             BigInteger in_bigInteger = Kerl.bigIntFromBytes(inBytes, 0, inBytes.length);
             Kerl.tritsFromBigInt(in_bigInteger, trits, 0, trit_size);
             BigInteger out_bigInteger = Kerl.bigIntFromTrits(trits, 0, trit_size);
-            Kerl.bytesFromBigInt(out_bigInteger, outBytes, 0);
+            Kerl.bytesFromBigInt(out_bigInteger, outBytes);
             if (i % 1_000 == 0) {
                 System.out.println(String.format("%d iteration: %s", i, in_bigInteger));
             }
@@ -75,7 +75,7 @@ public class KerlTest {
             inTrits[242] = 0;
 
             BigInteger in_bigInteger = Kerl.bigIntFromTrits(inTrits, 0, trit_size);
-            Kerl.bytesFromBigInt(in_bigInteger, bytes, 0);
+            Kerl.bytesFromBigInt(in_bigInteger, bytes);
             BigInteger out_bigInteger = Kerl.bigIntFromBytes(bytes, 0, bytes.length);
             Kerl.tritsFromBigInt(out_bigInteger, outTrits, 0, trit_size);
 
@@ -84,6 +84,16 @@ public class KerlTest {
             }
             Assert.assertTrue(String.format("bigInt that failed: %s", in_bigInteger), Arrays.equals(inTrits, outTrits));
         }
+    }
+
+    @Test
+    public void limitBigIntFromTrits() {
+        // this confirms that the limit we set using long math works for any size input
+        int[] trits = new int[2048];
+        Arrays.fill(trits, 1);
+        Kerl.bigIntFromTrits(trits, 0, trits.length);
+        Arrays.fill(trits, -1);
+        Kerl.bigIntFromTrits(trits, 0, trits.length);
     }
 
     //@Test

--- a/src/test/java/com/iota/iri/hash/KerlTest.java
+++ b/src/test/java/com/iota/iri/hash/KerlTest.java
@@ -37,7 +37,7 @@ public class KerlTest {
         BigInteger bigInteger = new BigInteger("13190295509826637194583200125168488859623001289643321872497025844241981297292953903419783680940401133507992851240799");
         byte[] outBytes = new byte[Kerl.BYTE_HASH_LENGTH];
         Kerl.bytesFromBigInt(bigInteger, outBytes);
-        BigInteger out_bigInteger = Kerl.bigIntFromBytes(outBytes, 0, outBytes.length);
+        BigInteger out_bigInteger = new BigInteger(outBytes);
         Assert.assertTrue(bigInteger.equals(out_bigInteger));
     }
 
@@ -51,7 +51,7 @@ public class KerlTest {
         byte[] outBytes = new byte[Kerl.BYTE_HASH_LENGTH];
         for (int i = 0; i < 10_000; i++) {
             seed.nextBytes(inBytes);
-            BigInteger in_bigInteger = Kerl.bigIntFromBytes(inBytes, 0, inBytes.length);
+            BigInteger in_bigInteger = new BigInteger(inBytes);
             Kerl.tritsFromBigInt(in_bigInteger, trits, 0, trit_size);
             BigInteger out_bigInteger = Kerl.bigIntFromTrits(trits, 0, trit_size);
             Kerl.bytesFromBigInt(out_bigInteger, outBytes);
@@ -76,7 +76,7 @@ public class KerlTest {
 
             BigInteger in_bigInteger = Kerl.bigIntFromTrits(inTrits, 0, trit_size);
             Kerl.bytesFromBigInt(in_bigInteger, bytes);
-            BigInteger out_bigInteger = Kerl.bigIntFromBytes(bytes, 0, bytes.length);
+            BigInteger out_bigInteger = new BigInteger(bytes);
             Kerl.tritsFromBigInt(out_bigInteger, outTrits, 0, trit_size);
 
             if (i % 1_000 == 0) {


### PR DESCRIPTION
`Kerl.absorb(...)` now 666% faster, plus cleaner and simplified code ! I'm exaggerating a little, it is actually only 665.55% faster. 
Snapshot.initial loading is now 👍 315% faster. 👍 

Big time hog was **bigIntFromTrits(...)**. Everything else in Kerl.java was very fast already.
- Created a fast track for Radix power multiplication.
- Created a native math routine to munch 40 trits at a time into the main math routine.
- Added test to ensure that there is no math overflow.

Reusable instance state removed since it complicates reading the code and offers no performance advantages. All state now method-local.

As per @th0br0  suggestion, I compared to alternate implementation [jota...kerl](https://github.com/iotaledger/iota.lib.java/blob/master/jota/src/main/java/jota/pow/Kerl.java) 
- My 'absorb' is **468% faster** - 4.34 seconds faster each round.
- jota-kerl 'squeeze' is **first-round 220% faster** than mine. However, it is insignificant since the difference from 'squeeze' on digesting a 20 MB file is less than 2/5th of a millisecond. After 20 rounds, my squeeze (and the original) are still faster.

**Tested digesting 20 complete loads of the 20MB+ snapshot. All times milliseconds.**

FIRST RUN | OLD | MINE | jota-kerl
-----------  | ----- | ------ | -------
SNAPSHOT | 9693 | **3074** | 7467
ABSORB     | 7920 |  **1190** | 5570
SQUEEZE    | 0.80  |      0.77    | 0.35

AVG of 20 runs |   OLD |   MINE |  jota-kerl
-------- | -------- | -----| -------
SNAPSHOT | 8760 |	**2569**	| 6784
ABSORB     | 7195 |	**1029**  | 5223
SQUEEZE	  |  0.19  |	0.18	| 0.32

Fixes # (issue)

## Type of change
- Enhancement - Speeds up Kerl considerably

# How Has This Been Tested?
- Test written
- Tested on Snapshot loading
- Tested via existing Kerl and Curl and Bundle Validator tests

# Checklist:
 [X] My code follows the style guidelines for this project
 [X] I have performed a self-review of my own code
 [X] I have added tests that prove my fix is effective or that my feature works
 [X] New and existing unit tests pass locally with my changes