### PR TITLE
fix generics in RocksDbPersistenceProvider

### DIFF
--- a/src/main/java/com/iota/iri/storage/FileExportProvider.java
+++ b/src/main/java/com/iota/iri/storage/FileExportProvider.java
@@ -143,7 +143,7 @@ public class FileExportProvider implements PersistenceProvider {
     }
 
     @Override
-    public void deleteBatch(Collection<Pair<Indexable, Class<Persistable>>> models) throws Exception {
+    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception {
 
     }
 

--- a/src/main/java/com/iota/iri/storage/PersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/PersistenceProvider.java
@@ -47,7 +47,7 @@ public interface PersistenceProvider {
      * @param models key value pairs that to be expunged from the db
      * @throws Exception
      */
-    void deleteBatch(Collection<Pair<Indexable, Class<Persistable>>> models) throws Exception;
+    void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception;
 
     void clear(Class<?> column) throws Exception;
     void clearMetadata(Class<?> column) throws Exception;

--- a/src/main/java/com/iota/iri/storage/Tangle.java
+++ b/src/main/java/com/iota/iri/storage/Tangle.java
@@ -67,7 +67,7 @@ public class Tangle {
             return exists;
     }
 
-    public void deleteBatch(Collection<Pair<Indexable, Class<Persistable>>> models) throws Exception {
+    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception {
         for(PersistenceProvider provider: persistenceProviders) {
             provider.deleteBatch(models);
         }

--- a/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
+++ b/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
@@ -166,7 +166,7 @@ public class ZmqPublishProvider implements PersistenceProvider {
     }
 
     @Override
-    public void deleteBatch(Collection<Pair<Indexable, Class<Persistable>>> models) throws Exception {
+    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception {
 
     }
 

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -319,7 +319,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         }
     }
 
-    public void deleteBatch(Collection<Pair<Indexable, Class<Persistable>>> models)
+    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models)
             throws Exception {
         if (CollectionUtils.isNotEmpty(models)) {
             try (WriteBatch writeBatch = new WriteBatch()) {

--- a/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
+++ b/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
@@ -54,14 +54,14 @@ public class RocksDBPersistenceProviderTest {
 
         rocksDBPersistenceProvider.saveBatch(models);
 
-        List<Pair<Indexable, Class<Persistable>>> modelsToDelete = models.stream()
+        List<Pair<Indexable, ? extends Class<? extends Persistable>>> modelsToDelete = models.stream()
                 .filter(entry -> ((IntegerIndex) entry.low).getValue() < 900)
-                .map(entry -> new Pair<>(entry.low, (Class<Persistable>) entry.hi.getClass()))
+                .map(entry -> new Pair<>(entry.low, entry.hi.getClass()))
                 .collect(Collectors.toList());
 
         rocksDBPersistenceProvider.deleteBatch(modelsToDelete);
 
-        for (Pair<Indexable, Class<Persistable>> model : modelsToDelete) {
+        for (Pair<Indexable, ? extends Class<? extends Persistable>> model : modelsToDelete) {
             Assert.assertNull("value at index " + ((IntegerIndex) model.low).getValue() + " should be deleted",
                     rocksDBPersistenceProvider.get(model.hi, model.low).bytes());
         }


### PR DESCRIPTION
# Description

Currently the java generics used in the `deleteBatch()` method forced us to use non trivial casting.
This change eliminates the use of casting. 

Fixes #939 

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
All unit tests pass

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
