### PR TITLE
Fail early on below max depth - WIP

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -154,8 +154,8 @@ public class IRI {
             final Option<Integer> milestoneStartIndex = parser.addIntegerOption("milestone-start");
             final Option<Integer> milestoneKeys = parser.addIntegerOption("milestone-keys");
             final Option<Long> snapshotTime = parser.addLongOption("snapshot-timestamp");
-            final Option<Integer> belowMaxDepthTxLimit = parser.addIntegerOption("below-max-depth");
-
+            final Option<Integer> belowMaxDepthTxLimit = parser.addIntegerOption("max-depth-tx-limit");
+            final Option<Integer> walkValidatorCacheSize = parser.addIntegerOption("walk-validator-cache");
 
             try {
                 parser.parse(args);
@@ -336,6 +336,11 @@ public class IRI {
             if (belowMaxDepthLimit != null) {
                 configuration.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT,
                         String.valueOf(belowMaxDepthLimit));
+            }
+
+            final Integer walkValidatorCache = parser.getOptionValue(walkValidatorCacheSize);
+            if (walkValidatorCache != null) {
+                configuration.put(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE, String.valueOf(walkValidatorCache));
             }
 
             return true;

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -154,6 +154,7 @@ public class IRI {
             final Option<Integer> milestoneStartIndex = parser.addIntegerOption("milestone-start");
             final Option<Integer> milestoneKeys = parser.addIntegerOption("milestone-keys");
             final Option<Long> snapshotTime = parser.addLongOption("snapshot-timestamp");
+            final Option<Integer> belowMaxDepthTxLimit = parser.addIntegerOption("below-max-depth");
 
 
             try {
@@ -330,7 +331,15 @@ public class IRI {
             if (vmaxPeers != null) {
                 configuration.put(DefaultConfSettings.MAX_PEERS, vmaxPeers);
             }
+
+            final Integer belowMaxDepthLimit = parser.getOptionValue(belowMaxDepthTxLimit);
+            if (belowMaxDepthLimit != null) {
+                configuration.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT,
+                        String.valueOf(belowMaxDepthLimit));
+            }
+
             return true;
+
         }
 
         private static void printUsage() {

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -68,6 +68,7 @@ public class Iota {
         double alpha = configuration.doubling(Configuration.DefaultConfSettings.TIPSELECTION_ALPHA.name());
         int belowMaxDepthTxLimit = configuration.integer(
                 Configuration.DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT);
+        int walkValidatorCacheSize = configuration.integer(Configuration.DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE);
 
         boolean dontValidateMilestoneSig = configuration.booling(Configuration.DefaultConfSettings
                 .DONT_VALIDATE_TESTNET_MILESTONE_SIG);
@@ -103,7 +104,7 @@ public class Iota {
         udpReceiver = new UDPReceiver(udpPort, node, configuration.integer(Configuration.DefaultConfSettings.TRANSACTION_PACKET_SIZE));
         ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
         tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel);
-        tipsSelector = createTipSelector(milestoneStartIndex, alpha, belowMaxDepthTxLimit);
+        tipsSelector = createTipSelector(milestoneStartIndex, alpha, belowMaxDepthTxLimit, walkValidatorCacheSize);
     }
 
     public void init() throws Exception {
@@ -200,12 +201,13 @@ public class Iota {
         }
     }
 
-    private TipSelector createTipSelector(int milestoneStartIndex, double alpha, int belowMaxDepthTxLimit) {
+    private TipSelector createTipSelector(int milestoneStartIndex, double alpha, int belowMaxDepthTxLimit,
+                                          int walkValidatorCacheSize) {
         EntryPointSelector entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, testnet, milestoneStartIndex);
         RatingCalculator ratingCalculator = new CumulativeWeightCalculator(tangle);
         TailFinder tailFinder = new TailFinderImpl(tangle);
         Walker walker = new WalkerAlpha(alpha, new SecureRandom(), tangle, messageQ, tailFinder);
         return new TipSelectorImpl(tangle, ledgerValidator, transactionValidator, entryPointSelector, ratingCalculator,
-                walker, milestone, maxTipSearchDepth, belowMaxDepthTxLimit);
+                walker, milestone, maxTipSearchDepth, belowMaxDepthTxLimit, walkValidatorCacheSize);
     }
 }

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -66,6 +66,8 @@ public class Iota {
         int milestoneStartIndex = configuration.integer(Configuration.DefaultConfSettings.MILESTONE_START_INDEX);
         int numKeysMilestone = configuration.integer(Configuration.DefaultConfSettings.NUMBER_OF_KEYS_IN_A_MILESTONE);
         double alpha = configuration.doubling(Configuration.DefaultConfSettings.TIPSELECTION_ALPHA.name());
+        int belowMaxDepthTxLimit = configuration.integer(
+                Configuration.DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT);
 
         boolean dontValidateMilestoneSig = configuration.booling(Configuration.DefaultConfSettings
                 .DONT_VALIDATE_TESTNET_MILESTONE_SIG);
@@ -101,7 +103,7 @@ public class Iota {
         udpReceiver = new UDPReceiver(udpPort, node, configuration.integer(Configuration.DefaultConfSettings.TRANSACTION_PACKET_SIZE));
         ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
         tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel);
-        tipsSelector = createTipSelector(milestoneStartIndex, alpha);
+        tipsSelector = createTipSelector(milestoneStartIndex, alpha, belowMaxDepthTxLimit);
     }
 
     public void init() throws Exception {
@@ -198,12 +200,12 @@ public class Iota {
         }
     }
 
-    private TipSelector createTipSelector(int milestoneStartIndex, double alpha) {
+    private TipSelector createTipSelector(int milestoneStartIndex, double alpha, int belowMaxDepthTxLimit) {
         EntryPointSelector entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, testnet, milestoneStartIndex);
         RatingCalculator ratingCalculator = new CumulativeWeightCalculator(tangle);
         TailFinder tailFinder = new TailFinderImpl(tangle);
         Walker walker = new WalkerAlpha(alpha, new SecureRandom(), tangle, messageQ, tailFinder);
         return new TipSelectorImpl(tangle, ledgerValidator, transactionValidator, entryPointSelector, ratingCalculator,
-                walker, milestone, maxTipSearchDepth);
+                walker, milestone, maxTipSearchDepth, belowMaxDepthTxLimit);
     }
 }

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -49,7 +49,7 @@ public class Configuration {
     public static final String REQ_HASH_SIZE = "46";
     public static final String TESTNET_REQ_HASH_SIZE = "49";
     public static final String BELOW_MAX_DEPTH_LIMIT = "20000";
-    public static final String WALK_VALIDATOR_CACHE = "20000";
+    public static final String WALK_VALIDATOR_CACHE = "200000";
 
 
 

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -48,7 +48,7 @@ public class Configuration {
     public static final String TESTNET_PACKET_SIZE = "1653";
     public static final String REQ_HASH_SIZE = "46";
     public static final String TESTNET_REQ_HASH_SIZE = "49";
-
+    public static final String BELOW_MAX_DEPTH_LIMIT = "20000";
 
 
 
@@ -104,9 +104,9 @@ public class Configuration {
         TRANSACTION_PACKET_SIZE,
         REQUEST_HASH_SIZE,
         SNAPSHOT_TIME,
-        TIPSELECTION_ALPHA
+        TIPSELECTION_ALPHA,
+        BELOW_MAX_DEPTH_TRANSACTION_LIMIT
     }
-
 
 
     {
@@ -170,7 +170,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.REQUEST_HASH_SIZE.name(), REQ_HASH_SIZE);
         conf.put(DefaultConfSettings.SNAPSHOT_TIME.name(), GLOBAL_SNAPSHOT_TIME);
         conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.001");
-
+        conf.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT.name(), BELOW_MAX_DEPTH_LIMIT);
     }
 
     public boolean init() throws IOException {

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -49,6 +49,7 @@ public class Configuration {
     public static final String REQ_HASH_SIZE = "46";
     public static final String TESTNET_REQ_HASH_SIZE = "49";
     public static final String BELOW_MAX_DEPTH_LIMIT = "20000";
+    public static final String WALK_VALIDATOR_CACHE = "20000";
 
 
 
@@ -105,8 +106,10 @@ public class Configuration {
         REQUEST_HASH_SIZE,
         SNAPSHOT_TIME,
         TIPSELECTION_ALPHA,
-        BELOW_MAX_DEPTH_TRANSACTION_LIMIT
+        BELOW_MAX_DEPTH_TRANSACTION_LIMIT,
+        WALK_VALIDATOR_CACHE_SIZE
     }
+
 
 
     {
@@ -171,6 +174,7 @@ public class Configuration {
         conf.put(DefaultConfSettings.SNAPSHOT_TIME.name(), GLOBAL_SNAPSHOT_TIME);
         conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.001");
         conf.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT.name(), BELOW_MAX_DEPTH_LIMIT);
+        conf.put(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE.name(), WALK_VALIDATOR_CACHE);
     }
 
     public boolean init() throws IOException {

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -444,7 +444,7 @@ public class API {
             }
 
 
-            if (!instance.transactionValidator.checkSolidity(txVM.getHash(), false)) {
+            if (!txVM.isSolid()) {
                 state = false;
                 info = "tails are not solid (missing a referenced tx): " + transaction;
                 break;
@@ -737,6 +737,7 @@ public class API {
     }
 
     private synchronized AbstractResponse findTransactionStatement(final Map<String, Object> request) throws Exception {
+
         final Set<Hash> foundTransactions =  new HashSet<>();
         boolean containsKey = false;
 

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -460,7 +460,8 @@ public class API {
             try {
                 WalkValidatorImpl walkValidator = new WalkValidatorImpl(instance.tangle, instance.ledgerValidator,
                         instance.transactionValidator, instance.milestone, instance.tipsSelector.getMaxDepth(),
-                        instance.configuration.integer(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT));
+                        instance.configuration.integer(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT),
+                        instance.configuration.integer(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE));
                 for (Hash transaction : transactions) {
                     if (!walkValidator.isValid(transaction)) {
                         state = false;

--- a/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
@@ -1,12 +1,22 @@
 package com.iota.iri.service.tipselection;
 
+import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
+import com.iota.iri.utils.collections.impl.BoundedHashSet;
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Validates consistency of tails.
  */
 @FunctionalInterface
 public interface WalkValidator {
+
+    int MAX_CACHE_SIZE = 2_000_000;
+    //As long as tip selection is synchronized we are fine with the collection not being thread safe
+    BoundedSet<Hash> FAILED_BELOW_MAX_DEPTH_CACHE = new BoundedHashSet<>(20_000, MAX_CACHE_SIZE);
 
     /**
      * Validation

--- a/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
@@ -1,22 +1,12 @@
 package com.iota.iri.service.tipselection;
 
-import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.utils.collections.impl.BoundedHashSet;
-import com.iota.iri.utils.collections.interfaces.BoundedSet;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 /**
  * Validates consistency of tails.
  */
 @FunctionalInterface
 public interface WalkValidator {
-
-    int MAX_CACHE_SIZE = 2_000_000;
-    //As long as tip selection is synchronized we are fine with the collection not being thread safe
-    BoundedSet<Hash> FAILED_BELOW_MAX_DEPTH_CACHE = new BoundedHashSet<>(20_000, MAX_CACHE_SIZE);
 
     /**
      * Validation

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -34,6 +34,7 @@ public class TipSelectorImpl implements TipSelector {
     private final Tangle tangle;
     private final Milestone milestone;
     private final int belowMaxDepthTxLimit;
+    private final int validatorCacheSize;
 
     @Override
     public int getMaxDepth() {
@@ -48,7 +49,8 @@ public class TipSelectorImpl implements TipSelector {
                            Walker walkerAlpha,
                            Milestone milestone,
                            int maxDepth,
-                           int belowMaxDepthTxLimit) {
+                           int belowMaxDepthTxLimit,
+                           int validatorCacheSize) {
 
 
         this.entryPointSelector = entryPointSelector;
@@ -63,6 +65,7 @@ public class TipSelectorImpl implements TipSelector {
         this.transactionValidator = transactionValidator;
         this.tangle = tangle;
         this.milestone = milestone;
+        this.validatorCacheSize = validatorCacheSize;
     }
 
     /**
@@ -93,7 +96,7 @@ public class TipSelectorImpl implements TipSelector {
             //random walk
             List<Hash> tips = new LinkedList<>();
             WalkValidator walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator, milestone,
-                    maxDepth, belowMaxDepthTxLimit);
+                    maxDepth, belowMaxDepthTxLimit, validatorCacheSize);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);
 

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -33,6 +33,7 @@ public class TipSelectorImpl implements TipSelector {
     private final TransactionValidator transactionValidator;
     private final Tangle tangle;
     private final Milestone milestone;
+    private final int belowMaxDepthTxLimit;
 
     @Override
     public int getMaxDepth() {
@@ -46,7 +47,9 @@ public class TipSelectorImpl implements TipSelector {
                            RatingCalculator ratingCalculator,
                            Walker walkerAlpha,
                            Milestone milestone,
-                           int maxDepth) {
+                           int maxDepth,
+                           int belowMaxDepthTxLimit) {
+
 
         this.entryPointSelector = entryPointSelector;
         this.ratingCalculator = ratingCalculator;
@@ -55,6 +58,7 @@ public class TipSelectorImpl implements TipSelector {
 
         //used by walkValidator
         this.maxDepth = maxDepth;
+        this.belowMaxDepthTxLimit = belowMaxDepthTxLimit;
         this.ledgerValidator = ledgerValidator;
         this.transactionValidator = transactionValidator;
         this.tangle = tangle;
@@ -89,7 +93,7 @@ public class TipSelectorImpl implements TipSelector {
             //random walk
             List<Hash> tips = new LinkedList<>();
             WalkValidator walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator, milestone,
-                    maxDepth);
+                    maxDepth, belowMaxDepthTxLimit);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);
 

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -78,7 +78,7 @@ public class WalkValidatorImpl implements WalkValidator {
         } else if (transactionViewModel.getCurrentIndex() != 0) {
             log.debug("Validation failed: {} not a tail", transactionHash);
             return false;
-        } else if (!transactionValidator.checkSolidity(transactionViewModel.getHash(), false)) {
+        } else if (!transactionViewModel.isSolid()) {
             log.debug("Validation failed: {} is not solid", transactionHash);
             return false;
         } else if (belowMaxDepth(transactionViewModel.getHash(), milestone.latestSolidSubtangleMilestoneIndex - maxDepth)) {

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -1,10 +1,10 @@
 package com.iota.iri.service.tipselection.impl;
 
 import com.iota.iri.LedgerValidator;
+import com.iota.iri.Milestone;
 import com.iota.iri.TransactionValidator;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.Milestone;
 import com.iota.iri.service.tipselection.WalkValidator;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.collections.impl.BoundedSetWrapper;
@@ -30,7 +30,7 @@ public class WalkValidatorImpl implements WalkValidator {
 
     public static final int INITIAL_CACHE_CAPACITY = 10_000;
     //As long as tip selection is synchronized we are fine with the collection not being thread safe
-    private static BoundedSet<Hash> failedBelowMaxDepthCache;
+    static BoundedSet<Hash> failedBelowMaxDepthCache;
     private int maxAnalyzedTxs;
 
     private final Tangle tangle;

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -33,7 +33,7 @@ public class WalkValidatorImpl implements WalkValidator {
     //As long as tip selection is synchronized we are fine with the collection not being thread safe
     private static final BoundedSet<Hash> FAILED_BELOW_MAX_DEPTH_CACHE = new BoundedSetWrapper<>(
             new LinkedHashSet<>(10_000), MAX_CACHE_SIZE);
-    private int maxAnalyzedTxs = 10_000;
+    private int maxAnalyzedTxs;
 
     private final Tangle tangle;
     private final Logger log = LoggerFactory.getLogger(WalkValidator.class);
@@ -48,12 +48,13 @@ public class WalkValidatorImpl implements WalkValidator {
     private Set<Hash> myApprovedHashes;
 
     public WalkValidatorImpl(Tangle tangle, LedgerValidator ledgerValidator, TransactionValidator transactionValidator,
-                             Milestone milestone, int maxDepth) {
+                             Milestone milestone, int maxDepth, int maxAnalyzedTxs) {
         this.tangle = tangle;
         this.ledgerValidator = ledgerValidator;
         this.transactionValidator = transactionValidator;
         this.milestone = milestone;
         this.maxDepth = maxDepth;
+        this.maxAnalyzedTxs = maxAnalyzedTxs;
 
         maxDepthOkMemoization = new HashSet<>();
         myDiff = new HashMap<>();

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * Implementation of <tt>WalkValidator</tt> that checks consistency of the ledger as part of validity checks.
@@ -63,7 +64,7 @@ public class WalkValidatorImpl implements WalkValidator {
     private BoundedSet<Hash> fetchCache(int cacheSize) {
         if (failedBelowMaxDepthCache == null) {
             failedBelowMaxDepthCache = new BoundedSetWrapper<>(
-                    new LinkedHashSet<>(INITIAL_CACHE_CAPACITY), cacheSize);
+                    new ConcurrentSkipListSet<>(), cacheSize);
         }
         return failedBelowMaxDepthCache;
     }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -82,9 +82,9 @@ public class WalkValidatorImpl implements WalkValidator {
         return true;
     }
 
-    private boolean belowMaxDepth(Hash tip, int allowedSnapshotIndex) throws Exception {
+    private boolean belowMaxDepth(Hash tip, int lowerAllowedSnapshotIndex) throws Exception {
         //if tip is confirmed stop
-        if (TransactionViewModel.fromHash(tangle, tip).snapshotIndex() >= allowedSnapshotIndex) {
+        if (TransactionViewModel.fromHash(tangle, tip).snapshotIndex() >= lowerAllowedSnapshotIndex) {
             return false;
         }
         //if tip unconfirmed, check if any referenced tx is confirmed below maxDepth
@@ -104,7 +104,7 @@ public class WalkValidatorImpl implements WalkValidator {
             if (analyzedTransactions.add(hash)) {
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
                 if ((transaction.snapshotIndex() != 0 || Objects.equals(Hash.NULL_HASH, transaction.getHash()))
-                        && transaction.snapshotIndex() < allowedSnapshotIndex) {
+                        && transaction.snapshotIndex() < lowerAllowedSnapshotIndex) {
                     updateCache(analyzedTransactions);
                     return true;
                 }

--- a/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
@@ -1,18 +1,19 @@
 package com.iota.iri.utils.collections.impl;
 
-import com.iota.iri.utils.collections.interfaces.BoundedCollection;
 import com.iota.iri.utils.collections.interfaces.BoundedSet;
 import org.apache.commons.collections4.SetUtils;
 
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
 /**
- * A set that doesn't allow to add elements to it once it is full
+ * A wrapper for a set that allows up to {@code maxsize} elements.
+ * Old elements are removed once it is full and new elements are added.
+ * The way old elements are chosen depends on the underlying set implementation.
+ *
  *
  * @param <E> the type parameter
  */

--- a/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
@@ -1,7 +1,6 @@
 package com.iota.iri.utils.collections.impl;
 
 import com.iota.iri.utils.collections.interfaces.BoundedSet;
-import org.apache.commons.collections4.SetUtils;
 
 import java.util.*;
 import java.util.function.Consumer;

--- a/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
@@ -1,0 +1,173 @@
+package com.iota.iri.utils.collections.impl;
+
+import com.iota.iri.utils.collections.interfaces.BoundedCollection;
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
+import org.apache.commons.collections4.SetUtils;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+/**
+ * A set that doesn't allow to add elements to it once it is full
+ *
+ * @param <E> the type parameter
+ */
+public class BoundedSetWrapper<E> implements BoundedSet<E>{
+    private final int maxSize;
+    private final Set<E> delegate;
+
+    /**
+     * Wraps the given set {@code c}
+     *
+     * @param c the set which you delegate the actions to
+     * @param maxSize the max size
+     * @throws NullPointerException if the {@code c} is null
+     * @throws IllegalArgumentException if {@code c} is larger than {@code maxSize}
+     */
+    public BoundedSetWrapper(Set<E> c, int maxSize) {
+        Objects.requireNonNull(c, "trying to wrap a null set");
+        if (c.size() > maxSize) {
+            throw new IllegalArgumentException(String.format("The given set size %d is larger then maxSize %d", c.size(),
+                    maxSize));
+        }
+        this.maxSize = maxSize;
+        this.delegate = c;
+    }
+
+    @Override
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    @Override
+    public int size() {
+       return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super E> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return delegate.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (isFull()) {
+            Iterator<E> iterator = delegate.iterator();
+            iterator.next();
+            iterator.remove();
+        }
+
+        return delegate.add(e);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        if (canCollectionBeFullyAdded(c)) {
+            return delegate.addAll(c);
+        }
+        else {
+            Set<E> transform = new HashSet<>(c);
+            Set<E> difference = SetUtils.difference(delegate, transform).toSet();
+            if (difference.size() > getMaxSize()) {
+                throw new IllegalArgumentException(String.format("The given set size %d is larger then maxSize %d",
+                        difference.size(), maxSize));
+            }
+            int itemsToDelete = delegate.size() + difference.size() - getMaxSize();
+            Iterator<E> iterator = delegate.iterator();
+            for (int i = 0; i < itemsToDelete; i++) {
+                iterator.next();
+                iterator.remove();
+            }
+            return delegate.addAll(c);
+        }
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        return delegate.removeIf(filter);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+       return delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public Spliterator<E> spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public Stream<E> stream() {
+        return delegate.stream();
+    }
+
+    @Override
+    public Stream<E> parallelStream() {
+        return delegate.parallelStream();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/BoundedSetWrapper.java
@@ -31,10 +31,7 @@ public class BoundedSetWrapper<E> implements BoundedSet<E>{
      */
     public BoundedSetWrapper(Set<E> c, int maxSize) {
         Objects.requireNonNull(c, "trying to wrap a null set");
-        if (c.size() > maxSize) {
-            throw new IllegalArgumentException(String.format("The given set size %d is larger then maxSize %d", c.size(),
-                    maxSize));
-        }
+        requireCollectionIsNotAboveMaxSize(c, maxSize);
         this.maxSize = maxSize;
         this.delegate = c;
     }
@@ -102,17 +99,12 @@ public class BoundedSetWrapper<E> implements BoundedSet<E>{
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
+        requireCollectionIsNotAboveMaxSize(c, getMaxSize());
         if (canCollectionBeFullyAdded(c)) {
             return delegate.addAll(c);
         }
         else {
-            Set<E> transform = new HashSet<>(c);
-            Set<E> difference = SetUtils.difference(delegate, transform).toSet();
-            if (difference.size() > getMaxSize()) {
-                throw new IllegalArgumentException(String.format("The given set size %d is larger then maxSize %d",
-                        difference.size(), maxSize));
-            }
-            int itemsToDelete = delegate.size() + difference.size() - getMaxSize();
+            int itemsToDelete = delegate.size() + c.size() - getMaxSize();
             Iterator<E> iterator = delegate.iterator();
             for (int i = 0; i < itemsToDelete; i++) {
                 iterator.next();
@@ -170,5 +162,12 @@ public class BoundedSetWrapper<E> implements BoundedSet<E>{
     @Override
     public String toString() {
         return delegate.toString();
+    }
+
+    private void requireCollectionIsNotAboveMaxSize(Collection<? extends E> c, int maxSize) {
+        if (c.size() > maxSize) {
+            throw new IllegalArgumentException(String.format("The given collection size %d is larger then maxSize %d", c.size(),
+                    maxSize));
+        }
     }
 }

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -76,8 +76,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle);
         Hash hash = tx.getTrunkTransactionHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
+        tx.updateSolid(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = depth;
@@ -128,8 +127,7 @@ public class WalkValidatorImplTest {
         tx.store(tangle);
         tx.setSnapshot(tangle, 2);
         Hash hash = tx.getHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
+        tx.updateSolid(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -8,7 +8,6 @@ import com.iota.iri.conf.Configuration;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.controllers.TransactionViewModelTest;
 import com.iota.iri.model.Hash;
-import com.iota.iri.model.Transaction;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import org.junit.AfterClass;
@@ -41,6 +40,7 @@ public class WalkValidatorImplTest {
     public static void tearDown() throws Exception {
         tangle.shutdown();
         dbFolder.delete();
+        WalkValidatorImpl.failedBelowMaxDepthCache.clear();
     }
 
     @BeforeClass

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -57,10 +57,9 @@ public class WalkValidatorImplTest {
     public void shouldPassValidation() throws Exception {
         int depth = 15;
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
+        tx.updateSolid(true);
         tx.store(tangle);
         Hash hash = tx.getHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = depth;
@@ -111,8 +110,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle);
         Hash hash = tx.getHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(false);
+        tx.updateSolid(false);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
@@ -152,11 +150,10 @@ public class WalkValidatorImplTest {
             tx = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(hash, hash), TransactionViewModelTest.getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
+            tx.updateSolid(true);
             hash = tx.getHash();
             tx.store(tangle);
         }
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 100;
@@ -203,11 +200,10 @@ public class WalkValidatorImplTest {
             tx = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(hash, hash), TransactionViewModelTest.getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
+            tx.updateSolid(true);
             hash = tx.getHash();
             tx.store(tangle);
         }
-        Mockito.when(transactionValidator.checkSolidity(tx.getHash(), false))
-                .thenReturn(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), tx.getHash()))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 15;

--- a/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
+++ b/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
@@ -1,0 +1,7 @@
+package com.iota.iri.utils.collections.impl;
+
+import static org.junit.Assert.*;
+
+public class BoundedSetWrapperTest {
+
+}

--- a/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
+++ b/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
+++ b/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
@@ -1,7 +1,46 @@
 package com.iota.iri.utils.collections.impl;
 
-import static org.junit.Assert.*;
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.internal.util.collections.Sets;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class BoundedSetWrapperTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createSetWithException() {
+        Set<Integer> set = Sets.newSet(1, 2, 3, 4, 5, 6);
+        new BoundedSetWrapper<>(set, 4);
+    }
+
+    @Test
+    public void createSetAndAssertEquals() {
+        Set<Integer> set = Sets.newSet(1, 2, 3, 4, 5, 6);
+        BoundedSet<Integer> boundedSetWrapper = new BoundedSetWrapper<>(set, 4);
+        Assert.assertEquals("sets should be equal", set, boundedSetWrapper);
+
+    }
+
+    @Test
+    public void testAdd() {
+        BoundedSet<Integer> boundedSet = new BoundedSetWrapper<>(new LinkedHashSet<>(), 3);
+        Assert.assertTrue("can't add", boundedSet.add(1));
+        Assert.assertTrue("can't add", boundedSet.add(2));
+        Assert.assertTrue("can't add", boundedSet.add(3));
+        Assert.assertTrue("can't add", boundedSet.add(4));
+        Assert.assertEquals("bounded set doesn't have expected contents",
+                Sets.newSet(2, 3, 4), boundedSet);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddAll() {
+        BoundedSet<Integer> boundedSet = new BoundedSetWrapper<>(new LinkedHashSet<>(), 3);
+        boundedSet.addAll(Arrays.asList(5, 6, 7, 8, 9));
+    }
 
 }

--- a/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
+++ b/src/test/java/com/iota/iri/utils/collections/impl/BoundedSetWrapperTest.java
@@ -20,7 +20,7 @@ public class BoundedSetWrapperTest {
     @Test
     public void createSetAndAssertEquals() {
         Set<Integer> set = Sets.newSet(1, 2, 3, 4, 5, 6);
-        BoundedSet<Integer> boundedSetWrapper = new BoundedSetWrapper<>(set, 4);
+        BoundedSet<Integer> boundedSetWrapper = new BoundedSetWrapper<>(set, 6);
         Assert.assertEquals("sets should be equal", set, boundedSetWrapper);
 
     }


### PR DESCRIPTION
# Description
If we analyze transactions in `belowMaxDepth` and we pass a certain threshold of transactions we fail.
We also cache the analyzed transactions so that in the future we can quickly fail `belowMaxDepth`.

Fixes #846 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests were added:
- Long chain tangle
  - Test from genesis
  - Old snapshot index
  - New snapshot index
- Short chain tangle
  - Test from genesis
  - Old snapshot index
  - New snapshot index


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# TODO:
1. What should be the threshold values?
MAX_CACHE_SIZE? MAX_ANALYZED_TXS?
2. Write tests for bounded set
3. Run canaries on network
4. Document `belowMaxDepth`