### PR TITLE
download testnet Db files from S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ script:
   - git clone https://github.com/iotaledger/iri-regression-tests.git
   - cd iri-regression-tests
   - git checkout -f master
+  - curl -LO https://s3.eu-central-1.amazonaws.com/iotaledger-dbfiles/dev/testnet_files.tgz
+  - tar -xzf testnet_files.tgz
   - mkdir iri
   - cp -rf ../target iri/target
   - bash run_all_stable_tests.sh $VERSION


### PR DESCRIPTION
# Description

Testnet db files are now in an S3 bucket and should be removed from the github repo.
 
Fixes #647 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Travis test passed


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
