### PR TITLE
print sha256sums of jar files in travis logs - for manual releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ script:
   - cp -rf ../target iri/target
   - bash run_all_stable_tests.sh $VERSION
   - cd ..
+  #print sha256sums of jar files - for manual releases
+  - cd target
+  - sha256sum *.jar*
+  - cd ..
 
 after_success:
   #codacy-coverage send report. Uses Travis Env variable (CODACY_PROJECT_TOKEN)


### PR DESCRIPTION
# Description

Print sha256sums of jar files in Travis logs - for manual releases
this is needed to track jars generated as part of the release process (JAR files are not deterministic - 2 builds on the same machine will have 2 different digests).

Fixes #268 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Running Travis on my personal repo.
- Travis will also run as part of this PR checks.

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
