### PR TITLE
fix MAX_TIMESTAMP_VALUE to actually represent "max positive 27-trits value"

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -74,7 +74,7 @@ public class API {
     private final static int HASH_SIZE = 81;
     private final static int TRYTES_SIZE = 2673;
 
-    private final static long MAX_TIMESTAMP_VALUE = (3^27 - 1) / 2;
+    private final static long MAX_TIMESTAMP_VALUE = (long) (Math.pow(3, 27) - 1) / 2; // max positive 27-trits value
 
     private final int minRandomWalks;
     private final int maxRandomWalks;


### PR DESCRIPTION
# Description

fix MAX_TIMESTAMP_VALUE to actually represent "max positive 27-trits value"

Fixes #531 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually checking the value of this field in the Debugger,
testing conversion of `3812798742493` to trytes: `MMMMMMMMM` (thanks to https://laurencetennant.com/iota-tools/)