### PR TITLE
ZMQ: Send transaction hash with trytes

### DIFF
--- a/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
+++ b/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
@@ -95,7 +95,8 @@ public class ZmqPublishProvider implements PersistenceProvider {
 
         try {
             txTrytesStringBuilder.append("tx_trytes ");
-            txTrytesStringBuilder.append(Converter.trytes(transactionViewModel.trits()));
+            txTrytesStringBuilder.append(Converter.trytes(transactionViewModel.trits())); txTrytesStringBuilder.append(" ");
+            txTrytesStringBuilder.append(transactionViewModel.getHash());
 
             messageQ.publish(txTrytesStringBuilder.toString());
         } catch (Exception e) {


### PR DESCRIPTION
# Description

(Re)Calculating the transaction hash can be slow for the app using the ZMQ topic `tx_trytes`, I propose to add it in the ZMQ message.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Custom JS script subscribing to ZMQ topic `tx_trytes`

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
