### PR TITLE
renamed addresses to addressList

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1026,7 +1026,7 @@ public class API {
             instance.milestone.latestSnapshot.rwlock.readLock().unlock();
         }
 
-        final List<String> elements = addresses.stream().map(address -> balances.get(address).toString())
+        final List<String> elements = addressList.stream().map(address -> balances.get(address).toString())
                 .collect(Collectors.toCollection(LinkedList::new));
 
         return GetBalancesResponse.create(elements, hashes.stream().map(h -> h.toString()).collect(Collectors.toList()), index);


### PR DESCRIPTION
Whilest renaming parameters for javadoc purposes, the variable stayed the same.
This happened because map.get just needs an object, so there was no error in the code (so IRI compiled)

Due to this, getBalance was broken. it is now fixed again.