### PR TITLE
tip selection: set default alpha value to 0.001

### DIFF
--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -169,7 +169,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE.name(), PACKET_SIZE);
         conf.put(DefaultConfSettings.REQUEST_HASH_SIZE.name(), REQ_HASH_SIZE);
         conf.put(DefaultConfSettings.SNAPSHOT_TIME.name(), GLOBAL_SNAPSHOT_TIME);
-        conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.1");
+        conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.001");
 
     }
 


### PR DESCRIPTION
# Description
This PR sets the default alpha value for the random walk to `0.001`,
in order for slower but honest users to still have a good chance of getting their transactions confirmed.

This value is based on both:
1. an analytical calculation of the probability of a transaction with slower PoW time `H ~= 5mins` to still get confirmed (assuming a constant `lambda = 10 TPS` and `H >> h`).

2. validation (of calculation) by running a private testnet (w/ 12TPS spam) where slower transactions were issued and confirmation rates were measured.

Fixes #801 

## Type of change
- Parameter tuning

# How Has This Been Tested?

see Description

# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
