### PR TITLE
Feat: added config variables for local snapshots

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -80,6 +80,15 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected double alpha = Defaults.ALPHA;
     private int maxAnalyzedTransactions = Defaults.MAX_ANALYZED_TXS;
 
+    //Snapshot
+    protected boolean localSnapshotsEnabled = Defaults.LOCAL_SNAPSHOTS_ENABLED;
+    protected boolean localSnapshotsPruningEnabled = Defaults.LOCAL_SNAPSHOTS_PRUNING_ENABLED;
+    protected int localSnapshotsPruningDelay = Defaults.LOCAL_SNAPSHOTS_PRUNING_DELAY;
+    protected int localSnapshotsIntervalSynced = Defaults.LOCAL_SNAPSHOTS_INTERVAL_SYNCED;
+    protected int localSnapshotsIntervalUnsynced = Defaults.LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED;
+    protected int localSnapshotsDepth = Defaults.LOCAL_SNAPSHOTS_DEPTH;
+    protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
+
     public BaseIotaConfig() {
         //empty constructor
     }
@@ -454,6 +463,83 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     @Override
+    public boolean getLocalSnapshotsEnabled() {
+        return this.localSnapshotsEnabled;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-enabled"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_ENABLED)
+    protected void setLocalSnapshotsEnabled(boolean localSnapshotsEnabled) {
+        this.localSnapshotsEnabled = localSnapshotsEnabled;
+    }
+
+    @Override
+    public boolean getLocalSnapshotsPruningEnabled() {
+        return this.localSnapshotsPruningEnabled;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-pruning-enabled"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_PRUNING_ENABLED)
+    protected void setLocalSnapshotsPruningEnabled(boolean localSnapshotsPruningEnabled) {
+        this.localSnapshotsPruningEnabled = localSnapshotsPruningEnabled;
+    }
+
+    @Override
+    public int getLocalSnapshotsPruningDelay() {
+        return this.localSnapshotsPruningDelay;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-pruning-delay"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_PRUNING_DELAY)
+    protected void setLocalSnapshotsPruningDelay(int localSnapshotsPruningDelay) {
+        this.localSnapshotsPruningDelay = localSnapshotsPruningDelay;
+    }
+
+    @Override
+    public int getLocalSnapshotsIntervalSynced() {
+        return this.localSnapshotsIntervalSynced;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-interval-synced"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_INTERVAL_SYNCED)
+    protected void setLocalSnapshotsIntervalSynced(int localSnapshotsIntervalSynced) {
+        this.localSnapshotsIntervalSynced = localSnapshotsIntervalSynced;
+    }
+
+    @Override
+    public int getLocalSnapshotsIntervalUnsynced() {
+        return this.localSnapshotsIntervalUnsynced;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-interval-unsynced"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED)
+    protected void setLocalSnapshotsIntervalUnsynced(int localSnapshotsIntervalUnsynced) {
+        this.localSnapshotsIntervalUnsynced = localSnapshotsIntervalUnsynced;
+    }
+
+    @Override
+    public int getLocalSnapshotsDepth() {
+        return this.localSnapshotsDepth;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-depth"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_DEPTH)
+    protected void setLocalSnapshotsDepth(int localSnapshotsDepth) {
+        this.localSnapshotsDepth = localSnapshotsDepth;
+    }
+
+    @Override
+    public String getLocalSnapshotsBasePath() {
+        return this.localSnapshotsBasePath;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--local-snapshots-base-path"}, description = SnapshotConfig.Descriptions.LOCAL_SNAPSHOTS_BASE_PATH)
+    protected void setLocalSnapshotsBasePath(String localSnapshotsBasePath) {
+        this.localSnapshotsBasePath = localSnapshotsBasePath;
+    }
+
+    @Override
     public long getSnapshotTime() {
         return Defaults.GLOBAL_SNAPSHOT_TIME;
     }
@@ -669,6 +755,13 @@ public abstract class BaseIotaConfig implements IotaConfig {
                 "KPWCHICGJZXKE9GSUDXZYUAPLHAKAHYHDXNPHENTERYMMBQOPSQIDENXKLKCEYCPVTZQLEEJVYJZV9BWU";
 
         //Snapshot
+        boolean LOCAL_SNAPSHOTS_ENABLED = true;
+        boolean LOCAL_SNAPSHOTS_PRUNING_ENABLED = false;
+        int LOCAL_SNAPSHOTS_PRUNING_DELAY = 1000;
+        int LOCAL_SNAPSHOTS_INTERVAL_SYNCED = 10;
+        int LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = 5000;
+        String LOCAL_SNAPSHOTS_BASE_PATH = "mainnet";
+        int LOCAL_SNAPSHOTS_DEPTH = 500;
         String SNAPSHOT_FILE = "/snapshotMainnet.txt";
         String SNAPSHOT_SIG_FILE = "/snapshotMainnet.sig";
         String PREVIOUS_EPOCHS_SPENT_ADDRESSES_TXT = "/previousEpochsSpentAddresses.txt";

--- a/src/main/java/com/iota/iri/conf/SnapshotConfig.java
+++ b/src/main/java/com/iota/iri/conf/SnapshotConfig.java
@@ -6,6 +6,36 @@ package com.iota.iri.conf;
 public interface SnapshotConfig extends Config {
 
     /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_ENABLED}
+     */
+    boolean getLocalSnapshotsEnabled();
+
+    /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_PRUNING_ENABLED}
+     */
+    boolean getLocalSnapshotsPruningEnabled();
+
+    /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_PRUNING_DELAY}
+     */
+    int getLocalSnapshotsPruningDelay();
+
+    /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_INTERVAL_SYNCED}
+     */
+    int getLocalSnapshotsIntervalSynced();
+
+    /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED}
+     */
+    int getLocalSnapshotsIntervalUnsynced();
+
+    /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_DEPTH}
+     */
+    int getLocalSnapshotsDepth();
+
+    /**
      * @return {@value Descriptions#SNAPSHOT_TIME}
      */
     long getSnapshotTime();
@@ -26,6 +56,11 @@ public interface SnapshotConfig extends Config {
     int getMilestoneStartIndex();
 
     /**
+     * @return {@value Descriptions#LOCAL_SNAPSHOTS_BASE_PATH}
+     */
+    String getLocalSnapshotsBasePath();
+
+    /**
      * @return {@value Descriptions#NUMBER_OF_KEYS_IN_A_MILESTONE}
      */
     int getNumberOfKeysInMilestone();
@@ -42,6 +77,13 @@ public interface SnapshotConfig extends Config {
 
     interface Descriptions {
 
+        String LOCAL_SNAPSHOTS_ENABLED = "Flag that determines if local snapshots are enabled.";
+        String LOCAL_SNAPSHOTS_PRUNING_ENABLED = "Flag that determines if pruning of old data is enabled.";
+        String LOCAL_SNAPSHOTS_PRUNING_DELAY = "Only prune data that precedes the local snapshot by n milestones.";
+        String LOCAL_SNAPSHOTS_INTERVAL_SYNCED = "Take local snapshots every n milestones if the node is fully synced.";
+        String LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = "Take local snapshots every n milestones if the node is syncing.";
+        String LOCAL_SNAPSHOTS_DEPTH = "Number of milestones to keep.";
+        String LOCAL_SNAPSHOTS_BASE_PATH = "Path to the snapshot files (without file extensions).";
         String SNAPSHOT_TIME = "Epoch time of the last snapshot.";
         String SNAPSHOT_FILE = "Path of the file that contains the state of the ledger at the last snapshot.";
         String SNAPSHOT_SIGNATURE_FILE = "Path to the file that contains a signature for the snapshot file.";

--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -18,6 +18,7 @@ public class TestnetConfig extends BaseIotaConfig {
     protected int numberOfKeysInMilestone = Defaults.KEYS_IN_MILESTONE;
     protected int transactionPacketSize = Defaults.PACKET_SIZE;
     protected int requestHashSize = Defaults.REQUEST_HASH_SIZE;
+    protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
 
     public TestnetConfig() {
         super();
@@ -161,6 +162,7 @@ public class TestnetConfig extends BaseIotaConfig {
     public interface Defaults {
         String COORDINATOR_ADDRESS = "EQQFCZBIHRHWPXKMTOLMYUYPCN9XLMJPYZVFJSAY9FQHCCLWTOLLUGKKMXYFDBOOYFBLBI9WUEILGECYM";
         boolean VALIDATE_MILESTONE_SIG = true;
+        String LOCAL_SNAPSHOTS_BASE_PATH = "testnet";
         String SNAPSHOT_FILE = "/snapshotTestnet.txt";
         int REQUEST_HASH_SIZE = 49;
         String SNAPSHOT_SIG = "/snapshotTestnet.sig";


### PR DESCRIPTION
# Description

This PR introduces the config variables required for local snapshots.

        String LOCAL_SNAPSHOTS_ENABLED = "Flag that determines if local snapshots are enabled.";
        String LOCAL_SNAPSHOTS_PRUNING_ENABLED = "Flag that determines if pruning of old data is enabled.";
        String LOCAL_SNAPSHOTS_PRUNING_DELAY = "Only prune data that precedes the local snapshot by n milestones.";
        String LOCAL_SNAPSHOTS_INTERVAL_SYNCED = "Take local snapshots every n milestones if the node is fully synced.";
        String LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = "Take local snapshots every n milestones if the node is syncing.";
        String LOCAL_SNAPSHOTS_DEPTH = "Number of milestones to keep.";
        String LOCAL_SNAPSHOTS_BASE_PATH = "Path to the snapshot files (without file extensions).";