### PR TITLE
Make TCPNeighbor send() synchronized to prevent queue overflows

### DIFF
--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -84,11 +84,14 @@ public class TCPNeighbor extends Neighbor {
      */
     @Override
     public void send(DatagramPacket packet) {
-        if (sendQueue.remainingCapacity() == 0) {
-            sendQueue.poll();
+        synchronized (sendQueue) {
+            if (sendQueue.remainingCapacity() == 0) {
+                sendQueue.poll();
+            }
+            byte[] bytes = packet.getData().clone();
+            sendQueue.add(ByteBuffer.wrap(bytes));
         }
-        byte[] bytes = packet.getData().clone();
-        sendQueue.add(ByteBuffer.wrap(bytes));
+            
     }
 
     @Override

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -19,7 +19,7 @@ public class TCPNeighbor extends Neighbor {
     private static final Logger log = LoggerFactory.getLogger(Neighbor.class);
     private int tcpPort;
 
-    private final ArrayBlockingQueue<ByteBuffer> sendQueue = new ArrayBlockingQueue<>(10);
+    private final ArrayBlockingQueue<ByteBuffer> sendQueue = new ArrayBlockingQueue<>(1000);
     private boolean stopped = false;
 
     public TCPNeighbor(InetSocketAddress address, boolean isConfigured) {

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -19,7 +19,7 @@ public class TCPNeighbor extends Neighbor {
     private static final Logger log = LoggerFactory.getLogger(Neighbor.class);
     private int tcpPort;
 
-    private final ArrayBlockingQueue<ByteBuffer> sendQueue = new ArrayBlockingQueue<>(1000);
+    private final ArrayBlockingQueue<ByteBuffer> sendQueue = new ArrayBlockingQueue<>(10);
     private boolean stopped = false;
 
     public TCPNeighbor(InetSocketAddress address, boolean isConfigured) {
@@ -87,7 +87,9 @@ public class TCPNeighbor extends Neighbor {
         synchronized (sendQueue) {
             if (sendQueue.remainingCapacity() == 0) {
                 sendQueue.poll();
+                log.info("Sendqueue full...dropped 1 tx");
             }
+            log.info("Sendqueue size: {}",sendQueue.size());
             byte[] bytes = packet.getData().clone();
             sendQueue.add(ByteBuffer.wrap(bytes));
         }


### PR DESCRIPTION
# Description

```
 @Override
    public void send(DatagramPacket packet) {
        if (sendQueue.remainingCapacity() == 0) {
            sendQueue.poll();
        }
        byte[] bytes = packet.getData().clone();
        sendQueue.add(ByteBuffer.wrap(bytes));
}
```

The sendQueue which is used in #TCPNeighbor.send() is a [ArrayBlockingQueue](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ArrayBlockingQueue.html) with a capacity of 10. I think this method needs a lock so that the poll() and add() are done synchronized (to prevent queue full exceptions), since three threads are calling this send method:
1. spawnReplyToRequestThread: `replyToRequestFromQueue -> replyToRequest -> sendPacket -> neighbor.send(sendingPacket);`
2. spawnTipRequesterThread:  `neighbors.forEach(n -> n.send(tipRequestingPacket));`
3. spawnBroadcasterThread:  `sendPacket ->  neighbor.send(sendingPacket);`

Although #Node.sendPacket() also contains a [lock](https://github.com/iotaledger/iri/blob/08c2cb9a0ff268001c77916c8d123956ddcbd889/src/main/java/com/iota/iri/network/Node.java#L465), the spawnTipRequesterThread does not provide such a mechanism. This can also explain that sometimes intermediate milestones are skipped (because of these dropouts).

Fixes #841 
Fixes #937 
Fixes #837 

It also might be useful to increase the size of this queue, so when people are syncing not too many are dropped.

## Type of change


- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?

No.


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
