### PR TITLE
Optimized maven checkstyle plugin settings

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <!--
 
 IOTA checkstyle draft

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
         <java-version>1.8</java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <undertow.version>1.4.6.Final</undertow.version>
+        <!-- Setting the checkstyle.config.location here will make checkstyle use this file in every maven target.
+             This variable will be load by checkstyle plugin automatically. It is more global than setting the
+             configLocation attribute on every maven goal. -->
+        <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
     </properties>
 
     <repositories>
@@ -245,6 +249,8 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- This checkstyle goal will only be invoked during the validate goal or by running "mvn validate"
+                 manually. It indirectly calls "mvn checkstyle:check" -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -254,11 +260,10 @@
                         <id>validate</id>
                         <phase>validate</phase>
                         <configuration>
-                            <configLocation>checkstyle.xml</configLocation>
+                            <configLocation>${checkstyle.config.location}</configLocation>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
-                            <linkXRef>false</linkXRef>
                         </configuration>
                         <goals>
                             <goal>check</goal>
@@ -550,10 +555,12 @@
     </profiles>
     <reporting>
         <plugins>
+            <!-- This checkstyle goal is indirectly called during report generation or by
+                 running "mvn checkstyle:checkstyle" manually-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>


### PR DESCRIPTION
The plugin now reads the local checkstyle.xml as default, instead of using the sun_checks.xml on other targets than "mvn validate".

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

# How Has This Been Tested?

The target "mvn checkstyle:checkstyle" returned more than 5.500 errors reported by checkstyle, because it uses the sun_checks.xml as fallback. I tested the following buid targets and they work correct now:

- mvn validate (worked correct before and after this change)
- mvn checkstyle:check (did not worked before this change)
- mvn checkstyle:checkstyle (did not worked before this change)

Verify the output by running the given maven goals and have a look at the console and the generated xml reports in the target folder.

# Checklist:

- [x ] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
