### PR TITLE
remove checkSolidity mocks

### DIFF
--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -89,8 +89,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(2);
         tx.store(tangle);
         Hash hash = tx.getHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
+        tx.updateSolid(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;
@@ -168,10 +167,9 @@ public class WalkValidatorImplTest {
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
             hash = tx.getHash();
+            tx.updateSolid(true);
             tx.store(tangle);
         }
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 100;
@@ -214,11 +212,10 @@ public class WalkValidatorImplTest {
                     TransactionViewModelTest.getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
+            tx.updateSolid(true);
             tx.store(tangle);
             hash = tx.getHash();
         }
-        Mockito.when(transactionValidator.checkSolidity(tx.getHash(), false))
-                .thenReturn(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), tx.getHash()))
                 .thenReturn(true);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = 17;
@@ -234,8 +231,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle);
         Hash hash = tx.getHash();
-        Mockito.when(transactionValidator.checkSolidity(hash, false))
-                .thenReturn(true);
+        tx.updateSolid(true);
         Mockito.when(ledgerValidator.updateDiff(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(false);
         milestoneTracker.latestSolidSubtangleMilestoneIndex = Integer.MAX_VALUE;


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Due to recent changes, one no no longer has to mock the `checkSolidity` methods in unit tests.
It is enough to do `updateSolidity()` on a given transaction.

Fixes #846 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
All unit tests pass


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
