### PR TITLE
IRI-329 ⁃ `readPreviousEpochsSpentAddresses` should only run on mainnet

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -110,7 +110,7 @@ public class API {
     }
 
     public void init() throws IOException {
-        readPreviousEpochsSpentAddresses(instance.configuration.booling(DefaultConfSettings.TESTNET));
+        readPreviousEpochsSpentAddresses(testNet);
 
         final int apiPort = instance.configuration.integer(DefaultConfSettings.PORT);
         final String apiHost = instance.configuration.string(DefaultConfSettings.API_HOST);

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -110,7 +110,7 @@ public class API {
     }
 
     public void init() throws IOException {
-        readPreviousEpochsSpentAddresses();
+        readPreviousEpochsSpentAddresses(instance.configuration.booling(DefaultConfSettings.TESTNET));
 
         final int apiPort = instance.configuration.integer(DefaultConfSettings.PORT);
         final String apiHost = instance.configuration.string(DefaultConfSettings.API_HOST);
@@ -145,14 +145,18 @@ public class API {
         server.start();
     }
 
-    private void readPreviousEpochsSpentAddresses() {
+    private void readPreviousEpochsSpentAddresses(boolean isTestnet) {
+        if (isTestnet) {
+            return;
+        }
+
         if (!SignedFiles.isFileSignatureValid(Configuration.PREVIOUS_EPOCHS_SPENT_ADDRESSES_TXT,
                 Configuration.PREVIOUS_EPOCH_SPENT_ADDRESSES_SIG,
                 Snapshot.SNAPSHOT_PUBKEY, Snapshot.SNAPSHOT_PUBKEY_DEPTH, Snapshot.SPENT_ADDRESSES_INDEX)) {
             throw new RuntimeException("Failed to load previousEpochsSpentAddresses - signature failed.");
         }
 
-        InputStream in = Snapshot.class.getResourceAsStream("/previousEpochsSpentAddresses.txt");
+        InputStream in = Snapshot.class.getResourceAsStream(Configuration.PREVIOUS_EPOCHS_SPENT_ADDRESSES_TXT);
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
         String line;
         try {


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

When creating private testnets we don't want to read the previous spent addresses file from the mainnet.
So when we are in testnet mode `previousEpochsSpentAddresses.txt` file is ignored.

Fixes https://iotaledger.atlassian.net/browse/IRI-26

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

IRI was ran with `--testnet` flag. The file was skipped.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes