### PR TITLE
Pearl driver optimal threading

### DIFF
--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -1,8 +1,6 @@
 package com.iota.iri.hash;
 
-import static com.iota.iri.hash.PearlDiver.State.CANCELLED;
-import static com.iota.iri.hash.PearlDiver.State.COMPLETED;
-import static com.iota.iri.hash.PearlDiver.State.RUNNING;
+import static com.iota.iri.hash.PearlDiver.State.*;
 
 /**
  * (c) 2016 Come-from-Beyond
@@ -34,7 +32,7 @@ public class PearlDiver {
     }
 
     public synchronized boolean search(final int[] transactionTrits, final int minWeightMagnitude,
-        int numberOfThreads) {
+                                       int numberOfThreads) {
 
         if (transactionTrits.length != TRANSACTION_LENGTH) {
             throw new RuntimeException(
@@ -95,14 +93,16 @@ public class PearlDiver {
                         midCurlStateLow[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
                         midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
 
-                    } break;
+                    }
+                    break;
 
                     case 1: {
 
                         midCurlStateLow[i] = 0b0000000000000000000000000000000000000000000000000000000000000000L;
                         midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
 
-                    } break;
+                    }
+                    break;
 
                     default: {
 
@@ -139,7 +139,7 @@ public class PearlDiver {
                 System.arraycopy(midCurlStateHigh, 0, midCurlStateCopyHigh, 0, CURL_STATE_LENGTH);
                 for (int i = threadIndex; i-- > 0; ) {
                     increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + CURL_HASH_LENGTH / 9,
-                            162 + (CURL_HASH_LENGTH / 9) * 2);
+                        162 + (CURL_HASH_LENGTH / 9) * 2);
 
                 }
 
@@ -149,7 +149,7 @@ public class PearlDiver {
                 while (state == RUNNING) {
 
                     increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + (CURL_HASH_LENGTH / 9) * 2,
-                            CURL_HASH_LENGTH);
+                        CURL_HASH_LENGTH);
 
                     System.arraycopy(midCurlStateCopyLow, 0, curlStateLow, 0, CURL_STATE_LENGTH);
                     System.arraycopy(midCurlStateCopyHigh, 0, curlStateHigh, 0, CURL_STATE_LENGTH);
@@ -214,7 +214,7 @@ public class PearlDiver {
     }
 
     private static void transform(final long[] curlStateLow, final long[] curlStateHigh,
-        final long[] curlScratchpadLow, final long[] curlScratchpadHigh) {
+                                  final long[] curlScratchpadLow, final long[] curlScratchpadHigh) {
 
         int curlScratchpadIndex = 0;
         for (int round = 0; round < Curl.NUMBER_OF_ROUNDSP81; round++) {
@@ -239,7 +239,7 @@ public class PearlDiver {
     }
 
     private static void increment(final long[] midCurlStateCopyLow,
-        final long[] midCurlStateCopyHigh, final int fromIndex, final int toIndex) {
+                                  final long[] midCurlStateCopyHigh, final int fromIndex, final int toIndex) {
 
         for (int i = fromIndex; i < toIndex; i++) {
             if (midCurlStateCopyLow[i] == LOW_BITS) {

--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -1,10 +1,10 @@
 package com.iota.iri.hash;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.iota.iri.hash.PearlDiver.State.*;
 
-/**
- * (c) 2016 Come-from-Beyond
- */
 public class PearlDiver {
 
     enum State {
@@ -27,13 +27,10 @@ public class PearlDiver {
     public void cancel() {
         synchronized (syncObj) {
             state = CANCELLED;
-            syncObj.notifyAll();
         }
     }
 
-    public synchronized boolean search(final int[] transactionTrits, final int minWeightMagnitude,
-                                       int numberOfThreads) {
-
+    private static void validateParameters(int[] transactionTrits, int minWeightMagnitude) {
         if (transactionTrits.length != TRANSACTION_LENGTH) {
             throw new RuntimeException(
                 "Invalid transaction trits length: " + transactionTrits.length);
@@ -41,187 +38,162 @@ public class PearlDiver {
         if (minWeightMagnitude < 0 || minWeightMagnitude > CURL_HASH_LENGTH) {
             throw new RuntimeException("Invalid min weight magnitude: " + minWeightMagnitude);
         }
+    }
 
+    public synchronized boolean search(final int[] transactionTrits, final int minWeightMagnitude,
+                                       int numberOfThreads) {
+
+        validateParameters(transactionTrits, minWeightMagnitude);
         synchronized (syncObj) {
             state = RUNNING;
         }
 
-        final long[] midCurlStateLow = new long[CURL_STATE_LENGTH], midCurlStateHigh = new long[CURL_STATE_LENGTH];
-
-        {
-            for (int i = CURL_HASH_LENGTH; i < CURL_STATE_LENGTH; i++) {
-                midCurlStateLow[i] = HIGH_BITS;
-                midCurlStateHigh[i] = HIGH_BITS;
-            }
-
-            int offset = 0;
-            final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH], curlScratchpadHigh = new long[CURL_STATE_LENGTH];
-            for (int i = (TRANSACTION_LENGTH - CURL_HASH_LENGTH) / CURL_HASH_LENGTH; i-- > 0; ) {
-
-                for (int j = 0; j < CURL_HASH_LENGTH; j++) {
-
-                    switch (transactionTrits[offset++]) {
-                        case 0: {
-                            midCurlStateLow[j] = HIGH_BITS;
-                            midCurlStateHigh[j] = HIGH_BITS;
-
-                        }
-                        break;
-
-                        case 1: {
-                            midCurlStateLow[j] = LOW_BITS;
-                            midCurlStateHigh[j] = HIGH_BITS;
-                        }
-                        break;
-
-                        default: {
-                            midCurlStateLow[j] = HIGH_BITS;
-                            midCurlStateHigh[j] = LOW_BITS;
-                        }
-                    }
-                }
-
-                transform(midCurlStateLow, midCurlStateHigh, curlScratchpadLow, curlScratchpadHigh);
-            }
-
-            for (int i = 0; i < 162; i++) {
-
-                switch (transactionTrits[offset++]) {
-
-                    case 0: {
-
-                        midCurlStateLow[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-                        midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-
-                    }
-                    break;
-
-                    case 1: {
-
-                        midCurlStateLow[i] = 0b0000000000000000000000000000000000000000000000000000000000000000L;
-                        midCurlStateHigh[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-
-                    }
-                    break;
-
-                    default: {
-
-                        midCurlStateLow[i] = 0b1111111111111111111111111111111111111111111111111111111111111111L;
-                        midCurlStateHigh[i] = 0b0000000000000000000000000000000000000000000000000000000000000000L;
-                    }
-                }
-            }
-
-            midCurlStateLow[162 + 0] = 0b1101101101101101101101101101101101101101101101101101101101101101L;
-            midCurlStateHigh[162 + 0] = 0b1011011011011011011011011011011011011011011011011011011011011011L;
-            midCurlStateLow[162 + 1] = 0b1111000111111000111111000111111000111111000111111000111111000111L;
-            midCurlStateHigh[162 + 1] = 0b1000111111000111111000111111000111111000111111000111111000111111L;
-            midCurlStateLow[162 + 2] = 0b0111111111111111111000000000111111111111111111000000000111111111L;
-            midCurlStateHigh[162 + 2] = 0b1111111111000000000111111111111111111000000000111111111111111111L;
-            midCurlStateLow[162 + 3] = 0b1111111111000000000000000000000000000111111111111111111111111111L;
-            midCurlStateHigh[162 + 3] = 0b0000000000111111111111111111111111111111111111111111111111111111L;
-
-        }
+        final long[] midCurlStateLow = new long[CURL_STATE_LENGTH];
+        final long[] midCurlStateHigh = new long[CURL_STATE_LENGTH];
+        initializeMidCurlStates(transactionTrits, midCurlStateLow, midCurlStateHigh);
 
         if (numberOfThreads <= 0) {
-            numberOfThreads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
+            numberOfThreads = Math.max(1, Math.floorDiv(numberOfThreads * 8, 10));
         }
-
-        Thread[] workers = new Thread[numberOfThreads];
-
+        List<Thread> workers = new ArrayList<>(numberOfThreads);
         while (numberOfThreads-- > 0) {
-
-            final int threadIndex = numberOfThreads;
-            Thread worker = (new Thread(() -> {
-
-                final long[] midCurlStateCopyLow = new long[CURL_STATE_LENGTH], midCurlStateCopyHigh = new long[CURL_STATE_LENGTH];
-                System.arraycopy(midCurlStateLow, 0, midCurlStateCopyLow, 0, CURL_STATE_LENGTH);
-                System.arraycopy(midCurlStateHigh, 0, midCurlStateCopyHigh, 0, CURL_STATE_LENGTH);
-                for (int i = threadIndex; i-- > 0; ) {
-                    increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + CURL_HASH_LENGTH / 9,
-                        162 + (CURL_HASH_LENGTH / 9) * 2);
-
-                }
-
-                final long[] curlStateLow = new long[CURL_STATE_LENGTH], curlStateHigh = new long[CURL_STATE_LENGTH];
-                final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH], curlScratchpadHigh = new long[CURL_STATE_LENGTH];
-                long mask, outMask = 1;
-                while (state == RUNNING) {
-
-                    increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + (CURL_HASH_LENGTH / 9) * 2,
-                        CURL_HASH_LENGTH);
-
-                    System.arraycopy(midCurlStateCopyLow, 0, curlStateLow, 0, CURL_STATE_LENGTH);
-                    System.arraycopy(midCurlStateCopyHigh, 0, curlStateHigh, 0, CURL_STATE_LENGTH);
-                    transform(curlStateLow, curlStateHigh, curlScratchpadLow, curlScratchpadHigh);
-
-                    mask = HIGH_BITS;
-                    for (int i = minWeightMagnitude; i-- > 0; ) {
-                        mask &= ~(curlStateLow[CURL_HASH_LENGTH - 1 - i] ^ curlStateHigh[
-                            CURL_HASH_LENGTH - 1 - i]);
-                        if (mask == 0) {
-                            break;
-                        }
-                    }
-                    if (mask == 0) {
-                        continue;
-                    }
-
-                    synchronized (syncObj) {
-                        if (state == RUNNING) {
-                            state = COMPLETED;
-                            while ((outMask & mask) == 0) {
-                                outMask <<= 1;
-                            }
-                            for (int i = 0; i < CURL_HASH_LENGTH; i++) {
-                                transactionTrits[TRANSACTION_LENGTH - CURL_HASH_LENGTH + i] =
-                                    (midCurlStateCopyLow[i] & outMask) == 0 ? 1
-                                        : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
-                            }
-                            syncObj.notifyAll();
-                        }
-                    }
-                    break;
-                }
-            }));
-            workers[threadIndex] = worker;
+            Runnable runnable = getRunnable(transactionTrits, minWeightMagnitude, midCurlStateLow, midCurlStateHigh, numberOfThreads);
+            Thread worker = new Thread(runnable);
+            workers.add(worker);
+            worker.setName(this + ":worker-" + numberOfThreads);
+            worker.setDaemon(true);
             worker.start();
         }
-
-        try {
-            synchronized (syncObj) {
-                if (state == RUNNING) {
-                    syncObj.wait();
-                }
-            }
-        } catch (final InterruptedException e) {
-            synchronized (syncObj) {
-                state = CANCELLED;
-            }
-        }
-
         for (Thread worker : workers) {
             try {
                 worker.join();
-            } catch (final InterruptedException e) {
+            } catch (InterruptedException e) {
                 synchronized (syncObj) {
                     state = CANCELLED;
                 }
             }
         }
-
         return state == COMPLETED;
+    }
+
+    private Runnable getRunnable(int[] transactionTrits, int minWeightMagnitude, long[] midCurlStateLow, long[] midCurlStateHigh, int threadIndex) {
+        return () -> {
+            final long[] midCurlStateCopyLow = new long[CURL_STATE_LENGTH];
+            final long[] midCurlStateCopyHigh = new long[CURL_STATE_LENGTH];
+            copy(midCurlStateLow, midCurlStateHigh, midCurlStateCopyLow, midCurlStateCopyHigh);
+
+            for (int i = 0; i < threadIndex; i++) {
+                increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + CURL_HASH_LENGTH / 9,
+                    162 + (CURL_HASH_LENGTH / 9) * 2);
+            }
+
+            final long[] curlStateLow = new long[CURL_STATE_LENGTH];
+            final long[] curlStateHigh = new long[CURL_STATE_LENGTH];
+
+            final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH];
+            final long[] curlScratchpadHigh = new long[CURL_STATE_LENGTH];
+
+            final int maskStartIndex = CURL_HASH_LENGTH - minWeightMagnitude;
+            long mask = 0;
+            while (state == RUNNING && mask == 0) {
+
+                increment(midCurlStateCopyLow, midCurlStateCopyHigh, 162 + (CURL_HASH_LENGTH / 9) * 2,
+                    CURL_HASH_LENGTH);
+
+                copy(midCurlStateCopyLow, midCurlStateCopyHigh, curlStateLow, curlStateHigh);
+                transform(curlStateLow, curlStateHigh, curlScratchpadLow, curlScratchpadHigh);
+
+                mask = HIGH_BITS;
+                for (int i = maskStartIndex; i < CURL_HASH_LENGTH && mask != 0; i++) {
+                    mask &= ~(curlStateLow[i] ^ curlStateHigh[i]);
+                }
+            }
+            if (mask != 0) {
+                synchronized (syncObj) {
+                    if (state == RUNNING) {
+                        state = COMPLETED;
+                        long outMask = 1;
+                        while ((outMask & mask) == 0) {
+                            outMask <<= 1;
+                        }
+                        for (int i = 0; i < CURL_HASH_LENGTH; i++) {
+                            transactionTrits[TRANSACTION_LENGTH - CURL_HASH_LENGTH + i] =
+                                (midCurlStateCopyLow[i] & outMask) == 0 ? 1
+                                    : (midCurlStateCopyHigh[i] & outMask) == 0 ? -1 : 0;
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private static void copy(long[] srcLow, long[] srcHigh, long[] destLow, long[] destHigh) {
+        System.arraycopy(srcLow, 0, destLow, 0, CURL_STATE_LENGTH);
+        System.arraycopy(srcHigh, 0, destHigh, 0, CURL_STATE_LENGTH);
+    }
+
+    private static void initializeMidCurlStates(int[] transactionTrits, long[] midCurlStateLow, long[] midCurlStateHigh) {
+        for (int i = CURL_HASH_LENGTH; i < CURL_STATE_LENGTH; i++) {
+            midCurlStateLow[i] = HIGH_BITS;
+            midCurlStateHigh[i] = HIGH_BITS;
+        }
+
+        int offset = 0;
+        final long[] curlScratchpadLow = new long[CURL_STATE_LENGTH];
+        final long[] curlScratchpadHigh = new long[CURL_STATE_LENGTH];
+        for (int i = (TRANSACTION_LENGTH - CURL_HASH_LENGTH) / CURL_HASH_LENGTH; i-- > 0; ) {
+
+            for (int j = 0; j < CURL_HASH_LENGTH; j++) {
+                switch (transactionTrits[offset++]) {
+                    case 0:
+                        midCurlStateLow[j] = HIGH_BITS;
+                        midCurlStateHigh[j] = HIGH_BITS;
+                        break;
+                    case 1:
+                        midCurlStateLow[j] = LOW_BITS;
+                        midCurlStateHigh[j] = HIGH_BITS;
+                        break;
+                    default:
+                        midCurlStateLow[j] = HIGH_BITS;
+                        midCurlStateHigh[j] = LOW_BITS;
+                }
+            }
+            transform(midCurlStateLow, midCurlStateHigh, curlScratchpadLow, curlScratchpadHigh);
+        }
+
+        for (int i = 0; i < 162; i++) {
+            switch (transactionTrits[offset++]) {
+                case 0:
+                    midCurlStateLow[i] = HIGH_BITS;
+                    midCurlStateHigh[i] = HIGH_BITS;
+                    break;
+                case 1:
+                    midCurlStateLow[i] = LOW_BITS;
+                    midCurlStateHigh[i] = HIGH_BITS;
+                    break;
+                default:
+                    midCurlStateLow[i] = HIGH_BITS;
+                    midCurlStateHigh[i] = LOW_BITS;
+            }
+        }
+
+        midCurlStateLow[162 + 0] = 0b1101101101101101101101101101101101101101101101101101101101101101L;
+        midCurlStateHigh[162 + 0] = 0b1011011011011011011011011011011011011011011011011011011011011011L;
+        midCurlStateLow[162 + 1] = 0b1111000111111000111111000111111000111111000111111000111111000111L;
+        midCurlStateHigh[162 + 1] = 0b1000111111000111111000111111000111111000111111000111111000111111L;
+        midCurlStateLow[162 + 2] = 0b0111111111111111111000000000111111111111111111000000000111111111L;
+        midCurlStateHigh[162 + 2] = 0b1111111111000000000111111111111111111000000000111111111111111111L;
+        midCurlStateLow[162 + 3] = 0b1111111111000000000000000000000000000111111111111111111111111111L;
+        midCurlStateHigh[162 + 3] = 0b0000000000111111111111111111111111111111111111111111111111111111L;
     }
 
     private static void transform(final long[] curlStateLow, final long[] curlStateHigh,
                                   final long[] curlScratchpadLow, final long[] curlScratchpadHigh) {
 
-        int curlScratchpadIndex = 0;
         for (int round = 0; round < Curl.NUMBER_OF_ROUNDSP81; round++) {
-            System.arraycopy(curlStateLow, 0, curlScratchpadLow, 0, CURL_STATE_LENGTH);
-            System.arraycopy(curlStateHigh, 0, curlScratchpadHigh, 0, CURL_STATE_LENGTH);
+            copy(curlStateLow, curlStateHigh, curlScratchpadLow, curlScratchpadHigh);
 
-            for (int curlStateIndex = 0; curlStateIndex < CURL_STATE_LENGTH; curlStateIndex++) {
+            for (int curlStateIndex = 0, curlScratchpadIndex = 0; curlStateIndex < CURL_STATE_LENGTH; curlStateIndex++) {
                 final long alpha = curlScratchpadLow[curlScratchpadIndex];
                 final long beta = curlScratchpadHigh[curlScratchpadIndex];
                 if (curlScratchpadIndex < 365) {
@@ -238,19 +210,18 @@ public class PearlDiver {
         }
     }
 
-    private static void increment(final long[] midCurlStateCopyLow,
-                                  final long[] midCurlStateCopyHigh, final int fromIndex, final int toIndex) {
+    private static void increment(final long[] midCurlStateCopyLow, final long[] midCurlStateCopyHigh,
+                                  final int fromIndex, final int toIndex) {
 
         for (int i = fromIndex; i < toIndex; i++) {
             if (midCurlStateCopyLow[i] == LOW_BITS) {
                 midCurlStateCopyLow[i] = HIGH_BITS;
                 midCurlStateCopyHigh[i] = LOW_BITS;
+            } else if (midCurlStateCopyHigh[i] == LOW_BITS) {
+                midCurlStateCopyHigh[i] = HIGH_BITS;
+                break;
             } else {
-                if (midCurlStateCopyHigh[i] == LOW_BITS) {
-                    midCurlStateCopyHigh[i] = HIGH_BITS;
-                } else {
-                    midCurlStateCopyLow[i] = LOW_BITS;
-                }
+                midCurlStateCopyLow[i] = LOW_BITS;
                 break;
             }
         }


### PR DESCRIPTION
See https://github.com/iotaledger/iri/issues/732

(0) Changed
OLD  `numberOfThreads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1)`
NEW `numberOfThreads = Math.max(1, Math.min(6, numberOfThreads - 1))` 
(as per charted performance over many thread counts.)

(1) Removed unnecessary wait conditions and notifyAll: Thread.join will automatically return since CANCELLED will terminate all loops and end all workers.

(2) Removed unnecessary sync on RUNNING at start.

(3) moved some same-line variable declarations to newlines for clarity.

(4) Removed unnecessary code blocks in Switch statements.

(5) Subbed in HIGHBITS and LOWBITS in second switch statement (consistent with first switch statement)

(6) Line 162 (old) 152 (new), put mask condition in WHILE condition instead of floating at end of logic.
... And moved COMPLETED stage to outside of loop.

(7) Set worker threads to daemon status (self terminates on VM exit) and added names to them for monitoring.
