### PR TITLE
`--remote` flag will enable API interface to all hosts

### DIFF
--- a/src/main/java/com/iota/iri/conf/APIConfig.java
+++ b/src/main/java/com/iota/iri/conf/APIConfig.java
@@ -58,5 +58,6 @@ public interface APIConfig extends Config {
         String MAX_REQUESTS_LIST = "The maximal number of parameters one can place in an API call. If the number parameters exceeds this number an error will be returned";
         String MAX_GET_TRYTES = "The maximal number of trytes that may be returned by the \"getTrytes\" API call. If the number of transactions found exceeds this number an error will be returned.";
         String MAX_BODY_LENGTH = "The maximal number of characters the body of an API call may hold. If a request body length exceeds this number an error will be returned.";
+        String REMOTE = "Open the API interface to any host. Equivalent to \"--api-host 0.0.0.0\"";
     }
 }

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -3,6 +3,7 @@ package com.iota.iri.conf;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.iota.iri.IRI;
 import com.iota.iri.utils.IotaUtils;
@@ -31,6 +32,8 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected int maxGetTrytes = Defaults.MAX_GET_TRYTES;
     protected int maxBodyLength = Defaults.MAX_BODY_LENGTH;
     protected String remoteAuth = Defaults.REMOTE_AUTH;
+    //We don't have a REMOTE config but we have a remote flag. We must add a field for JCommander
+    private boolean remote;
 
 
     //Network
@@ -129,6 +132,12 @@ public abstract class BaseIotaConfig implements IotaConfig {
     @Parameter(names = {"--api-host"}, description = APIConfig.Descriptions.API_HOST)
     protected void setApiHost(String apiHost) {
         this.apiHost = apiHost;
+    }
+
+    @JsonIgnore
+    @Parameter(names = {"--remote"}, description = APIConfig.Descriptions.REMOTE)
+    protected void setRemote(boolean remote) {
+        this.apiHost = "0.0.0.0";
     }
 
     @Override

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -1,5 +1,6 @@
 package com.iota.iri.conf;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.iota.iri.utils.IotaUtils;
@@ -108,6 +109,14 @@ public class ConfigTest {
     }
 
     @Test
+    public void testRemoteFlag() {
+        String[] args = {"--remote"};
+        IotaConfig iotaConfig = ConfigFactory.createIotaConfig(false);
+        iotaConfig.parseConfigFromArgs(args);
+        Assert.assertEquals("The api interface should be open to the public", "0.0.0.0", iotaConfig.getApiHost());
+    }
+
+    @Test
     public void testArgsParsingTestnet() {
         String[] args = {
                 "-p", "14000",
@@ -207,6 +216,8 @@ public class ConfigTest {
                 .append("NUMBER_OF_KEYS_IN_A_MILESTONE = 3").append(System.lineSeparator())
                 .append("DONT_VALIDATE_TESTNET_MILESTONE_SIG = true").append(System.lineSeparator())
                 .append("TIPSELECTION_ALPHA = 1.1").append(System.lineSeparator())
+                //doesn't do anything
+                .append("REMOTE")
                 .append("FAKE").append(System.lineSeparator())
                 .append("FAKE2 = lies")
                 .toString();
@@ -227,6 +238,8 @@ public class ConfigTest {
         Assert.assertEquals("TIPSELECTION_ALPHA", 1.1d, iotaConfig.getAlpha(), 0);
         Assert.assertEquals("DONT_VALIDATE_TESTNET_MILESTONE_SIG",
                 iotaConfig.isDontValidateTestnetMilestoneSig(), true);
+        //prove that REMOTE did nothing
+        Assert.assertEquals("API_HOST", iotaConfig.getApiHost(), "localhost");
     }
 
     @Test
@@ -245,6 +258,11 @@ public class ConfigTest {
     }
 
     private String deriveNameFromSetter(Method setter) {
+        JsonIgnore jsonIgnore = setter.getAnnotation(JsonIgnore.class);
+        if (jsonIgnore != null) {
+            return null;
+        }
+
         JsonProperty jsonProperty = setter.getAnnotation(JsonProperty.class);
         //Code works w/o annotation but we wish to enforce its usage
         Assert.assertNotNull("Setter " + setter.getName() + "must have JsonProperty annotation", jsonProperty);


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
The `--remote` flag that opens the api interface to all hosts was accidentally removed. It is now returned

Fixes #952 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit tests were added

- `testRemoteFlag()` ascertains that `api_host == 0.0.0.0`
- `testIniParsingTestnet()` now makes sure that `REMOTE` in INI has no effect (This conforms to backwards compatibility)


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
