### PR TITLE
fix TRANSACTION_PACKET_SIZE assignment to TCP replicators

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -65,7 +65,7 @@ public class Iota {
         int numKeysMilestone = configuration.integer(Configuration.DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE);
         boolean dontValidateMilestoneSig = configuration.booling(Configuration.DefaultConfSettings
                 .DONT_VALIDATE_TESTNET_MILESTONE_SIG);
-        int reqHashSize = configuration.integer(Configuration.DefaultConfSettings.REQUEST_HASH_SIZE);
+        int transactionPacketSize = configuration.integer(Configuration.DefaultConfSettings.TRANSACTION_PACKET_SIZE);
 
         maxTipSearchDepth = configuration.integer(Configuration.DefaultConfSettings.MAX_DEPTH);
         if(testnet) {
@@ -93,7 +93,7 @@ public class Iota {
         milestone = new Milestone(tangle, coordinator, initialSnapshot, transactionValidator, testnet, messageQ,
                 numKeysMilestone, milestoneStartIndex, dontValidateMilestoneSig);
         node = new Node(configuration, tangle, transactionValidator, transactionRequester, tipsViewModel, milestone, messageQ);
-        replicator = new Replicator(node, tcpPort, maxPeers, testnet, reqHashSize);
+        replicator = new Replicator(node, tcpPort, maxPeers, testnet, transactionPacketSize);
         udpReceiver = new UDPReceiver(udpPort, node, configuration.integer(Configuration.DefaultConfSettings.TRANSACTION_PACKET_SIZE));
         ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
         tipsManager = new TipsManager(tangle, ledgerValidator, transactionValidator, tipsViewModel, milestone,

--- a/src/main/java/com/iota/iri/network/replicator/Replicator.java
+++ b/src/main/java/com/iota/iri/network/replicator/Replicator.java
@@ -13,9 +13,9 @@ public class Replicator {
     private final int port;
     private ReplicatorSourcePool replicatorSourcePool;
 
-    public Replicator(final Node node, int port, final int maxPeers, final boolean testnet, int reqHashSize) {
+    public Replicator(final Node node, int port, final int maxPeers, final boolean testnet, int transactionPacketSize) {
         this.port = port;
-        replicatorSinkPool = new ReplicatorSinkPool(node, port, reqHashSize);
+        replicatorSinkPool = new ReplicatorSinkPool(node, port, transactionPacketSize);
         replicatorSourcePool = new ReplicatorSourcePool(replicatorSinkPool, node, maxPeers, testnet);
     }
 

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkPool.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkPool.java
@@ -18,7 +18,7 @@ public class ReplicatorSinkPool  implements Runnable {
     
     private static final Logger log = LoggerFactory.getLogger(ReplicatorSinkPool.class);
     private final int port;
-    private int reqHashSize;
+    private int transactionPacketSize;
     private final Node node;
 
     private ExecutorService sinkPool;
@@ -27,10 +27,10 @@ public class ReplicatorSinkPool  implements Runnable {
 
     public final static int PORT_BYTES = 10;
 
-    public ReplicatorSinkPool(Node node, int port, int reqHashSize) {
+    public ReplicatorSinkPool(Node node, int port, int transactionPacketSize) {
         this.node = node;
         this.port = port;
-        this.reqHashSize = reqHashSize;
+        this.transactionPacketSize = transactionPacketSize;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class ReplicatorSinkPool  implements Runnable {
     }
     
     public void createSink(TCPNeighbor neighbor) {
-        Runnable proc = new ReplicatorSinkProcessor( neighbor, this, port, reqHashSize);
+        Runnable proc = new ReplicatorSinkProcessor( neighbor, this, port, transactionPacketSize);
         sinkPool.submit(proc);
     }
     

--- a/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkProcessor.java
+++ b/src/main/java/com/iota/iri/network/replicator/ReplicatorSinkProcessor.java
@@ -11,8 +11,6 @@ import com.iota.iri.network.TCPNeighbor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.iota.iri.network.Node;
-
 class ReplicatorSinkProcessor implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorSinkProcessor.class);
@@ -22,15 +20,15 @@ class ReplicatorSinkProcessor implements Runnable {
     public final static int CRC32_BYTES = 16;
     private final ReplicatorSinkPool replicatorSinkPool;
     private final int port;
-    private int reqHashSize;
+    private int transactionPacketSize;
 
     public ReplicatorSinkProcessor(final TCPNeighbor neighbor,
                                    final ReplicatorSinkPool replicatorSinkPool,
-                                   final int port, int reqHashSize) {
+                                   final int port, int transactionPacketSize) {
         this.neighbor = neighbor;
         this.replicatorSinkPool = replicatorSinkPool;
         this.port = port;
-        this.reqHashSize = reqHashSize;
+        this.transactionPacketSize = transactionPacketSize;
     }
 
     @Override
@@ -89,7 +87,7 @@ class ReplicatorSinkProcessor implements Runnable {
                                     
                                         byte[] bytes = message.array();
 
-                                        if (bytes.length == reqHashSize) {
+                                        if (bytes.length == transactionPacketSize) {
                                             try {
                                                 CRC32 crc32 = new CRC32();                                        
                                                 crc32.update(message.array());


### PR DESCRIPTION
# Description

This fixes a regression in #610 - `TRANSACTION_PACKET_SIZE` was replaced by `REQUEST_HASH_SIZE` in TCP replicators.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- used git bisect to find where TCP stopped working
- tested syncing a local node with and without the fix.