### PR TITLE
Parse case insensitive boolean text

### DIFF
--- a/src/main/java/com/iota/iri/conf/ConfigFactory.java
+++ b/src/main/java/com/iota/iri/conf/ConfigFactory.java
@@ -39,6 +39,7 @@ public class ConfigFactory {
             objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
             objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
             objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
             SimpleModule booleanParser = new SimpleModule("BooleanParser");
             StdDeserializer<Boolean> booleanDeserializer = new CustomBoolDeserializer();

--- a/src/main/java/com/iota/iri/conf/ConfigFactory.java
+++ b/src/main/java/com/iota/iri/conf/ConfigFactory.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.iota.iri.conf.IniDeserializers.CustomBoolDeserializer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,6 +40,10 @@ public class ConfigFactory {
             objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+            SimpleModule booleanParser = new SimpleModule("BooleanParser");
+            StdDeserializer<Boolean> booleanDeserializer = new CustomBoolDeserializer();
+            booleanParser.addDeserializer(Boolean.TYPE, booleanDeserializer);
+            objectMapper.registerModule(booleanParser);
             iotaConfig = objectMapper.convertValue(props, iotaConfigClass);
         }
         return iotaConfig;

--- a/src/main/java/com/iota/iri/conf/ConfigFactory.java
+++ b/src/main/java/com/iota/iri/conf/ConfigFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.iota.iri.conf.IniDeserializers.CustomBoolDeserializer;
+import com.iota.iri.conf.deserializers.CustomBoolDeserializer;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/main/java/com/iota/iri/conf/IniDeserializers/CustomBoolDeserializer.java
+++ b/src/main/java/com/iota/iri/conf/IniDeserializers/CustomBoolDeserializer.java
@@ -1,0 +1,43 @@
+package com.iota.iri.conf.IniDeserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+
+public class CustomBoolDeserializer extends StdDeserializer<Boolean>{
+
+    public CustomBoolDeserializer() {
+        this(Boolean.class);
+    }
+
+    protected CustomBoolDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Boolean deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+        JsonToken t = parser.getCurrentToken();
+        if (t == JsonToken.VALUE_TRUE) return true;
+        if (t == JsonToken.VALUE_FALSE) return false;
+        if (t == JsonToken.VALUE_NULL) {
+            return parseNull(ctxt);
+        }
+        if (t == JsonToken.VALUE_STRING) {
+            String text = parser.getText().trim();
+            if (StringUtils.isEmpty(text)) {
+                return parseNull(ctxt);
+            }
+            return Boolean.valueOf(text);
+        }
+        return false;
+    }
+
+    private Boolean parseNull(DeserializationContext ctxt) throws IOException {
+        _verifyNullForPrimitive(ctxt);
+        return false;
+    }
+}

--- a/src/main/java/com/iota/iri/conf/IniDeserializers/CustomBoolDeserializer.java
+++ b/src/main/java/com/iota/iri/conf/IniDeserializers/CustomBoolDeserializer.java
@@ -21,8 +21,12 @@ public class CustomBoolDeserializer extends StdDeserializer<Boolean>{
     @Override
     public Boolean deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
         JsonToken t = parser.getCurrentToken();
-        if (t == JsonToken.VALUE_TRUE) return true;
-        if (t == JsonToken.VALUE_FALSE) return false;
+        if (t == JsonToken.VALUE_TRUE) {
+            return true;
+        }
+        if (t == JsonToken.VALUE_FALSE) {
+            return false;
+        }
         if (t == JsonToken.VALUE_NULL) {
             return parseNull(ctxt);
         }

--- a/src/main/java/com/iota/iri/conf/deserializers/CustomBoolDeserializer.java
+++ b/src/main/java/com/iota/iri/conf/deserializers/CustomBoolDeserializer.java
@@ -1,4 +1,4 @@
-package com.iota.iri.conf.IniDeserializers;
+package com.iota.iri.conf.deserializers;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -203,7 +203,6 @@ public class ConfigTest {
         Assert.assertNotEquals("MWM", 4, iotaConfig.getMwm());
     }
 
-
     @Test
     public void testIniParsingTestnet() throws Exception {
         String iniContent = new StringBuilder()
@@ -212,8 +211,6 @@ public class ConfigTest {
                 .append("NEIGHBORS = udp://neighbor1 neighbor, tcp://neighbor2").append(System.lineSeparator())
                 .append("ZMQ_ENABLED = true").append(System.lineSeparator())
                 .append("DNS_RESOLUTION_ENABLED = TRUE").append(System.lineSeparator())
-                //this should be false
-                .append("REVALIDATE").append(System.lineSeparator())
                 .append("EXPORT = FALSE").append(System.lineSeparator())
                 .append("P_REMOVE_REQUEST = 0.4").append(System.lineSeparator())
                 .append("MWM = 4").append(System.lineSeparator())
@@ -237,12 +234,13 @@ public class ConfigTest {
                 iotaConfig.getNeighbors());
         Assert.assertEquals("ZMQ_ENABLED", true, iotaConfig.isZmqEnabled());
         Assert.assertEquals("DNS_RESOLUTION_ENABLED", true, iotaConfig.isDnsResolutionEnabled());
-        Assert.assertEquals("REVALIDATE", false, iotaConfig.isRevalidate());
         Assert.assertEquals("EXPORT", false, iotaConfig.isExport());
         //true by default
         Assert.assertEquals("DNS_REFRESHER_ENABLED", true, iotaConfig.isDnsRefresherEnabled());
         //false by default
         Assert.assertEquals("RESCAN", false, iotaConfig.isRescanDb());
+        //false by default
+        Assert.assertEquals("REVALIDATE", false, iotaConfig.isRevalidate());
         Assert.assertEquals("P_REMOVE_REQUEST", 0.4d, iotaConfig.getpRemoveRequest(), 0);
         Assert.assertEquals("MWM", 4, iotaConfig.getMwm());
         Assert.assertEquals("NUMBER_OF_KEYS_IN_A_MILESTONE", 3, iotaConfig.getNumberOfKeysInMilestone());
@@ -251,6 +249,18 @@ public class ConfigTest {
                 iotaConfig.isDontValidateTestnetMilestoneSig(), true);
         //prove that REMOTE did nothing
         Assert.assertEquals("API_HOST", iotaConfig.getApiHost(), "localhost");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidIni() throws IOException {
+        String iniContent = new StringBuilder()
+                .append("[IRI]").append(System.lineSeparator())
+                .append("REVALIDATE")
+                .toString();
+        try (Writer writer = new FileWriter(configFile)) {
+            writer.write(iniContent);
+        }
+        ConfigFactory.createFromFile(configFile, false);
     }
 
     @Test

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -211,6 +211,10 @@ public class ConfigTest {
                 .append("PORT = 17000").append(System.lineSeparator())
                 .append("NEIGHBORS = udp://neighbor1 neighbor, tcp://neighbor2").append(System.lineSeparator())
                 .append("ZMQ_ENABLED = true").append(System.lineSeparator())
+                .append("DNS_RESOLUTION_ENABLED = TRUE").append(System.lineSeparator())
+                //this should be false
+                .append("REVALIDATE").append(System.lineSeparator())
+                .append("EXPORT = FALSE").append(System.lineSeparator())
                 .append("P_REMOVE_REQUEST = 0.4").append(System.lineSeparator())
                 .append("MWM = 4").append(System.lineSeparator())
                 .append("NUMBER_OF_KEYS_IN_A_MILESTONE = 3").append(System.lineSeparator())
@@ -232,6 +236,13 @@ public class ConfigTest {
         Assert.assertEquals("NEIGHBORS", Arrays.asList("udp://neighbor1", "neighbor", "tcp://neighbor2"),
                 iotaConfig.getNeighbors());
         Assert.assertEquals("ZMQ_ENABLED", true, iotaConfig.isZmqEnabled());
+        Assert.assertEquals("DNS_RESOLUTION_ENABLED", true, iotaConfig.isDnsResolutionEnabled());
+        Assert.assertEquals("REVALIDATE", false, iotaConfig.isRevalidate());
+        Assert.assertEquals("EXPORT", false, iotaConfig.isExport());
+        //true by default
+        Assert.assertEquals("DNS_REFRESHER_ENABLED", true, iotaConfig.isDnsRefresherEnabled());
+        //false by default
+        Assert.assertEquals("RESCAN", false, iotaConfig.isRescanDb());
         Assert.assertEquals("P_REMOVE_REQUEST", 0.4d, iotaConfig.getpRemoveRequest(), 0);
         Assert.assertEquals("MWM", 4, iotaConfig.getMwm());
         Assert.assertEquals("NUMBER_OF_KEYS_IN_A_MILESTONE", 3, iotaConfig.getNumberOfKeysInMilestone());


### PR DESCRIPTION
# Description

Fixes case insensitive parsing of boolean configurations.
For example `DNS_RESOLUTION_ENABLED = TRUE` failed with the following error:
```
ERROR com.iota.iri.IRI$IRILauncher - There was a problem reading configuration from file: Cannot deserialize value of type `boolean` from String "TRUE": only "true" or "false" recognized
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.iota.iri.conf.TestnetConfig["DNS_RESOLUTION_ENABLED"])
```

Fixes #724 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?

Unit tests  were added that ascertain

- Test "TRUE"
- Test "FALSE"
- Test that writing the key with no value gives an error (this is backwards compatible behavior).
- Test that defaults value don't change if keys are missing.


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
