### PR TITLE
Fix solidity propagation from bottom to top

### DIFF
--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -172,6 +172,11 @@ public class TransactionValidator {
             while(!shuttingDown.get()) {
                 propagateSolidTransactions();
             }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
         };
     }
 
@@ -204,11 +209,6 @@ public class TransactionValidator {
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
             }
-        }
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -1,15 +1,14 @@
 package com.iota.iri;
 
 import com.iota.iri.controllers.TipsViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.hash.Curl;
 import com.iota.iri.hash.Sponge;
 import com.iota.iri.hash.SpongeFactory;
-import com.iota.iri.network.TransactionRequester;
-import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.zmq.MessageQ;
+import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.storage.Tangle;
-
+import com.iota.iri.zmq.MessageQ;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,15 +52,19 @@ public class TransactionValidator {
     }
 
     public void init(boolean testnet, int mwm) {
+        setMwm(testnet, mwm);
+
+        newSolidThread = new Thread(spawnSolidTransactionsPropagation(), "Solid TX cascader");
+        newSolidThread.start();
+    }
+
+    void setMwm(boolean testnet, int mwm) {
         MIN_WEIGHT_MAGNITUDE = mwm;
 
         //lowest allowed MWM encoded in 46 bytes.
         if (!testnet && MIN_WEIGHT_MAGNITUDE<13){
             MIN_WEIGHT_MAGNITUDE = 13;
         }
-
-        newSolidThread = new Thread(spawnSolidTransactionsPropagation(), "Solid TX cascader");
-        newSolidThread.start();
     }
 
     public void shutdown() throws InterruptedException {
@@ -167,51 +170,50 @@ public class TransactionValidator {
     private Runnable spawnSolidTransactionsPropagation() {
         return () -> {
             while(!shuttingDown.get()) {
-                Set<Hash> newSolidHashes = new HashSet<>();
-                useFirst.set(!useFirst.get());
-                synchronized (cascadeSync) {
-                    if (useFirst.get()) {
-                        newSolidHashes.addAll(newSolidTransactionsTwo);
-                    } else {
-                        newSolidHashes.addAll(newSolidTransactionsOne);
-                    }
-                }
-                Iterator<Hash> cascadeIterator = newSolidHashes.iterator();
-                Set<Hash> hashesToCascade = new HashSet<>();
-                while(cascadeIterator.hasNext() && !shuttingDown.get()) {
-                    try {
-                        Hash hash = cascadeIterator.next();
-                        TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
-                        Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
-                        for(Hash h: approvers) {
-                            TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
-                            if(quietQuickSetSolid(tx)) {
-                                tx.update(tangle, "solid");
-                            } else {
-                                if (transaction.isSolid()) {
-                                    addSolidTransaction(hash);
-                                }
-                            }
-                        }
-                    } catch (Exception e) {
-                        log.error("Some error", e);
-                        // TODO: Do something, maybe, or do nothing.
-                    }
-                }
-                synchronized (cascadeSync) {
-                    if (useFirst.get()) {
-                        newSolidTransactionsTwo.clear();
-                    } else {
-                        newSolidTransactionsOne.clear();
-                    }
-                }
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+                propagateSolidTransactions();
             }
         };
+    }
+
+    void propagateSolidTransactions() {
+        Set<Hash> newSolidHashes = new HashSet<>();
+        useFirst.set(!useFirst.get());
+        synchronized (cascadeSync) {
+            if (useFirst.get()) {
+                newSolidHashes.addAll(newSolidTransactionsTwo);
+            } else {
+                newSolidHashes.addAll(newSolidTransactionsOne);
+            }
+        }
+        Iterator<Hash> cascadeIterator = newSolidHashes.iterator();
+        while(cascadeIterator.hasNext() && !shuttingDown.get()) {
+            try {
+                Hash hash = cascadeIterator.next();
+                TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
+                Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
+                for(Hash h: approvers) {
+                    TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
+                    if(quietQuickSetSolid(tx)) {
+                        tx.update(tangle, "solid");
+                        addSolidTransaction(h);
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Error while propagating solidity upwards", e);
+            }
+        }
+        synchronized (cascadeSync) {
+            if (useFirst.get()) {
+                newSolidTransactionsTwo.clear();
+            } else {
+                newSolidTransactionsOne.clear();
+            }
+        }
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
@@ -264,6 +266,11 @@ public class TransactionValidator {
             return true;
         }
         return approovee.isSolid();
+    }
+
+    //for testing
+    boolean isNewSolidTxSetsEmpty () {
+        return newSolidTransactionsOne.isEmpty() && newSolidTransactionsTwo.isEmpty();
     }
 
     public static class StaleTimestampException extends RuntimeException {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -178,11 +178,14 @@ public class TransactionValidator {
     void propagateSolidTransactions() {
         Set<Hash> newSolidHashes = new HashSet<>();
         useFirst.set(!useFirst.get());
+        //synchronized to make sure no one is changing the newSolidTransactions collections during addAll
         synchronized (cascadeSync) {
             if (useFirst.get()) {
                 newSolidHashes.addAll(newSolidTransactionsTwo);
+                newSolidTransactionsTwo.clear();
             } else {
                 newSolidHashes.addAll(newSolidTransactionsOne);
+                newSolidTransactionsOne.clear();
             }
         }
         Iterator<Hash> cascadeIterator = newSolidHashes.iterator();
@@ -200,13 +203,6 @@ public class TransactionValidator {
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
-            }
-        }
-        synchronized (cascadeSync) {
-            if (useFirst.get()) {
-                newSolidTransactionsTwo.clear();
-            } else {
-                newSolidTransactionsOne.clear();
             }
         }
         try {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -62,8 +62,8 @@ public class TransactionValidator {
         MIN_WEIGHT_MAGNITUDE = mwm;
 
         //lowest allowed MWM encoded in 46 bytes.
-        if (!testnet && MIN_WEIGHT_MAGNITUDE<13){
-            MIN_WEIGHT_MAGNITUDE = 13;
+        if (!testnet){
+            MIN_WEIGHT_MAGNITUDE = Math.max(MIN_WEIGHT_MAGNITUDE, 13);
         }
     }
 

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -1,7 +1,5 @@
 package com.iota.iri.controllers;
 
-import java.util.*;
-
 import com.iota.iri.model.*;
 import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
@@ -9,11 +7,14 @@ import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Converter;
 import com.iota.iri.utils.Pair;
 
+import java.util.*;
+
 public class TransactionViewModel {
 
     private final com.iota.iri.model.Transaction transaction;
 
     public static final int SIZE = 1604;
+    public static final int TRYTES_SIZE = 2673;
     private static final int TAG_SIZE_IN_BYTES = 17; // = ceil(81 TRITS / 5 TRITS_PER_BYTE)
 
     public static final long SUPPLY = 2779530283277761L; // = (3^33 - 1) / 2

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -14,7 +14,6 @@ public class TransactionViewModel {
     private final com.iota.iri.model.Transaction transaction;
 
     public static final int SIZE = 1604;
-    public static final int TRYTES_SIZE = 2673;
     private static final int TAG_SIZE_IN_BYTES = 17; // = ceil(81 TRITS / 5 TRITS_PER_BYTE)
 
     public static final long SUPPLY = 2779530283277761L; // = (3^33 - 1) / 2
@@ -37,6 +36,7 @@ public class TransactionViewModel {
     private static final int NONCE_TRINARY_OFFSET = ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_OFFSET + ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_SIZE, NONCE_TRINARY_SIZE = 81;
 
     public static final int TRINARY_SIZE = NONCE_TRINARY_OFFSET + NONCE_TRINARY_SIZE;
+    public static final int TRYTES_SIZE = TRINARY_SIZE / 3;
 
     public static final int ESSENCE_TRINARY_OFFSET = ADDRESS_TRINARY_OFFSET, ESSENCE_TRINARY_SIZE = ADDRESS_TRINARY_SIZE + VALUE_TRINARY_SIZE + OBSOLETE_TAG_TRINARY_SIZE + TIMESTAMP_TRINARY_SIZE + CURRENT_INDEX_TRINARY_SIZE + LAST_INDEX_TRINARY_SIZE;
 

--- a/src/test/java/com/iota/iri/TransactionTestUtils.java
+++ b/src/test/java/com/iota/iri/TransactionTestUtils.java
@@ -38,14 +38,14 @@ public class TransactionTestUtils {
     }
 
     public static TransactionViewModel createTransactionWithTrytes(String trytes) {
-        trytes  = expandTrytes(trytes);
-        byte[] trits = Converter.allocatingTritsFromTrytes(trytes);
+        String expandedTrytes  = expandTrytes(trytes);
+        byte[] trits = Converter.allocatingTritsFromTrytes(expandedTrytes);
         return new TransactionViewModel(trits, Hash.calculate(SpongeFactory.Mode.CURLP81, trits));
     }
 
     public static TransactionViewModel createTransactionWithTrunkAndBranch(String trytes, Hash trunk, Hash branch) {
-        trytes = expandTrytes(trytes);
-        byte[] trits =  Converter.allocatingTritsFromTrytes(trytes);
+        String expandedTrytes = expandTrytes(trytes);
+        byte[] trits =  Converter.allocatingTritsFromTrytes(expandedTrytes);
         System.arraycopy(trunk.trits(), 0, trits, TransactionViewModel.TRUNK_TRANSACTION_TRINARY_OFFSET,
                 TransactionViewModel.TRUNK_TRANSACTION_TRINARY_SIZE);
         System.arraycopy(branch.trits(), 0, trits, TransactionViewModel.BRANCH_TRANSACTION_TRINARY_OFFSET,

--- a/src/test/java/com/iota/iri/TransactionTestUtils.java
+++ b/src/test/java/com/iota/iri/TransactionTestUtils.java
@@ -2,8 +2,10 @@ package com.iota.iri;
 
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.controllers.TransactionViewModelTest;
+import com.iota.iri.hash.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.utils.Converter;
+import org.apache.commons.lang3.StringUtils;
 
 public class TransactionTestUtils {
 
@@ -33,5 +35,25 @@ public class TransactionTestUtils {
         System.arraycopy(trunkTx.trits(), TransactionViewModel.BUNDLE_TRINARY_OFFSET, tx.trits(),
                 TransactionViewModel.BUNDLE_TRINARY_OFFSET, TransactionViewModel.BUNDLE_TRINARY_SIZE);
         return tx;
+    }
+
+    public static TransactionViewModel createTransactionWithTrytes(String trytes) {
+        trytes  = expandTrytes(trytes);
+        byte[] trits = Converter.allocatingTritsFromTrytes(trytes);
+        return new TransactionViewModel(trits, Hash.calculate(SpongeFactory.Mode.CURLP81, trits));
+    }
+
+    public static TransactionViewModel createTransactionWithTrunkAndBranch(String trytes, Hash trunk, Hash branch) {
+        trytes = expandTrytes(trytes);
+        byte[] trits =  Converter.allocatingTritsFromTrytes(trytes);
+        System.arraycopy(trunk.trits(), 0, trits, TransactionViewModel.TRUNK_TRANSACTION_TRINARY_OFFSET,
+                TransactionViewModel.TRUNK_TRANSACTION_TRINARY_SIZE);
+        System.arraycopy(branch.trits(), 0, trits, TransactionViewModel.BRANCH_TRANSACTION_TRINARY_OFFSET,
+                TransactionViewModel.BRANCH_TRANSACTION_TRINARY_SIZE);
+        return new TransactionViewModel(trits, Hash.calculate(SpongeFactory.Mode.CURLP81, trits));
+    }
+
+    private static String expandTrytes(String trytes) {
+        return trytes + StringUtils.repeat('9', TransactionViewModel.TRYTES_SIZE - trytes.length());
     }
 }

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -11,12 +11,12 @@ import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import com.iota.iri.utils.Converter;
 import com.iota.iri.zmq.MessageQ;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionTrits;
-import static org.junit.Assert.assertEquals;
+import static com.iota.iri.controllers.TransactionViewModelTest.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -43,12 +43,11 @@ public class TransactionValidatorTest {
     TransactionRequester txRequester = new TransactionRequester(tangle, messageQ);
     txValidator = new TransactionValidator(tangle, tipsViewModel, txRequester, messageQ,
             Long.parseLong(Configuration.GLOBAL_SNAPSHOT_TIME));
-    txValidator.init(false, MAINNET_MWM);
+    txValidator.setMwm(false, MAINNET_MWM);
   }
 
   @AfterClass
   public static void tearDown() throws Exception {
-    txValidator.shutdown();
     tangle.shutdown();
     dbFolder.delete();
     logFolder.delete();
@@ -56,7 +55,6 @@ public class TransactionValidatorTest {
 
   @Test
   public void testMinMwm() throws InterruptedException {
-    txValidator.shutdown();
     txValidator.init(false, 5);
     assertTrue(txValidator.getMinWeightMagnitude() == 13);
     txValidator.shutdown();
@@ -134,6 +132,76 @@ public class TransactionValidatorTest {
     tx.store(tangle);
 
     return tx;
+  }
+
+    @Test
+    public void testTransactionPropagation() throws Exception {
+        TransactionViewModel leftChildLeaf = TransactionTestUtils.createTransactionWithTrytes("CHILDTX");
+        leftChildLeaf.updateSolid(true);
+        leftChildLeaf.store(tangle);
+
+        TransactionViewModel rightChildLeaf = TransactionTestUtils.createTransactionWithTrytes("CHILDTWOTX");
+        rightChildLeaf.updateSolid(true);
+        rightChildLeaf.store(tangle);
+
+        TransactionViewModel parent = TransactionTestUtils.createTransactionWithTrunkAndBranch("PARENT",
+                leftChildLeaf.getHash(), rightChildLeaf.getHash());
+        parent.updateSolid(false);
+        parent.store(tangle);
+
+        TransactionViewModel parentSibling = TransactionTestUtils.createTransactionWithTrytes("PARENTLEAF");
+        parentSibling.updateSolid(true);
+        parentSibling.store(tangle);
+
+        TransactionViewModel grandParent = TransactionTestUtils.createTransactionWithTrunkAndBranch("GRANDPARENT", parent.getHash(),
+                        parentSibling.getHash());
+        grandParent.updateSolid(false);
+        grandParent.store(tangle);
+
+        txValidator.addSolidTransaction(leftChildLeaf.getHash());
+        while (!txValidator.isNewSolidTxSetsEmpty()) {
+            txValidator.propagateSolidTransactions();
+        }
+
+        parent = TransactionViewModel.fromHash(tangle, parent.getHash());
+        Assert.assertTrue("tx3 was expected to be solid", parent.isSolid());
+        grandParent = TransactionViewModel.fromHash(tangle, grandParent.getHash());
+        Assert.assertTrue("tx5 was expected to be solid", grandParent.isSolid());
+    }
+
+  @Test
+  public void testTransactionPropagationFailure() throws Exception {
+    TransactionViewModel leftChildLeaf = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+    leftChildLeaf.updateSolid(true);
+    leftChildLeaf.store(tangle);
+
+    TransactionViewModel rightChildLeaf = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+    rightChildLeaf.updateSolid(true);
+    rightChildLeaf.store(tangle);
+
+    TransactionViewModel parent = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(leftChildLeaf.getHash(),
+            rightChildLeaf.getHash()), getRandomTransactionHash());
+    parent.updateSolid(false);
+    parent.store(tangle);
+
+    TransactionViewModel parentSibling = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+    parentSibling.updateSolid(false);
+    parentSibling.store(tangle);
+
+    TransactionViewModel grandParent = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(parent.getHash(),
+            parentSibling.getHash()), getRandomTransactionHash());
+    grandParent.updateSolid(false);
+    grandParent.store(tangle);
+
+    txValidator.addSolidTransaction(leftChildLeaf.getHash());
+    while (!txValidator.isNewSolidTxSetsEmpty()) {
+      txValidator.propagateSolidTransactions();
+    }
+
+    parent = TransactionViewModel.fromHash(tangle, parent.getHash());
+    Assert.assertTrue("parent tx was expected to be solid", parent.isSolid());
+    grandParent = TransactionViewModel.fromHash(tangle, grandParent.getHash());
+    Assert.assertFalse("grandParent tx was expected to be not solid", grandParent.isSolid());
   }
 
   private TransactionViewModel getTxWithoutBranchAndTrunk() throws Exception {

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -164,9 +164,9 @@ public class TransactionValidatorTest {
         }
 
         parent = TransactionViewModel.fromHash(tangle, parent.getHash());
-        Assert.assertTrue("tx3 was expected to be solid", parent.isSolid());
+        Assert.assertTrue("Parent tx was expected to be solid", parent.isSolid());
         grandParent = TransactionViewModel.fromHash(tangle, grandParent.getHash());
-        Assert.assertTrue("tx5 was expected to be solid", grandParent.isSolid());
+        Assert.assertTrue("Grandparent  was expected to be solid", grandParent.isSolid());
     }
 
   @Test
@@ -199,9 +199,9 @@ public class TransactionValidatorTest {
     }
 
     parent = TransactionViewModel.fromHash(tangle, parent.getHash());
-    Assert.assertTrue("parent tx was expected to be solid", parent.isSolid());
+    Assert.assertTrue("Parent tx was expected to be solid", parent.isSolid());
     grandParent = TransactionViewModel.fromHash(tangle, grandParent.getHash());
-    Assert.assertFalse("grandParent tx was expected to be not solid", grandParent.isSolid());
+    Assert.assertFalse("GrandParent tx was expected to be not solid", grandParent.isSolid());
   }
 
   private TransactionViewModel getTxWithoutBranchAndTrunk() throws Exception {


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

There is a `propagateSolidTransaction` thread that is supposed to cascade solidity from bottom to top.
If a transaction is solid and its approver's other parent is solid then make the approver solid. Then keep on propagating upwards in this manner.
Unfortunately, this didn't happen. The solidified approver didn't reenter the queue so the change was not cascaded.
 
May help with #899 / #898 

## Type of change


- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

The following unit tests have been added 
- `testTransactionPropagation`
- `testTransactionPropagationFailure`

In addition, canaries were run by @DyrellC and @geminoz.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
