### PR TITLE
Remove trailing space in getBalances tips body param

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -255,7 +255,7 @@ public class API {
                 case "getBalances": {
                     final List<String> addresses = getParameterAsList(request,"addresses", HASH_SIZE);
                     final List<String> tips = request.containsKey("tips") ?
-                            getParameterAsList(request,"tips ", HASH_SIZE):
+                            getParameterAsList(request,"tips", HASH_SIZE):
                             null;
                     final int threshold = getParameterAsInt(request, "threshold");
                     return getBalancesStatement(addresses, tips, threshold);
@@ -1177,4 +1177,3 @@ public class API {
         broadcastTransactionStatement(powResult);
     }
 }
-


### PR DESCRIPTION
# Description

tips body param of getBalances is unusable due to a trailing space.

Fixes #768 

# Type of change

Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Integration test with the IOTA C++ Library.

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
