### PR TITLE
Allow IXI Modules to dictate response's content-type.

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1201,7 +1201,7 @@ public class API {
         final HeaderMap headerMap = exchange.getResponseHeaders();
         headerMap.add(new HttpString("Access-Control-Allow-Origin"),"*");
         headerMap.add(new HttpString("Keep-Alive"), "timeout=500, max=100");
-        headerMap.put(Headers.CONTENT_TYPE, getResponseContentType(response));
+        headerMap.put(Headers.CONTENT_TYPE, getResponseContentType(res));
     }
 
     private String getResponseContentType(AbstractResponse response) {

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1204,7 +1204,7 @@ public class API {
         headerMap.put(Headers.CONTENT_TYPE, getResponseContentType(res));
     }
 
-    private String getResponseContentType(AbstractResponse response) {
+    private static String getResponseContentType(AbstractResponse response) {
         if(response instanceof IXIResponse){
             return ((IXIResponse)response).getResponseContentType();
         }

--- a/src/main/java/com/iota/iri/service/dto/IXIResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/IXIResponse.java
@@ -1,5 +1,7 @@
 package com.iota.iri.service.dto;
 
+import java.util.Map;
+
 /**
  * Created by paul on 2/10/17.
  */
@@ -15,4 +17,24 @@ public class IXIResponse extends AbstractResponse {
     public Object getResponse() {
         return ixi;
     }
+
+    private String getdefaultContentType() {
+        return "application/json";
+    }
+
+    public String getResponseContentType() {
+        Object fieldObj = getResponseMapper().get("contentType");
+        String fieldValue = fieldObj == null || fieldObj == "" ? getdefaultContentType() : fieldObj.toString();
+        return fieldValue;
+    }
+
+    private Map<String, Object> getResponseMapper(){
+        return (Map<String, Object>)ixi;
+    }
+
+    public String getContent() {
+        Object fieldObj = getResponseMapper().get("content");
+        String fieldValue = fieldObj == null || fieldObj == "" ? null : fieldObj.toString();
+        return fieldValue;
+	}
 }


### PR DESCRIPTION
# Description

This PR allows IXI Modules to decide the content-type they wish to send to the client. The idea is that clients might want, for example, load web content directly on their browser, or get data in XML format, images, or whatever the IXI module serves.

This PR was created for issue https://github.com/iotaledger/iri/issues/615

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
