### PR TITLE
Added defaults for remote-limt-api so sensitive calls are blocked by …

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -604,7 +604,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
 		//API
         int API_PORT = 14265;
         String API_HOST = "localhost";
-        List<String> REMOTE_LIMIT_API = IotaUtils.createImmutableList("addNeighbors", "getNeighbors", "removeNeighbors");
+        List<String> REMOTE_LIMIT_API = IotaUtils.createImmutableList("addNeighbors", "getNeighbors", "removeNeighbors", "attachToTangle", "interruptAttachingToTangle");
         int MAX_FIND_TRANSACTIONS = 100_000;
         int MAX_REQUESTS_LIST = 1_000;
         int MAX_GET_TRYTES = 10_000;

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -601,7 +601,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     public interface Defaults {
-		//API
+        //API
         int API_PORT = 14265;
         String API_HOST = "localhost";
         List<String> REMOTE_LIMIT_API = IotaUtils.createImmutableList("addNeighbors", "getNeighbors", "removeNeighbors", "attachToTangle", "interruptAttachingToTangle");

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -9,6 +9,7 @@ import com.iota.iri.utils.IotaUtils;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /*
@@ -25,7 +26,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
     //API
     protected int port = Defaults.API_PORT;
     protected String apiHost = Defaults.API_HOST;
-    protected List<String> remoteLimitApi = new ArrayList<>();
+    protected List<String> remoteLimitApi = new ArrayList<>(Arrays.asList(Defaults.REMOTE_LIMIT_API));
     protected int maxFindTransactions = Defaults.MAX_FIND_TRANSACTIONS;
     protected int maxRequestsList = Defaults.MAX_REQUESTS_LIST;
     protected int maxGetTrytes = Defaults.MAX_GET_TRYTES;
@@ -600,9 +601,10 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     public interface Defaults {
-        //API
+		//API
         int API_PORT = 14265;
         String API_HOST = "localhost";
+        String[] REMOTE_LIMIT_API = new String[] {"addNeighbors", "getNeighbors", "removeNeighbors"};
         int MAX_FIND_TRANSACTIONS = 100_000;
         int MAX_REQUESTS_LIST = 1_000;
         int MAX_GET_TRYTES = 10_000;

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -26,7 +26,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
     //API
     protected int port = Defaults.API_PORT;
     protected String apiHost = Defaults.API_HOST;
-    protected List<String> remoteLimitApi = new ArrayList<>(Arrays.asList(Defaults.REMOTE_LIMIT_API));
+    protected List<String> remoteLimitApi = Defaults.REMOTE_LIMIT_API;
     protected int maxFindTransactions = Defaults.MAX_FIND_TRANSACTIONS;
     protected int maxRequestsList = Defaults.MAX_REQUESTS_LIST;
     protected int maxGetTrytes = Defaults.MAX_GET_TRYTES;
@@ -604,7 +604,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
 		//API
         int API_PORT = 14265;
         String API_HOST = "localhost";
-        String[] REMOTE_LIMIT_API = new String[] {"addNeighbors", "getNeighbors", "removeNeighbors"};
+        List<String> REMOTE_LIMIT_API = IotaUtils.createImmutableList("addNeighbors", "getNeighbors", "removeNeighbors");
         int MAX_FIND_TRANSACTIONS = 100_000;
         int MAX_REQUESTS_LIST = 1_000;
         int MAX_GET_TRYTES = 10_000;

--- a/src/main/java/com/iota/iri/utils/IotaUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaUtils.java
@@ -51,4 +51,8 @@ public class IotaUtils {
         }
         return Collections.unmodifiableList(setters);
     }
+
+	public static <T> List<T> createImmutableList(T... values) {
+		return Collections.unmodifiableList(Arrays.asList(values));
+	}
 }


### PR DESCRIPTION
# Description
Provides defaults for keeping an iri node secure when you do not provide flags.

Fixes #306

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Started default IRI node with port parameter -> correct calls are blocked
Started IRI with --remote-api-limit for just blocking getNeighbors, and only that call is blocked

# Checklist:
- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
