### PR TITLE
configure surefire plugin with forkCount to prevent mvn package crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,7 @@
                     <excludes>
                         <exclude>integration/*.java</exclude>
                     </excludes>
+		    <forkCount>0</forkCount>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
I am one of the developers behind `iota.lib.cpp`.

Recently, we started to get some failures on Travis OSX build (image osx 6.4) when building IRI in our testing environment.
While we reported the issue at first on travis side because this bug has been stable for months and it seems that the image does not package the same java version, I happened to buy a new computer recently and encountered the exact same failure.

My java environment is as follows:
```
➜  iri git:(simon-fix-test-crash) ✗ java -version
java version "10.0.2" 2018-07-17
Java(TM) SE Runtime Environment 18.3 (build 10.0.2+13)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.2+13, mixed mode)
```

I'm running on the latest macbook pro 2018 with OSX 10.13.6.

The failure happens when running `mvn package`:

```
➜  iri git:(dev) ✗ mvn package
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------------< com.iota:iri >----------------------------
[INFO] Building IRI 1.5.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-checkstyle-plugin:3.0.0:check (validate) @ iri ---
[INFO] Starting audit...
Audit done.
[INFO]
[INFO] --- jacoco-maven-plugin:0.7.9:prepare-agent (default) @ iri ---
[INFO] argLine set to -javaagent:/Users/simon/.m2/repository/org/jacoco/org.jacoco.agent/0.7.9/org.jacoco.agent-0.7.9-runtime.jar=destfile=/Users/simon/github/iota.lib.cpp/test/testnet/iri/target/jacoco.exec
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ iri ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 8 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ iri ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 109 source files to /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/classes
[WARNING] /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/IXI.java:[28,38] com.sun.jmx.mbeanserver.Util is internal proprietary API and may be removed in a future release
[WARNING] /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/IXI.java:[28,38] com.sun.jmx.mbeanserver.Util is internal proprietary API and may be removed in a future release
[WARNING] /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/IXI.java:[28,38] com.sun.jmx.mbeanserver.Util is internal proprietary API and may be removed in a future release
[INFO] /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java: /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java uses or overrides a deprecated API.
[INFO] /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java: Recompile with -Xlint:deprecation for details.
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ iri ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/simon/github/iota.lib.cpp/test/testnet/iri/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ iri ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-surefire-plugin:2.21.0:test (default-test) @ iri ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire-reports/2018-07-17T22-52-30_785-jvmRun1.dumpstream
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.567 s
[INFO] Finished at: 2018-07-17T22:52:31-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.21.0:test (default-test) on project iri: There are test failures.
[ERROR]
[ERROR] Please refer to /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/simon/github/iota.lib.cpp/test/testnet/iri && /Library/Java/JavaVirtualMachines/jdk-10.0.2.jdk/Contents/Home/bin/java -javaagent:/Users/simon/.m2/repository/org/jacoco/org.jacoco.agent/0.7.9/org.jacoco.agent-0.7.9-runtime.jar=destfile=/Users/simon/github/iota.lib.cpp/test/testnet/iri/target/jacoco.exec -jar /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire/surefirebooter1802547629303428724.jar /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire 2018-07-17T22-52-30_785-jvmRun1 surefire8784072518338999956tmp surefire_03610224156885187571tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/simon/github/iota.lib.cpp/test/testnet/iri && /Library/Java/JavaVirtualMachines/jdk-10.0.2.jdk/Contents/Home/bin/java -javaagent:/Users/simon/.m2/repository/org/jacoco/org.jacoco.agent/0.7.9/org.jacoco.agent-0.7.9-runtime.jar=destfile=/Users/simon/github/iota.lib.cpp/test/testnet/iri/target/jacoco.exec -jar /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire/surefirebooter1802547629303428724.jar /Users/simon/github/iota.lib.cpp/test/testnet/iri/target/surefire 2018-07-17T22-52-30_785-jvmRun1 surefire8784072518338999956tmp surefire_03610224156885187571tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:671)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:533)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:278)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:244)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1149)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:978)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:854)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:954)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

The change prevents the testing plugin to fork as detailed in [the documentation](https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html).

Similar issues can be found on stackoverflow. FOr example, [here](https://stackoverflow.com/questions/9320620/junit-maven-error-occured-in-starting-fork-check-output-in-log).
Possibly, this may be an issue from the version of the surefire plugin, not sure if it has been updated recently in the pom.xml.

# How Has This Been Tested?

Run `mvn package`.
If necessary, I can setup `iota.lib.cpp` to use this branch to build IRI, such that it got tested on several linux, OSX and windows environments.

# Checklist:

- [x ] I have performed a self-review of my own code
