### PR TITLE
PPA webupd8team bumped Java to 8u181-1~webupd8~1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04 as local_stage_java
 MAINTAINER giorgio@iota.org
 
 # Install Java
-ARG JAVA_VERSION=8u171-1
+ARG JAVA_VERSION=8u181-1
 RUN \
   apt-get update && \
   apt-get install -y software-properties-common --no-install-recommends && \


### PR DESCRIPTION
8u171-1 is not in release anymore and Dockerfile does not build.

Fixes #877 

## Type of change

Bumped JAVA_VERSION to `8u181-1`
