### PR TITLE
Remove WalkValidator cache of tips that are below max depth

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -155,7 +155,6 @@ public class IRI {
             final Option<Integer> milestoneKeys = parser.addIntegerOption("milestone-keys");
             final Option<Long> snapshotTime = parser.addLongOption("snapshot-timestamp");
             final Option<Integer> belowMaxDepthTxLimit = parser.addIntegerOption("max-depth-tx-limit");
-            final Option<Integer> walkValidatorCacheSize = parser.addIntegerOption("walk-validator-cache");
 
             try {
                 parser.parse(args);
@@ -332,19 +331,7 @@ public class IRI {
                 configuration.put(DefaultConfSettings.MAX_PEERS, vmaxPeers);
             }
 
-            final Integer belowMaxDepthLimit = parser.getOptionValue(belowMaxDepthTxLimit);
-            if (belowMaxDepthLimit != null) {
-                configuration.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT,
-                        String.valueOf(belowMaxDepthLimit));
-            }
-
-            final Integer walkValidatorCache = parser.getOptionValue(walkValidatorCacheSize);
-            if (walkValidatorCache != null) {
-                configuration.put(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE, String.valueOf(walkValidatorCache));
-            }
-
             return true;
-
         }
 
         private static void printUsage() {

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -68,7 +68,6 @@ public class Iota {
         double alpha = configuration.doubling(Configuration.DefaultConfSettings.TIPSELECTION_ALPHA.name());
         int belowMaxDepthTxLimit = configuration.integer(
                 Configuration.DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT);
-        int walkValidatorCacheSize = configuration.integer(Configuration.DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE);
 
         boolean dontValidateMilestoneSig = configuration.booling(Configuration.DefaultConfSettings
                 .DONT_VALIDATE_TESTNET_MILESTONE_SIG);
@@ -104,7 +103,7 @@ public class Iota {
         udpReceiver = new UDPReceiver(udpPort, node, configuration.integer(Configuration.DefaultConfSettings.TRANSACTION_PACKET_SIZE));
         ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
         tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel);
-        tipsSelector = createTipSelector(milestoneStartIndex, alpha, belowMaxDepthTxLimit, walkValidatorCacheSize);
+        tipsSelector = createTipSelector(milestoneStartIndex, alpha, belowMaxDepthTxLimit);
     }
 
     public void init() throws Exception {
@@ -201,13 +200,12 @@ public class Iota {
         }
     }
 
-    private TipSelector createTipSelector(int milestoneStartIndex, double alpha, int belowMaxDepthTxLimit,
-                                          int walkValidatorCacheSize) {
+    private TipSelector createTipSelector(int milestoneStartIndex, double alpha, int belowMaxDepthTxLimit) {
         EntryPointSelector entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, testnet, milestoneStartIndex);
         RatingCalculator ratingCalculator = new CumulativeWeightCalculator(tangle);
         TailFinder tailFinder = new TailFinderImpl(tangle);
         Walker walker = new WalkerAlpha(alpha, new SecureRandom(), tangle, messageQ, tailFinder);
         return new TipSelectorImpl(tangle, ledgerValidator, transactionValidator, entryPointSelector, ratingCalculator,
-                walker, milestone, maxTipSearchDepth, belowMaxDepthTxLimit, walkValidatorCacheSize);
+                walker, milestone, maxTipSearchDepth, belowMaxDepthTxLimit);
     }
 }

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -49,7 +49,6 @@ public class Configuration {
     public static final String REQ_HASH_SIZE = "46";
     public static final String TESTNET_REQ_HASH_SIZE = "49";
     public static final String BELOW_MAX_DEPTH_LIMIT = "20000";
-    public static final String WALK_VALIDATOR_CACHE = "200000";
 
 
 
@@ -107,7 +106,6 @@ public class Configuration {
         SNAPSHOT_TIME,
         TIPSELECTION_ALPHA,
         BELOW_MAX_DEPTH_TRANSACTION_LIMIT,
-        WALK_VALIDATOR_CACHE_SIZE
     }
 
 
@@ -174,7 +172,6 @@ public class Configuration {
         conf.put(DefaultConfSettings.SNAPSHOT_TIME.name(), GLOBAL_SNAPSHOT_TIME);
         conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.001");
         conf.put(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT.name(), BELOW_MAX_DEPTH_LIMIT);
-        conf.put(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE.name(), WALK_VALIDATOR_CACHE);
     }
 
     public boolean init() throws IOException {

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -460,8 +460,7 @@ public class API {
             try {
                 WalkValidatorImpl walkValidator = new WalkValidatorImpl(instance.tangle, instance.ledgerValidator,
                         instance.transactionValidator, instance.milestone, instance.tipsSelector.getMaxDepth(),
-                        instance.configuration.integer(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT),
-                        instance.configuration.integer(DefaultConfSettings.WALK_VALIDATOR_CACHE_SIZE));
+                        instance.configuration.integer(DefaultConfSettings.BELOW_MAX_DEPTH_TRANSACTION_LIMIT));
                 for (Hash transaction : transactions) {
                     if (!walkValidator.isValid(transaction)) {
                         state = false;

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -8,11 +8,11 @@ import com.iota.iri.model.HashId;
 import com.iota.iri.service.tipselection.*;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.collections.interfaces.UnIterableMap;
-import com.iota.iri.zmq.MessageQ;
 
 import java.security.InvalidAlgorithmParameterException;
-import java.security.SecureRandom;
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Implementation of <tt>TipSelector</tt> that selects 2 tips,
@@ -34,7 +34,6 @@ public class TipSelectorImpl implements TipSelector {
     private final Tangle tangle;
     private final Milestone milestone;
     private final int belowMaxDepthTxLimit;
-    private final int validatorCacheSize;
 
     @Override
     public int getMaxDepth() {
@@ -49,8 +48,7 @@ public class TipSelectorImpl implements TipSelector {
                            Walker walkerAlpha,
                            Milestone milestone,
                            int maxDepth,
-                           int belowMaxDepthTxLimit,
-                           int validatorCacheSize) {
+                           int belowMaxDepthTxLimit) {
 
 
         this.entryPointSelector = entryPointSelector;
@@ -65,7 +63,6 @@ public class TipSelectorImpl implements TipSelector {
         this.transactionValidator = transactionValidator;
         this.tangle = tangle;
         this.milestone = milestone;
-        this.validatorCacheSize = validatorCacheSize;
     }
 
     /**
@@ -96,7 +93,7 @@ public class TipSelectorImpl implements TipSelector {
             //random walk
             List<Hash> tips = new LinkedList<>();
             WalkValidator walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator, milestone,
-                    maxDepth, belowMaxDepthTxLimit, validatorCacheSize);
+                    maxDepth, belowMaxDepthTxLimit);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);
 

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -291,4 +291,52 @@ public class WalkValidatorImplTest {
         Assert.assertTrue("Validation of tx2 failed but should have succeeded since tx is above max depth",
                 walkValidator.isValid(tx2.getHash()));
     }
+
+    @Test
+    public void allowConfirmedTxToPassBelowMaxDepthAfterMilestoneConfirmation() throws Exception {
+        final int maxAnalyzedTxs = Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT);
+        TransactionViewModel tx1 = TransactionTestUtils.createBundleHead(0);
+        tx1.store(tangle);
+        tx1.setSnapshot(tangle, 92);
+
+        TransactionViewModel txBad = TransactionTestUtils.createBundleHead(0);
+        txBad.store(tangle);
+        txBad.setSnapshot(tangle, 10);
+
+        TransactionViewModel tx2 = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(tx1.getHash(), tx1.getHash()),
+                TransactionViewModelTest.getRandomTransactionHash());
+        TransactionTestUtils.setLastIndex(tx2,0);
+        TransactionTestUtils.setCurrentIndex(tx2,0);
+        tx2.updateSolid(true);
+        tx2.store(tangle);
+
+        TransactionViewModel tx3 = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
+                TransactionViewModelTest.getRandomTransactionHash());
+        TransactionTestUtils.setLastIndex(tx3,0);
+        TransactionTestUtils.setCurrentIndex(tx3,0);
+        tx3.updateSolid(true);
+        tx3.store(tangle);
+
+        TransactionViewModel tx4 = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
+                TransactionViewModelTest.getRandomTransactionHash());
+        TransactionTestUtils.setLastIndex(tx4,0);
+        TransactionTestUtils.setCurrentIndex(tx4,0);
+        tx4.updateSolid(true);
+        tx4.store(tangle);
+
+        Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), tx4.getHash()))
+                .thenReturn(true);
+
+        milestoneTracker.latestSolidSubtangleMilestoneIndex = 100;
+        WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
+                milestoneTracker, 15, maxAnalyzedTxs);
+        Assert.assertFalse("Validation of tx4 succeeded but should have failed since tx is below max depth",
+                walkValidator.isValid(tx4.getHash()));
+
+        //Now assume milestone 99 confirmed tx3
+        tx3.setSnapshot(tangle, 99);
+
+        Assert.assertTrue("Validation of tx4 failed but should have succeeded since tx is above max depth",
+                walkValidator.isValid(tx4.getHash()));
+    }
 }

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -40,7 +40,6 @@ public class WalkValidatorImplTest {
     public static void tearDown() throws Exception {
         tangle.shutdown();
         dbFolder.delete();
-        WalkValidatorImpl.failedBelowMaxDepthCache.clear();
     }
 
     @BeforeClass
@@ -65,8 +64,7 @@ public class WalkValidatorImplTest {
         milestoneTracker.latestSolidSubtangleMilestoneIndex = depth;
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, depth, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT) ,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, depth, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertTrue("Validation failed", walkValidator.isValid(hash));
     }
 
@@ -82,8 +80,7 @@ public class WalkValidatorImplTest {
         milestoneTracker.latestSolidSubtangleMilestoneIndex = depth;
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, depth, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT),
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, depth, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertFalse("Validation succeded but should have failed since tx is missing", walkValidator.isValid(hash));
     }
 
@@ -99,8 +96,7 @@ public class WalkValidatorImplTest {
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT),
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertFalse("Validation succeded but should have failed since we are not on a tail", walkValidator.isValid(hash));
     }
 
@@ -115,8 +111,7 @@ public class WalkValidatorImplTest {
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator,transactionValidator,
-                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT) ,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertFalse("Validation succeded but should have failed since tx is not solid",
                 walkValidator.isValid(hash));
     }
@@ -132,8 +127,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT),
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertFalse("Validation succeeded but should have failed tx is below max depth",
                 walkValidator.isValid(hash));
     }
@@ -156,8 +150,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 100;
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT) ,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertTrue("Validation failed but should have succeeded since tx is above max depth",
                 walkValidator.isValid(hash));
     }
@@ -183,8 +176,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 100;
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, maxAnalyzedTxs,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, maxAnalyzedTxs);
         Assert.assertFalse("Validation succeeded but should have failed since tx is below max depth",
                 walkValidator.isValid(hash));
     }
@@ -206,8 +198,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 15;
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, maxAnalyzedTxs,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, maxAnalyzedTxs);
         Assert.assertTrue("Validation failed but should have succeeded. We didn't exceed the maximal amount of" +
                         "transactions that may be analyzed.",
                 walkValidator.isValid(tx.getHash()));
@@ -232,8 +223,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 17;
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, maxAnalyzedTxs,
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, maxAnalyzedTxs);
         Assert.assertFalse("Validation succeeded but should have failed. We exceeded the maximal amount of" +
                         "transactions that may be analyzed.",
                 walkValidator.isValid(tx.getHash()));
@@ -251,8 +241,7 @@ public class WalkValidatorImplTest {
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator,
-                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT),
-                Integer.parseInt(Configuration.WALK_VALIDATOR_CACHE));
+                milestoneTracker, 15, Integer.parseInt(Configuration.BELOW_MAX_DEPTH_LIMIT));
         Assert.assertFalse("Validation succeded but should have failed due to inconsistent ledger state",
                 walkValidator.isValid(hash));
     }


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
Removes the bad tips cache. We found that valid txs are being stored there and this disrupts tipselection.

Fixes #900

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

All unit and regression tests have passed.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
