### PR TITLE
allocateTritsForTrytes wrong return

### DIFF
--- a/src/main/java/com/iota/iri/utils/Converter.java
+++ b/src/main/java/com/iota/iri/utils/Converter.java
@@ -53,7 +53,7 @@ public class Converter {
     }
 
     public static byte[] allocateTritsForTrytes(int tryteCount) {
-        return new byte[tryteCount * NUMBER_OF_TRITS_IN_A_TRYTE];
+        return allocateBytesForTrits(tryteCount * NUMBER_OF_TRITS_IN_A_TRYTE);
     }
 
     public static void bytes(final byte[] trits, final int srcPos, byte[] dest, int destPos, final int tritsLength) {


### PR DESCRIPTION
returns wrong length of byte[]

# Description

allocateTritsForTrytes method in utils returns wrong length of byte[]

Fixes # (945)

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
