### PR TITLE
[urgent bug fix] PearlDiver - Inserted check for number of available processors.

### DIFF
--- a/src/main/java/com/iota/iri/hash/PearlDiver.java
+++ b/src/main/java/com/iota/iri/hash/PearlDiver.java
@@ -53,7 +53,8 @@ public class PearlDiver {
         initializeMidCurlStates(transactionTrits, midStateLow, midStateHigh);
 
         if (numberOfThreads <= 0) {
-            numberOfThreads = Math.max(1, Math.floorDiv(numberOfThreads * 8, 10));
+            int available = Runtime.getRuntime().availableProcessors();
+            numberOfThreads = Math.max(1, Math.floorDiv(available * 8, 10));
         }
         List<Thread> workers = new ArrayList<>(numberOfThreads);
         while (numberOfThreads-- > 0) {


### PR DESCRIPTION
BUG FIX
```
int available = Runtime.getRuntime().availableProcessors();
numberOfThreads = Math.max(1, Math.floorDiv(available * 8, 10));
```