### PR TITLE
some TransactionValidator fixes regarding solidity

### DIFF
--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -202,10 +202,10 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-			tx.update(tangle, "solid|height"); //update to db here
+                        tx.update(tangle, "solid|height");
+			tipsViewModel.setSolid(h);
                         addSolidTransaction(h);
-                    }     
-		    updateTipsView(tx);
+                    }
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
@@ -215,27 +215,17 @@ public class TransactionValidator {
 
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
-      
-	if(quickSetSolid(transactionViewModel)) {
-	    transactionViewModel.update(tangle, "solid|height"); //update to db here
-            addSolidTransaction(transactionViewModel.getHash());
+        if(transactionViewModel.getApprovers(tangle).size() == 0) {
+            tipsViewModel.addTipHash(transactionViewModel.getHash());
         }
-        updateTipsView(transactionViewModel);
-    }
-    
-    private void updateTipsView(TransactionViewModel transactionViewModel) throws Exception {
-	if(transactionViewModel.getApprovers(tangle).size() == 0){
-        	tipsViewModel.addTipHash(transactionViewModel.getHash());
-            	if(transactionViewModel.isSolid()){
-			tipsViewModel.setSolid(transactionViewModel.getHash());
-	    	}
-        }
-        else{
-	        tipsViewModel.removeTipHash(transactionViewModel.getHash()); 
-		//hash should already have been removed as soon parent attaches
-	}
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
+
+        if(quickSetSolid(transactionViewModel)) {
+	    transactionViewModel.update(tangle,"solid|height");
+	    tipsViewModel.setSolid(transactionViewModel.getHash());
+            addSolidTransaction(transactionViewModel.getHash());
+        }
     }
 
     public boolean quietQuickSetSolid(TransactionViewModel transactionViewModel) {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -198,14 +198,14 @@ public class TransactionValidator {
             try {
                 Hash hash = cascadeIterator.next();
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
-		transaction.update(tangle, "solid|height"); //update to db here
-		updateTipsView(transaction);
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
+			transaction.update(tangle, "solid|height"); //update to db here
                         addSolidTransaction(h);
-                    }                
+                    }     
+		    updateTipsView(transaction);
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
@@ -217,6 +217,7 @@ public class TransactionValidator {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
       
 	if(quickSetSolid(transactionViewModel)) {
+	    transaction.update(tangle, "solid|height"); //update to db here
             addSolidTransaction(transactionViewModel.getHash());
         }
         updateTipsView(transactionViewModel);
@@ -230,7 +231,7 @@ public class TransactionValidator {
 	    	}
         }
         else{
-	        tipsViewModel.removeTipHash(transactionViewModel.getHash());
+	        tipsViewModel.removeTipHash(transactionViewModel.getHash()); //won't happen in practice i think ????
 	}
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -200,13 +200,13 @@ public class TransactionValidator {
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
-                    TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
-                    if(quietQuickSetSolid(tx)) {
-			tx.update(tangle, "solid|height");
-			tipsViewModel.setSolid(h);
-			addSolidTransaction(h);
-		    }
-                }
+					TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
+					if(quietQuickSetSolid(tx)) {
+						tx.update(tangle, "solid|height");
+						tipsViewModel.setSolid(h);
+						addSolidTransaction(h);
+					}
+				}
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
             }
@@ -220,13 +220,13 @@ public class TransactionValidator {
         }
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
-
-        if(quickSetSolid(transactionViewModel)) {
-		transactionViewModel.update(tangle,"solid|height");
-		tipsViewModel.setSolid(transactionViewModel.getHash());
-		addSolidTransaction(transactionViewModel.getHash());
+		
+		if(quickSetSolid(transactionViewModel)) {
+			transactionViewModel.update(tangle,"solid|height");
+			tipsViewModel.setSolid(transactionViewModel.getHash());
+			addSolidTransaction(transactionViewModel.getHash());
+		}
 	}
-    }
 
     public boolean quietQuickSetSolid(TransactionViewModel transactionViewModel) {
         try {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -76,7 +76,7 @@ public class TransactionValidator {
         return MIN_WEIGHT_MAGNITUDE;
     }
 
-    private boolean hasInvalidTimestamp(TransactionViewModel transactionViewModel) {
+    private static boolean hasInvalidTimestamp(TransactionViewModel transactionViewModel) {
         if (transactionViewModel.getAttachmentTimestamp() == 0) {
             return transactionViewModel.getTimestamp() < snapshotTimestamp && !Objects.equals(transactionViewModel.getHash(), Hash.NULL_HASH)
                     || transactionViewModel.getTimestamp() > (System.currentTimeMillis() / 1000) + MAX_TIMESTAMP_FUTURE;
@@ -85,7 +85,7 @@ public class TransactionValidator {
                 || transactionViewModel.getAttachmentTimestamp() > System.currentTimeMillis() + MAX_TIMESTAMP_FUTURE_MS;
     }
 
-    public void runValidation(TransactionViewModel transactionViewModel, final int minWeightMagnitude) {
+    public static void runValidation(TransactionViewModel transactionViewModel, final int minWeightMagnitude) {
         transactionViewModel.setMetadata();
         transactionViewModel.setAttachmentData();
         if(hasInvalidTimestamp(transactionViewModel)) {
@@ -107,17 +107,17 @@ public class TransactionValidator {
         }
     }
 
-    public TransactionViewModel validateTrits(final byte[] trits, int minWeightMagnitude) {
+    public static TransactionViewModel validateTrits(final byte[] trits, int minWeightMagnitude) {
         TransactionViewModel transactionViewModel = new TransactionViewModel(trits, Hash.calculate(trits, 0, trits.length, SpongeFactory.create(SpongeFactory.Mode.CURLP81)));
         runValidation(transactionViewModel, minWeightMagnitude);
         return transactionViewModel;
     }
 
-    public TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude) {
+    public static TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude) {
         return validateBytes(bytes, minWeightMagnitude, SpongeFactory.create(SpongeFactory.Mode.CURLP81));
     }
 
-    public TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude, Sponge curl) {
+    public static TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude, Sponge curl) {
         TransactionViewModel transactionViewModel = new TransactionViewModel(bytes, Hash.calculate(bytes, TransactionViewModel.TRINARY_SIZE, curl));
         runValidation(transactionViewModel, minWeightMagnitude);
         return transactionViewModel;

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -199,13 +199,13 @@ public class TransactionValidator {
                 Hash hash = cascadeIterator.next();
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
 		transaction.update(tangle, "solid|height"); //update to db here
+		updateTipsView(transaction);
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
                         addSolidTransaction(h);
-                    }
-                    updateTipsView(tx);
+                    }                
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -198,11 +198,11 @@ public class TransactionValidator {
             try {
                 Hash hash = cascadeIterator.next();
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
+		transaction.update(tangle, "solid|height"); //update to db here
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-			tx.update(tangle, "solid");
                         addSolidTransaction(h);
                     }
                     updateTipsView(tx);
@@ -217,22 +217,21 @@ public class TransactionValidator {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
       
 	if(quickSetSolid(transactionViewModel)) {
-	    transactionViewModel.update(tangle, "solid");
             addSolidTransaction(transactionViewModel.getHash());
         }
         updateTipsView(transactionViewModel);
     }
     
     private void updateTipsView(TransactionViewModel transactionViewModel) throws Exception {
-	    if(transactionViewModel.getApprovers(tangle).size() == 0){
-            tipsViewModel.addTipHash(transactionViewModel.getHash());
-            if(transactionViewModel.isSolid()){
-		        tipsViewModel.setSolid(transactionViewModel.getHash());
-	        }
+	if(transactionViewModel.getApprovers(tangle).size() == 0){
+        	tipsViewModel.addTipHash(transactionViewModel.getHash());
+            	if(transactionViewModel.isSolid()){
+			tipsViewModel.setSolid(transactionViewModel.getHash());
+	    	}
         }
         else{
 	        tipsViewModel.removeTipHash(transactionViewModel.getHash());
-	    }
+	}
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
     }

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -205,7 +205,7 @@ public class TransactionValidator {
 			tx.update(tangle, "solid|height"); //update to db here
                         addSolidTransaction(h);
                     }     
-		    updateTipsView(transaction);
+		    updateTipsView(tx);
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -207,11 +207,11 @@ public class TransactionValidator {
 						addSolidTransaction(h);
 					}
 				}
-            } catch (Exception e) {
-                log.error("Error while propagating solidity upwards", e);
-            }
-        }
-    }
+			} catch (Exception e) {
+				log.error("Error while propagating solidity upwards", e);
+			}
+		}
+	}
 
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -222,7 +222,7 @@ public class TransactionValidator {
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
 
         if(quickSetSolid(transactionViewModel)) {
-            transactionViewModel.update(tangle,"solid|height");
+            transactionViewModel.update(tangle, "solid|height");
             tipsViewModel.setSolid(transactionViewModel.getHash());
             addSolidTransaction(transactionViewModel.getHash());
         }

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -201,10 +201,10 @@ public class TransactionValidator {
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
-                    if(quietQuickSetSolid(tx)) {
-                        tx.update(tangle, "solid|height");
-			tipsViewModel.setSolid(h);
-                        addSolidTransaction(h);
+                    if(quietQuickSetSolid(tx)) {			    
+                    	tx.update(tangle, "solid|height");
+						tipsViewModel.setSolid(h);
+                    	addSolidTransaction(h);
                     }
                 }
             } catch (Exception e) {
@@ -222,8 +222,8 @@ public class TransactionValidator {
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
 
         if(quickSetSolid(transactionViewModel)) {
-	    transactionViewModel.update(tangle,"solid|height");
-	    tipsViewModel.setSolid(transactionViewModel.getHash());
+	    	transactionViewModel.update(tangle,"solid|height");
+	    	tipsViewModel.setSolid(transactionViewModel.getHash());
             addSolidTransaction(transactionViewModel.getHash());
         }
     }

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -202,7 +202,7 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-			transaction.update(tangle, "solid|height"); //update to db here
+			tx.update(tangle, "solid|height"); //update to db here
                         addSolidTransaction(h);
                     }     
 		    updateTipsView(transaction);
@@ -217,7 +217,7 @@ public class TransactionValidator {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
       
 	if(quickSetSolid(transactionViewModel)) {
-	    transaction.update(tangle, "solid|height"); //update to db here
+	    transactionViewModel.update(tangle, "solid|height"); //update to db here
             addSolidTransaction(transactionViewModel.getHash());
         }
         updateTipsView(transactionViewModel);
@@ -231,7 +231,8 @@ public class TransactionValidator {
 	    	}
         }
         else{
-	        tipsViewModel.removeTipHash(transactionViewModel.getHash()); //won't happen in practice i think ????
+	        tipsViewModel.removeTipHash(transactionViewModel.getHash()); 
+		//hash should already have been removed as soon parent attaches
 	}
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -76,7 +76,7 @@ public class TransactionValidator {
         return MIN_WEIGHT_MAGNITUDE;
     }
 
-    private static boolean hasInvalidTimestamp(TransactionViewModel transactionViewModel) {
+    private boolean hasInvalidTimestamp(TransactionViewModel transactionViewModel) {
         if (transactionViewModel.getAttachmentTimestamp() == 0) {
             return transactionViewModel.getTimestamp() < snapshotTimestamp && !Objects.equals(transactionViewModel.getHash(), Hash.NULL_HASH)
                     || transactionViewModel.getTimestamp() > (System.currentTimeMillis() / 1000) + MAX_TIMESTAMP_FUTURE;
@@ -85,7 +85,7 @@ public class TransactionValidator {
                 || transactionViewModel.getAttachmentTimestamp() > System.currentTimeMillis() + MAX_TIMESTAMP_FUTURE_MS;
     }
 
-    public static void runValidation(TransactionViewModel transactionViewModel, final int minWeightMagnitude) {
+    public void runValidation(TransactionViewModel transactionViewModel, final int minWeightMagnitude) {
         transactionViewModel.setMetadata();
         transactionViewModel.setAttachmentData();
         if(hasInvalidTimestamp(transactionViewModel)) {
@@ -107,17 +107,17 @@ public class TransactionValidator {
         }
     }
 
-    public static TransactionViewModel validateTrits(final byte[] trits, int minWeightMagnitude) {
+    public TransactionViewModel validateTrits(final byte[] trits, int minWeightMagnitude) {
         TransactionViewModel transactionViewModel = new TransactionViewModel(trits, Hash.calculate(trits, 0, trits.length, SpongeFactory.create(SpongeFactory.Mode.CURLP81)));
         runValidation(transactionViewModel, minWeightMagnitude);
         return transactionViewModel;
     }
 
-    public static TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude) {
+    public TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude) {
         return validateBytes(bytes, minWeightMagnitude, SpongeFactory.create(SpongeFactory.Mode.CURLP81));
     }
 
-    public static TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude, Sponge curl) {
+    public TransactionViewModel validateBytes(final byte[] bytes, int minWeightMagnitude, Sponge curl) {
         TransactionViewModel transactionViewModel = new TransactionViewModel(bytes, Hash.calculate(bytes, TransactionViewModel.TRINARY_SIZE, curl));
         runValidation(transactionViewModel, minWeightMagnitude);
         return transactionViewModel;
@@ -200,18 +200,18 @@ public class TransactionValidator {
                 TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
-					TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
-					if(quietQuickSetSolid(tx)) {
-						tx.update(tangle, "solid|height");
-						tipsViewModel.setSolid(h);
-						addSolidTransaction(h);
-					}
-				}
-			} catch (Exception e) {
-				log.error("Error while propagating solidity upwards", e);
-			}
-		}
-	}
+                    TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
+                    if(quietQuickSetSolid(tx)) {
+                        tx.update(tangle, "solid|height");
+                        tipsViewModel.setSolid(h);
+                        addSolidTransaction(h);
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Error while propagating solidity upwards", e);
+            }
+        }
+    }
 
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
@@ -220,13 +220,13 @@ public class TransactionValidator {
         }
         tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
-		
-		if(quickSetSolid(transactionViewModel)) {
-			transactionViewModel.update(tangle,"solid|height");
-			tipsViewModel.setSolid(transactionViewModel.getHash());
-			addSolidTransaction(transactionViewModel.getHash());
-		}
-	}
+
+        if(quickSetSolid(transactionViewModel)) {
+            transactionViewModel.update(tangle,"solid|height");
+            tipsViewModel.setSolid(transactionViewModel.getHash());
+            addSolidTransaction(transactionViewModel.getHash());
+        }
+    }
 
     public boolean quietQuickSetSolid(TransactionViewModel transactionViewModel) {
         try {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -202,10 +202,10 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-						tx.update(tangle, "solid|height");
-						tipsViewModel.setSolid(h);
-						addSolidTransaction(h);
-                    }
+			tx.update(tangle, "solid|height");
+			tipsViewModel.setSolid(h);
+			addSolidTransaction(h);
+		    }
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
@@ -222,10 +222,10 @@ public class TransactionValidator {
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
 
         if(quickSetSolid(transactionViewModel)) {
-			transactionViewModel.update(tangle,"solid|height");
-			tipsViewModel.setSolid(transactionViewModel.getHash());
-			addSolidTransaction(transactionViewModel.getHash());
-        }
+		transactionViewModel.update(tangle,"solid|height");
+		tipsViewModel.setSolid(transactionViewModel.getHash());
+		addSolidTransaction(transactionViewModel.getHash());
+	}
     }
 
     public boolean quietQuickSetSolid(TransactionViewModel transactionViewModel) {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -202,6 +202,7 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
+			tx.update(tangle, "solid");
                         addSolidTransaction(h);
                     }
                     updateTipsView(tx);
@@ -215,7 +216,8 @@ public class TransactionValidator {
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
       
-	    if(quickSetSolid(transactionViewModel)) {
+	if(quickSetSolid(transactionViewModel)) {
+	    transactionViewModel.update(tangle, "solid");
             addSolidTransaction(transactionViewModel.getHash());
         }
         updateTipsView(transactionViewModel);

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -202,9 +202,9 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-                        tx.update(tangle, "solid");
                         addSolidTransaction(h);
                     }
+                    updateTipsView(tx);
                 }
             } catch (Exception e) {
                 log.error("Error while propagating solidity upwards", e);
@@ -214,15 +214,25 @@ public class TransactionValidator {
 
     public void updateStatus(TransactionViewModel transactionViewModel) throws Exception {
         transactionRequester.clearTransactionRequest(transactionViewModel.getHash());
-        if(transactionViewModel.getApprovers(tangle).size() == 0) {
-            tipsViewModel.addTipHash(transactionViewModel.getHash());
-        }
-        tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
-        tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
-
-        if(quickSetSolid(transactionViewModel)) {
+      
+	    if(quickSetSolid(transactionViewModel)) {
             addSolidTransaction(transactionViewModel.getHash());
         }
+        updateTipsView(transactionViewModel);
+    }
+    
+    private void updateTipsView(TransactionViewModel transactionViewModel) throws Exception {
+	    if(transactionViewModel.getApprovers(tangle).size() == 0){
+            tipsViewModel.addTipHash(transactionViewModel.getHash());
+            if(transactionViewModel.isSolid()){
+		        tipsViewModel.setSolid(transactionViewModel.getHash());
+	        }
+        }
+        else{
+	        tipsViewModel.removeTipHash(transactionViewModel.getHash());
+	    }
+        tipsViewModel.removeTipHash(transactionViewModel.getTrunkTransactionHash());
+        tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
     }
 
     public boolean quietQuickSetSolid(TransactionViewModel transactionViewModel) {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -201,10 +201,10 @@ public class TransactionValidator {
                 Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();
                 for(Hash h: approvers) {
                     TransactionViewModel tx = TransactionViewModel.fromHash(tangle, h);
-                    if(quietQuickSetSolid(tx)) {			    
-                    	tx.update(tangle, "solid|height");
+                    if(quietQuickSetSolid(tx)) {
+						tx.update(tangle, "solid|height");
 						tipsViewModel.setSolid(h);
-                    	addSolidTransaction(h);
+						addSolidTransaction(h);
                     }
                 }
             } catch (Exception e) {
@@ -222,9 +222,9 @@ public class TransactionValidator {
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
 
         if(quickSetSolid(transactionViewModel)) {
-	    	transactionViewModel.update(tangle,"solid|height");
-	    	tipsViewModel.setSolid(transactionViewModel.getHash());
-            addSolidTransaction(transactionViewModel.getHash());
+			transactionViewModel.update(tangle,"solid|height");
+			tipsViewModel.setSolid(transactionViewModel.getHash());
+			addSolidTransaction(transactionViewModel.getHash());
         }
     }
 

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -98,6 +98,12 @@ public class TipsViewModel {
             return tips.size();
         }
     }
+    
+    public int solidSize() {
+        synchronized (sync) {
+            return solidTips.size();
+        }
+    }
 
     public int size() {
         synchronized (sync) {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -34,7 +34,7 @@ public class TipsSolidifier {
             while (!shuttingDown) {
                 try {
                     scanTipsForSolidity();
-                    if(log.isDebugEnabled()) {
+                    if (log.isDebugEnabled()) {
                         long now = System.currentTimeMillis();
                         if ((now - lastTime) > 10000L) {
                             lastTime = now;

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -52,8 +52,7 @@ public class TipsSolidifier {
     }
 
     private void scanTipsForSolidity() throws Exception {
-        int size = tipsViewModel.nonSolidSize();
-        
+        int size = tipsViewModel.nonSolidSize();        
         if (size != 0) {
             Hash hash = tipsViewModel.getRandomNonSolidTipHash();
             boolean isTip = true;
@@ -65,8 +64,7 @@ public class TipsSolidifier {
                 //if(hash != null && TransactionViewModel.fromHash(hash).isSolid() && isTip) {
                 tipsViewModel.setSolid(hash);
             }
-        }
-        
+        }        
     }
 
     public void shutdown() {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -29,6 +29,7 @@ public class TipsSolidifier {
 
     public void init() {
         solidityRescanHandle = new Thread(() -> {
+            
             long lastTime = 0;
             while (!shuttingDown) {
                 try {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -29,7 +29,7 @@ public class TipsSolidifier {
 
     public void init() {
         solidityRescanHandle = new Thread(() -> {
-            
+
             long lastTime = 0;
             while (!shuttingDown) {
                 try {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -48,6 +48,8 @@ public class TipsSolidifier {
 
     private void scanTipsForSolidity() throws Exception {
         int size = tipsViewModel.nonSolidSize();
+        log.info("#Solid/NonSolid: {}/{}",tipsViewModel.size()-size,size);
+        /*
         if (size != 0) {
             Hash hash = tipsViewModel.getRandomNonSolidTipHash();
             boolean isTip = true;
@@ -60,6 +62,7 @@ public class TipsSolidifier {
                 tipsViewModel.setSolid(hash);
             }
         }
+        */
     }
 
     public void shutdown() {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -52,7 +52,7 @@ public class TipsSolidifier {
     }
 
     private void scanTipsForSolidity() throws Exception {
-        int size = tipsViewModel.nonSolidSize();        
+        int size = tipsViewModel.nonSolidSize();
         if (size != 0) {
             Hash hash = tipsViewModel.getRandomNonSolidTipHash();
             boolean isTip = true;
@@ -64,7 +64,7 @@ public class TipsSolidifier {
                 //if(hash != null && TransactionViewModel.fromHash(hash).isSolid() && isTip) {
                 tipsViewModel.setSolid(hash);
             }
-        }        
+        }
     }
 
     public void shutdown() {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -37,7 +37,7 @@ public class TipsSolidifier {
                     long now = System.currentTimeMillis();
                     if ((now - lastTime) > 10000L) {
                         lastTime = now;
-                        log.debug("#Solid/NonSolid: {}/{}",tipsViewModel.solidSize(),tipsViewModel.nonSolidSize());
+                        log.debug("#Solid/NonSolid: {}/{}", tipsViewModel.solidSize(), tipsViewModel.nonSolidSize());
                     } 
                 } catch (Exception e) {
                     log.error("Error during solidity scan : {}", e);

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -49,7 +49,7 @@ public class TipsSolidifier {
     private void scanTipsForSolidity() throws Exception {
         int size = tipsViewModel.nonSolidSize();
         log.info("#Solid/NonSolid: {}/{}",tipsViewModel.size()-size,size);
-        /*
+        
         if (size != 0) {
             Hash hash = tipsViewModel.getRandomNonSolidTipHash();
             boolean isTip = true;
@@ -62,7 +62,7 @@ public class TipsSolidifier {
                 tipsViewModel.setSolid(hash);
             }
         }
-        */
+        
     }
 
     public void shutdown() {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -29,10 +29,15 @@ public class TipsSolidifier {
 
     public void init() {
         solidityRescanHandle = new Thread(() -> {
-
+            long lastTime = 0;
             while (!shuttingDown) {
                 try {
                     scanTipsForSolidity();
+                    long now = System.currentTimeMillis();
+                    if ((now - lastTime) > 10000L) {
+                        lastTime = now;
+                        log.debug("#Solid/NonSolid: {}/{}",tipsViewModel.solidSize(),tipsViewModel.nonSolidSize());
+                    } 
                 } catch (Exception e) {
                     log.error("Error during solidity scan : {}", e);
                 }
@@ -48,7 +53,6 @@ public class TipsSolidifier {
 
     private void scanTipsForSolidity() throws Exception {
         int size = tipsViewModel.nonSolidSize();
-        log.info("#Solid/NonSolid: {}/{}",tipsViewModel.size()-size,size);
         
         if (size != 0) {
             Hash hash = tipsViewModel.getRandomNonSolidTipHash();

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -34,11 +34,13 @@ public class TipsSolidifier {
             while (!shuttingDown) {
                 try {
                     scanTipsForSolidity();
-                    long now = System.currentTimeMillis();
-                    if ((now - lastTime) > 10000L) {
-                        lastTime = now;
-                        log.debug("#Solid/NonSolid: {}/{}", tipsViewModel.solidSize(), tipsViewModel.nonSolidSize());
-                    } 
+                    if(log.isDebugEnabled()) {
+                        long now = System.currentTimeMillis();
+                        if ((now - lastTime) > 10000L) {
+                            lastTime = now;
+                            log.debug("#Solid/NonSolid: {}/{}", tipsViewModel.solidSize(), tipsViewModel.nonSolidSize());
+                        }
+                    }
                 } catch (Exception e) {
                     log.error("Error during solidity scan : {}", e);
                 }


### PR DESCRIPTION
TipsViewModel is responsible for keeping an accurate picture of the solid and non-solid tips. Currently this view is managed within #TransactionValidator.updateStatus() and a separate TipsSolidifier thread (which is not really efficient since it picks one random non-solid tip at a time each 750ms). This leads to a lag in the tips reality. See also issue #761 and #573. With PR #907 in place, we can manage the TipsViewModel fully within TransactionValidator and keep an accurate and up-to-date picture of the current (solid/non-solid) tips.