### PR TITLE
WIP - redefine "validSubtangleStatus" as "reasonably synced" - with in `maxDepth` range.

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -217,7 +217,7 @@ public class API {
                         return ErrorResponse.create("Invalid params");
                     }
 
-                    if (invalidSubtangleStatus()) {
+                    if (!isValidSubtangleStatus()) {
                         return ErrorResponse
                                 .create("This operations cannot be executed: The subtangle has not been updated yet.");
                     }
@@ -261,7 +261,7 @@ public class API {
                     return getBalancesStatement(addresses, tips, threshold);
                 }
                 case "getInclusionStates": {
-                    if (invalidSubtangleStatus()) {
+                    if (!isValidSubtangleStatus()) {
                         return ErrorResponse
                                 .create("This operations cannot be executed: The subtangle has not been updated yet.");
                     }
@@ -339,7 +339,7 @@ public class API {
                     }
                 }
                 case "checkConsistency": {
-                    if (invalidSubtangleStatus()) {
+                    if (!isValidSubtangleStatus()) {
                         return ErrorResponse
                                 .create("This operations cannot be executed: The subtangle has not been updated yet.");
                     }
@@ -530,8 +530,9 @@ public class API {
 
     }
 
-    public boolean invalidSubtangleStatus() {
-        return (instance.milestone.latestSolidSubtangleMilestoneIndex == milestoneStartIndex);
+    public boolean isValidSubtangleStatus() {
+        return (instance.milestone.latestSolidSubtangleMilestoneIndex != milestoneStartIndex &&
+            instance.milestone.latestSolidSubtangleMilestoneIndex + instance.tipsSelector.getMaxDepth() >= instance.milestone.latestMilestoneIndex);
     }
 
     private AbstractResponse removeNeighborsStatement(List<String> uris) {
@@ -581,7 +582,7 @@ public class API {
 
     public synchronized List<Hash> getTransactionToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
 
-        if (invalidSubtangleStatus()) {
+        if (!isValidSubtangleStatus()) {
             throw new IllegalStateException("This operations cannot be executed: The subtangle has not been updated yet.");
         }
 


### PR DESCRIPTION
# Description

When a node is deeply out of sync - or just started, Tipselection can take a long time, and resulting tips would most likely be rejected by the network due to laziness.
The solution proposed is to redefine `invalidSubtangleStatus()` to check that a node is "reasonably solid" to perform the required task.

Currently, the definition is "not solid on any milestone" - i.e. latestSolidSubtangleMilestone: 999...
This could be changed to latestSolidSubtangleMilestone + max_depth < latestMilestone (the predicate is a negative).

Also, to avoid future confusion, I swapped the predicate to be `isValidSubtangleStatus`, but left API logic intact.

Fixes #844

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Running a local network with a syncing node and checking different faults:
  - Both solid and not solid milestone set to `999...`(current functionality)
  - latest ok, but solid is still `999...` (current functionality)
  - latest ok, solid exists, but behind maxDepth (new functionality)