### PR TITLE
Test/db benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,19 @@
             <version>1.72</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -352,6 +365,7 @@
                 <configuration>
                     <excludes>
                         <exclude>integration/*.java</exclude>
+                        <exclude>benchmarks/**/*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
                     <target>${java-version}</target>
                     <testSource>${java-version}</testSource>
                     <testTarget>${java-version}</testTarget>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
+++ b/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
@@ -1,0 +1,31 @@
+package com.iota.iri.benchmarks;
+
+import com.iota.iri.benchmarks.dbbenchmark.RocksDbBenchmark;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+public class BenchmarkRunner {
+
+    @Test
+    public void launchDbBenchmarks() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(RocksDbBenchmark.class.getName() + ".*")
+                .mode(Mode.AverageTime)
+                .timeUnit(TimeUnit.MILLISECONDS)
+                .warmupIterations(5)
+                .forks(1)
+                .measurementIterations(10)
+                .shouldFailOnError(true)
+                .shouldDoGC(false)
+                .build();
+
+        //possible to do assertions over run results
+        new Runner(opts).run();
+    }
+}

--- a/src/test/java/com/iota/iri/benchmarks/dbbenchmark/RocksDbBenchmark.java
+++ b/src/test/java/com/iota/iri/benchmarks/dbbenchmark/RocksDbBenchmark.java
@@ -1,0 +1,49 @@
+package com.iota.iri.benchmarks.dbbenchmark;
+
+import com.iota.iri.benchmarks.dbbenchmark.states.EmptyState;
+import com.iota.iri.benchmarks.dbbenchmark.states.FullState;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Transaction;
+import com.iota.iri.storage.Indexable;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.utils.Pair;
+import org.openjdk.jmh.annotations.Benchmark;
+
+
+public class RocksDbBenchmark {
+
+    @Benchmark
+    public void persistOneByOne(EmptyState state) throws Exception {
+        for (TransactionViewModel tvm: state.getTransactions()) {
+            tvm.store(state.getTangle());
+        }
+    }
+
+    @Benchmark
+    public void deleteOneByOne(FullState state) throws Exception {
+        for (TransactionViewModel tvm : state.getTransactions()) {
+            tvm.delete(state.getTangle());
+        }
+    }
+
+    @Benchmark
+    public void dropAll(FullState state) throws Exception {
+        state.getTangle().clearColumn(Transaction.class);
+        state.getTangle().clearMetadata(Transaction.class);
+    }
+
+    @Benchmark
+    public void deleteBatch(FullState state) throws Exception {
+        state.getTangle().deleteBatch(state.getPairs());
+    }
+
+    @Benchmark
+    public void fetchBatch(FullState state) throws Exception {
+        for (Pair<Indexable, ? extends Class<? extends Persistable>> pair : state.getPairs()) {
+            state.getTangle().load(pair.hi, pair.low);
+        }
+    }
+
+
+
+}

--- a/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/DbState.java
+++ b/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/DbState.java
@@ -1,0 +1,89 @@
+package com.iota.iri.benchmarks.dbbenchmark.states;
+
+import com.iota.iri.TransactionTestUtils;
+import com.iota.iri.conf.BaseIotaConfig;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Transaction;
+import com.iota.iri.storage.PersistenceProvider;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import org.apache.commons.io.FileUtils;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@State(Scope.Benchmark)
+public abstract class DbState {
+    private final File dbFolder = new File("db-clean");
+    private final File logFolder = new File("db-log-clean");
+
+    private Tangle tangle;
+    private List<TransactionViewModel> transactions;
+
+    @Param({"10", "100", "500", "1000", "3000"})
+    private int numTxsToTest;
+
+
+    public void setup() throws Exception {
+        System.out.println("-----------------------trial setup--------------------------------");
+        boolean mkdirs = dbFolder.mkdirs();
+        System.out.println("mkdirs success: " + mkdirs );
+        logFolder.mkdirs();
+        PersistenceProvider dbProvider = new RocksDBPersistenceProvider(dbFolder.getPath(), logFolder.getPath(),
+                BaseIotaConfig.Defaults.DB_CACHE_SIZE);
+        dbProvider.init();
+        tangle = new Tangle();
+        tangle.addPersistenceProvider(dbProvider);
+        String trytes = "";
+        System.out.println("numTxsToTest = [" + numTxsToTest + "]");
+        transactions = new ArrayList<>(numTxsToTest);
+        for (int i = 0; i < numTxsToTest; i++) {
+            trytes = nextWord(trytes);
+            TransactionViewModel tvm = TransactionTestUtils.createTransactionWithTrytes(trytes);
+            transactions.add(tvm);
+        }
+        transactions = Collections.unmodifiableList(transactions);
+    }
+
+    public void teardown() throws Exception {
+        System.out.println("-----------------------trial teardown--------------------------------");
+        tangle.shutdown();
+        FileUtils.forceDelete(dbFolder);
+        FileUtils.forceDelete(logFolder);
+    }
+
+    public void clearDb() throws Exception {
+        System.out.println("-----------------------iteration teardown--------------------------------");
+        tangle.clearColumn(Transaction.class);
+        tangle.clearMetadata(Transaction.class);
+    }
+
+    private String nextWord(String trytes) {
+        if ("".equals(trytes)) {
+            return "A";
+        }
+        trytes = trytes.toUpperCase();
+        char[] chars = trytes.toCharArray();
+        for (int i = chars.length -1; i>=0; --i) {
+            if (chars[i] != 'Z') {
+                ++chars[i];
+                return new String(chars);
+            }
+        }
+        return trytes + 'A';
+    }
+
+    public Tangle getTangle() {
+        return tangle;
+    }
+
+    public List<TransactionViewModel> getTransactions() {
+        return transactions;
+    }
+}
+

--- a/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/EmptyState.java
+++ b/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/EmptyState.java
@@ -1,0 +1,26 @@
+package com.iota.iri.benchmarks.dbbenchmark.states;
+
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+public class EmptyState extends DbState {
+
+    @Override
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        super.teardown();
+    }
+
+    @Override
+    @TearDown(Level.Iteration)
+    public void clearDb() throws Exception {
+        super.clearDb();
+    }
+
+}

--- a/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/FullState.java
+++ b/src/test/java/com/iota/iri/benchmarks/dbbenchmark/states/FullState.java
@@ -1,0 +1,52 @@
+package com.iota.iri.benchmarks.dbbenchmark.states;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Transaction;
+import com.iota.iri.storage.Indexable;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.utils.Pair;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@State(Scope.Benchmark)
+public class FullState extends DbState {
+
+    private List<Pair<Indexable, ? extends Class<? extends Persistable>>> pairs;
+
+    @Override
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        super.setup();
+        pairs = getTransactions().stream()
+                .map(tvm -> new Pair<>((Indexable) tvm.getHash(), Transaction.class))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+
+    }
+
+    @Override
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        super.teardown();
+    }
+
+    @Override
+    @TearDown(Level.Iteration)
+    public void clearDb() throws Exception {
+        super.clearDb();
+    }
+
+    @Setup(Level.Iteration)
+    public void populateDb() throws Exception {
+        System.out.println("-----------------------iteration setup--------------------------------");
+        for (TransactionViewModel tvm : getTransactions()) {
+            tvm.store(getTangle());
+        }
+    }
+
+    public List<Pair<Indexable, ? extends Class<? extends Persistable>>> getPairs() {
+        return pairs;
+    }
+}


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
This utilizes JMH (Java Microbenchmark Harness) to profile IRI's db provider performance.

We have the following test:
- Persisting transactions
- Fetching transcations
- Deleting transactions in loop
- Deleting transactions in batch
- Dropping columns

After running `mvn clean install` the easiest way to run is to do: `mvn surefire:test -Dtest=BenchmarkRunner`. I decided not to add them to the `post-integration-test` phase because I imagine we will have buildkite running it in separate.
 
Fixes #924 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
Maven had been run to make sure the benchmark is excluded in the normal built.
The benchmarks themselves were run on my laptop and on a Hetzner machine.


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
