### PR TITLE
Check ini file before loading default testnet values and add testnetdb flag

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -109,6 +109,7 @@ public class IRI {
         final Option<Boolean> dnsResolutionFalse = parser.addBooleanOption("dns-resolution-false");
         final Option<String> maxPeers = parser.addStringOption("max-peers");
         final Option<String> testnetCoordinator = parser.addStringOption("testnet-coordinator");
+        final Option<String> testnetDbPath = parser.addStringOption("db-path");
         final Option<Boolean> disableCooValidation = parser.addBooleanOption("testnet-no-coo-validation");
         final Option<String> snapshot = parser.addStringOption("snapshot");
         final Option<String> snapshotSignature = parser.addStringOption("snapshot-sig");
@@ -139,18 +140,69 @@ public class IRI {
                 || configuration.booling(DefaultConfSettings.TESTNET);
         if (isTestnet) {
             configuration.put(DefaultConfSettings.TESTNET, "true");
-            configuration.put(DefaultConfSettings.DB_PATH.name(), "testnetdb");
-            configuration.put(DefaultConfSettings.DB_LOG_PATH.name(), "testnetdb.log");
-            configuration.put(DefaultConfSettings.COORDINATOR, Configuration.TESTNET_COORDINATOR_ADDRESS);
-            configuration.put(DefaultConfSettings.SNAPSHOT_FILE, Configuration.TESTNET_SNAPSHOT_FILE);
-            configuration.put(DefaultConfSettings.MILESTONE_START_INDEX, Configuration.TESTNET_MILESTONE_START_INDEX);
+
+            String dbPath = configuration.string(DefaultConfSettings.DB_PATH);
+            if (StringUtils.isEmpty(dbPath)) {
+                dbPath = Configuration.TESTNETDB;
+            }
+            configuration.put(DefaultConfSettings.DB_PATH.name(), dbPath);
+
+            String dbLog = configuration.string(DefaultConfSettings.DB_LOG_PATH);
+            if (StringUtils.isEmpty(dbLog)) {
+                dbLog = Configuration.TESTNETDB_LOG;
+            }
+            configuration.put(DefaultConfSettings.DB_LOG_PATH.name(), dbLog);
+
+            String coordinator_address = configuration.string(DefaultConfSettings.COORDINATOR);
+            if (StringUtils.isEmpty(coordinator_address)) {
+                coordinator_address = Configuration.TESTNET_COORDINATOR_ADDRESS;
+            }
+            configuration.put(DefaultConfSettings.COORDINATOR, coordinator_address);
+
+            String snapshotFile = configuration.string(DefaultConfSettings.SNAPSHOT_FILE);
+            if (StringUtils.isEmpty(snapshotFile)) {
+                snapshotFile = Configuration.TESTNET_SNAPSHOT_FILE;
+            }
+            configuration.put(DefaultConfSettings.SNAPSHOT_FILE, snapshotFile);
+
+            String milestoneStart = configuration.string(DefaultConfSettings.MILESTONE_START_INDEX);
+            if (StringUtils.isEmpty(milestoneStart)) {
+                milestoneStart = Configuration.TESTNET_MILESTONE_START_INDEX;
+            }
+            configuration.put(DefaultConfSettings.MILESTONE_START_INDEX, milestoneStart);
+
+            //this should always be empty
             configuration.put(DefaultConfSettings.SNAPSHOT_SIGNATURE_FILE, "");
-            configuration.put(DefaultConfSettings.MWM, Configuration.TESTNET_MWM);
-            configuration.put(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE,
-                    Configuration.TESTNET_NUM_KEYS_IN_MILESTONE);
-            configuration.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE, Configuration.TESTNET_PACKET_SIZE);
-            configuration.put(DefaultConfSettings.REQUEST_HASH_SIZE, Configuration.TESTNET_REQ_HASH_SIZE);
-            configuration.put(DefaultConfSettings.SNAPSHOT_TIME, Configuration.TESTNET_GLOBAL_SNAPSHOT_TIME);
+
+            String mwm = configuration.string(DefaultConfSettings.MWM);
+            if (StringUtils.isEmpty(mwm)) {
+                mwm = Configuration.TESTNET_MWM;
+            }
+            configuration.put(DefaultConfSettings.MWM, mwm);
+
+            String keysInMilestone = configuration.string(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE);
+            if (StringUtils.isEmpty(keysInMilestone)) {
+                keysInMilestone = Configuration.TESTNET_NUM_KEYS_IN_MILESTONE;
+            }
+            configuration.put(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE, keysInMilestone);
+
+            String transactionPacketSize = configuration.string(DefaultConfSettings.TRANSACTION_PACKET_SIZE);
+            if (StringUtils.isEmpty(transactionPacketSize)) {
+                transactionPacketSize = Configuration.TESTNET_PACKET_SIZE;
+            }
+            configuration.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE, transactionPacketSize);
+
+            String reqHashSize = configuration.string(DefaultConfSettings.REQUEST_HASH_SIZE);
+            if (StringUtils.isEmpty(reqHashSize)) {
+                reqHashSize = Configuration.TESTNET_REQ_HASH_SIZE;
+            }
+            configuration.put(DefaultConfSettings.REQUEST_HASH_SIZE, reqHashSize);
+
+            String globalSnapshotTime = configuration.string(DefaultConfSettings.SNAPSHOT_TIME);
+            if (StringUtils.isEmpty(globalSnapshotTime)) {
+                globalSnapshotTime = Configuration.TESTNET_GLOBAL_SNAPSHOT_TIME;
+            }
+            configuration.put(DefaultConfSettings.SNAPSHOT_TIME, globalSnapshotTime);
         }
 
         // mandatory args
@@ -222,6 +274,15 @@ public class IRI {
             StatusPrinter.print((LoggerContext) LoggerFactory.getILoggerFactory());
         }
 
+        final String dbPath = parser.getOptionValue(testnetDbPath);
+        if (dbPath != null) {
+            if (isTestnet) {
+                configuration.put(DefaultConfSettings.DB_PATH, dbPath);
+                configuration.put(DefaultConfSettings.DB_LOG_PATH.name(), dbPath + ".log");
+            } else {
+                log.warn(TESTNET_FLAG_REQUIRED + testnetDbPath.longForm());
+            }
+        }
 
         final String coordinatorAddress = parser.getOptionValue(testnetCoordinator);
         if (coordinatorAddress != null) {

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -139,70 +139,7 @@ public class IRI {
         final boolean isTestnet = Optional.ofNullable(parser.getOptionValue(testnet)).orElse(Boolean.FALSE)
                 || configuration.booling(DefaultConfSettings.TESTNET);
         if (isTestnet) {
-            configuration.put(DefaultConfSettings.TESTNET, "true");
-
-            String dbPath = configuration.string(DefaultConfSettings.DB_PATH);
-            if (StringUtils.isEmpty(dbPath)) {
-                dbPath = Configuration.TESTNETDB;
-            }
-            configuration.put(DefaultConfSettings.DB_PATH.name(), dbPath);
-
-            String dbLog = configuration.string(DefaultConfSettings.DB_LOG_PATH);
-            if (StringUtils.isEmpty(dbLog)) {
-                dbLog = Configuration.TESTNETDB_LOG;
-            }
-            configuration.put(DefaultConfSettings.DB_LOG_PATH.name(), dbLog);
-
-            String coordinator_address = configuration.string(DefaultConfSettings.COORDINATOR);
-            if (StringUtils.isEmpty(coordinator_address)) {
-                coordinator_address = Configuration.TESTNET_COORDINATOR_ADDRESS;
-            }
-            configuration.put(DefaultConfSettings.COORDINATOR, coordinator_address);
-
-            String snapshotFile = configuration.string(DefaultConfSettings.SNAPSHOT_FILE);
-            if (StringUtils.isEmpty(snapshotFile)) {
-                snapshotFile = Configuration.TESTNET_SNAPSHOT_FILE;
-            }
-            configuration.put(DefaultConfSettings.SNAPSHOT_FILE, snapshotFile);
-
-            String milestoneStart = configuration.string(DefaultConfSettings.MILESTONE_START_INDEX);
-            if (StringUtils.isEmpty(milestoneStart)) {
-                milestoneStart = Configuration.TESTNET_MILESTONE_START_INDEX;
-            }
-            configuration.put(DefaultConfSettings.MILESTONE_START_INDEX, milestoneStart);
-
-            //this should always be empty
-            configuration.put(DefaultConfSettings.SNAPSHOT_SIGNATURE_FILE, "");
-
-            String mwm = configuration.string(DefaultConfSettings.MWM);
-            if (StringUtils.isEmpty(mwm)) {
-                mwm = Configuration.TESTNET_MWM;
-            }
-            configuration.put(DefaultConfSettings.MWM, mwm);
-
-            String keysInMilestone = configuration.string(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE);
-            if (StringUtils.isEmpty(keysInMilestone)) {
-                keysInMilestone = Configuration.TESTNET_NUM_KEYS_IN_MILESTONE;
-            }
-            configuration.put(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE, keysInMilestone);
-
-            String transactionPacketSize = configuration.string(DefaultConfSettings.TRANSACTION_PACKET_SIZE);
-            if (StringUtils.isEmpty(transactionPacketSize)) {
-                transactionPacketSize = Configuration.TESTNET_PACKET_SIZE;
-            }
-            configuration.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE, transactionPacketSize);
-
-            String reqHashSize = configuration.string(DefaultConfSettings.REQUEST_HASH_SIZE);
-            if (StringUtils.isEmpty(reqHashSize)) {
-                reqHashSize = Configuration.TESTNET_REQ_HASH_SIZE;
-            }
-            configuration.put(DefaultConfSettings.REQUEST_HASH_SIZE, reqHashSize);
-
-            String globalSnapshotTime = configuration.string(DefaultConfSettings.SNAPSHOT_TIME);
-            if (StringUtils.isEmpty(globalSnapshotTime)) {
-                globalSnapshotTime = Configuration.TESTNET_GLOBAL_SNAPSHOT_TIME;
-            }
-            configuration.put(DefaultConfSettings.SNAPSHOT_TIME, globalSnapshotTime);
+            setTestnetConfigs(configuration);
         }
 
         // mandatory args
@@ -356,6 +293,73 @@ public class IRI {
         if (vmaxPeers != null) {
             configuration.put(DefaultConfSettings.MAX_PEERS, vmaxPeers);
         }
+    }
+
+    private static void setTestnetConfigs(Configuration configuration) {
+        configuration.put(DefaultConfSettings.TESTNET, "true");
+
+        String dbPath = configuration.string(DefaultConfSettings.DB_PATH);
+        if (StringUtils.isEmpty(dbPath)) {
+            dbPath = Configuration.TESTNETDB;
+        }
+        configuration.put(DefaultConfSettings.DB_PATH.name(), dbPath);
+
+        String dbLog = configuration.string(DefaultConfSettings.DB_LOG_PATH);
+        if (StringUtils.isEmpty(dbLog)) {
+            dbLog = Configuration.TESTNETDB_LOG;
+        }
+        configuration.put(DefaultConfSettings.DB_LOG_PATH.name(), dbLog);
+
+        String coordinator_address = configuration.string(DefaultConfSettings.COORDINATOR);
+        if (StringUtils.isEmpty(coordinator_address)) {
+            coordinator_address = Configuration.TESTNET_COORDINATOR_ADDRESS;
+        }
+        configuration.put(DefaultConfSettings.COORDINATOR, coordinator_address);
+
+        String snapshotFile = configuration.string(DefaultConfSettings.SNAPSHOT_FILE);
+        if (StringUtils.isEmpty(snapshotFile)) {
+            snapshotFile = Configuration.TESTNET_SNAPSHOT_FILE;
+        }
+        configuration.put(DefaultConfSettings.SNAPSHOT_FILE, snapshotFile);
+
+        String milestoneStart = configuration.string(DefaultConfSettings.MILESTONE_START_INDEX);
+        if (StringUtils.isEmpty(milestoneStart)) {
+            milestoneStart = Configuration.TESTNET_MILESTONE_START_INDEX;
+        }
+        configuration.put(DefaultConfSettings.MILESTONE_START_INDEX, milestoneStart);
+
+        //this should always be empty
+        configuration.put(DefaultConfSettings.SNAPSHOT_SIGNATURE_FILE, "");
+
+        String mwm = configuration.string(DefaultConfSettings.MWM);
+        if (StringUtils.isEmpty(mwm)) {
+            mwm = Configuration.TESTNET_MWM;
+        }
+        configuration.put(DefaultConfSettings.MWM, mwm);
+
+        String keysInMilestone = configuration.string(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE);
+        if (StringUtils.isEmpty(keysInMilestone)) {
+            keysInMilestone = Configuration.TESTNET_NUM_KEYS_IN_MILESTONE;
+        }
+        configuration.put(DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE, keysInMilestone);
+
+        String transactionPacketSize = configuration.string(DefaultConfSettings.TRANSACTION_PACKET_SIZE);
+        if (StringUtils.isEmpty(transactionPacketSize)) {
+            transactionPacketSize = Configuration.TESTNET_PACKET_SIZE;
+        }
+        configuration.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE, transactionPacketSize);
+
+        String reqHashSize = configuration.string(DefaultConfSettings.REQUEST_HASH_SIZE);
+        if (StringUtils.isEmpty(reqHashSize)) {
+            reqHashSize = Configuration.TESTNET_REQ_HASH_SIZE;
+        }
+        configuration.put(DefaultConfSettings.REQUEST_HASH_SIZE, reqHashSize);
+
+        String globalSnapshotTime = configuration.string(DefaultConfSettings.SNAPSHOT_TIME);
+        if (StringUtils.isEmpty(globalSnapshotTime)) {
+            globalSnapshotTime = Configuration.TESTNET_GLOBAL_SNAPSHOT_TIME;
+        }
+        configuration.put(DefaultConfSettings.SNAPSHOT_TIME, globalSnapshotTime);
     }
 
     private static void printUsage() {

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -48,6 +48,8 @@ public class Configuration {
     public static final String TESTNET_PACKET_SIZE = "1653";
     public static final String REQ_HASH_SIZE = "46";
     public static final String TESTNET_REQ_HASH_SIZE = "49";
+    public static final String TESTNETDB = "testnetdb";
+    public static final String TESTNETDB_LOG = "testnetdb.log";
 
 
 


### PR DESCRIPTION

<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

In order to run private testnets it is useful to be able to control the db folder.
The `--testnet` flag has overriden user configs from ini file and disabled this option.

So a flag for a custom folder was added AND the overriding behavior of the ini is now gone.

# Fixes
https://iotaledger.atlassian.net/browse/IRI-25

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

IRI was ran with flag and modified ini file.


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes