### PR TITLE
travis merge to upstream branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ script:
   # see  https://stackoverflow.com/questions/34405047/how-do-you-merge-into-another-branch-using-travis-with-git-commands?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
   - build_head=$(git rev-parse HEAD) 
   - git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-  - git fetch origin dev
-  - git checkout -f dev
+  - git fetch origin $TRAVIS_BRANCH
+  - git checkout -f $TRAVIS_BRANCH
   - git checkout $build_head
-  - git merge dev
+  - git merge $TRAVIS_BRANCH
   - mvn integration-test -Dlogging-level=INFO
   #run jar sanity tests
   - VERSION=`echo -e 'setns x=http://maven.apache.org/POM/4.0.0\ncat /x:project/x:version/text()' | xmllint --shell pom.xml | grep -v / | tr -d -` 


### PR DESCRIPTION
# Description

Fixes #993 - hard-coded merge to `dev` instead of the upstream branch.
* This merge is needed because Travis does not update PR builds when upstream is changed, and restarting the build does not change the underlying refs.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

See related issue
- Personal branch
- This PR itself

# Open Questions

- should we also not merge in `push` triggers by wrapping explicit merges w/ `test  $TRAVIS_PULL_REQUEST = "true" && ...`?