### PR TITLE
Dev add documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,9 @@
         <java-version>1.8</java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <undertow.version>1.4.6.Final</undertow.version>
+        <javadoc-version>3.0.1</javadoc-version>
+        <checkstyle-version>3.0.0</checkstyle-version>
+
         <!-- Setting the checkstyle.config.location here will make checkstyle use this file in every maven target.
              This variable will be load by checkstyle plugin automatically. It is more global than setting the
              configLocation attribute on every maven goal. -->
@@ -210,10 +213,12 @@
                     <useIncrementalCompilation>false</useIncrementalCompilation>
                 </configuration>
             </plugin>
+            <!-- The javadoc plugin can be called by running "mvn javadoc:javadoc" and will generate the classic javadoc
+                 files in folder "target/site/apidocs" -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${javadoc-version}</version>
                 <configuration>
                     <!-- These tags are not defined by the default javadoc configuration. They must be defined here
                          or maven will break with unknown parameter @implNote for example. -->
@@ -275,7 +280,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${checkstyle-version}</version>
                 <executions>
                     <execution>
                         <id>validate</id>
@@ -579,12 +584,24 @@
          It can be called manually by running mvn clean site -->
     <reporting>
         <plugins>
+            <!-- The site plugin can be called by "mvn site". This is the classic configuration and recommended
+                 configuration format. for more details visit:
+
+                 https://maven.apache.org/plugins/maven-site-plugin/maven-3.html and
+                 https://maven.apache.org/plugins/maven-site-plugin/usage.html
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>
+
             <!-- This checkstyle goal is indirectly called during report generation or by
                  running "mvn checkstyle:checkstyle" manually-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${checkstyle-version}</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -592,6 +609,36 @@
                         </reports>
                     </reportSet>
                 </reportSets>
+            </plugin>
+
+            <!-- The javadoc for the report can be called by running "mvn site" and will generate the the iota
+                 documentation in Markdown format. To compile this report you need the iri-mdx-doclet files from:
+                 https://github.com/iotaledger/iri-mdx-doclet. Follow the documentation on the github site to compile
+                 and install the iri-mdx-doclet locally in your maven repository.
+
+                 Note: If you need the classic api documentation run "mvn javadoc:javadoc" instead.
+                 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadoc-version}</version>
+                <configuration>
+
+                    <!-- This dependency can be found at: https://github.com/iotaledger/iri-mdx-doclet -->
+                    <doclet>com.iota.mdxdoclet.MDXDoclet</doclet>
+                    <sourcepath>src/main/java</sourcepath>
+                    <useStandardDocletOptions>false</useStandardDocletOptions>
+                    <additionalOptions>
+                        <additionalOption>-version "${project.version}"</additionalOption>
+                    </additionalOptions>
+                    <quiet>true</quiet>
+                    <docletArtifact>
+                        <groupId>com.iota</groupId>
+                        <artifactId>mdxdoclet</artifactId>
+                        <version>0.1</version>
+                    </docletArtifact>
+                </configuration>
+                
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -207,24 +207,31 @@
                 </configuration>
             </plugin>
             <plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-javadoc-plugin</artifactId>
-			    <version>3.0.0</version>
-			    <configuration>
-			        <doclet>com.iota.mdxdoclet.MDXDoclet</doclet>
-			        <sourcepath>src/main/java</sourcepath>
-			        <useStandardDocletOptions>false</useStandardDocletOptions>
-			        <additionalOptions>
-			            <additionalOption>-version "${project.version}"</additionalOption>
-			        </additionalOptions>
-			        <quiet>true</quiet>
-			        <docletArtifact>
-			            <groupId>com.iota</groupId>
-			            <artifactId>mdxdoclet</artifactId>
-			            <version>0.1</version>
-			        </docletArtifact>
-			    </configuration>
-			</plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <!-- These tags are not defined by the default javadoc configuration. They must be defined here
+                         or maven will break with unknown parameter @implNote for example. -->
+                    <tags>
+                        <tag>
+                            <name>apiNote</name>
+                            <placement>a</placement>
+                            <head>API Note:</head>
+                        </tag>
+                        <tag>
+                            <name>implSpec</name>
+                            <placement>a</placement>
+                            <head>Implementation Requirements:</head>
+                        </tag>
+                        <tag>
+                            <name>implNote</name>
+                            <placement>a</placement>
+                            <head>Implementation Note:</head>
+                        </tag>
+                    </tags>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -563,6 +570,8 @@
             </build>
         </profile>
     </profiles>
+    <!-- The reporting section is called during the maven site goal.
+         It can be called manually by running mvn clean site -->
     <reporting>
         <plugins>
             <plugin>

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -33,8 +33,8 @@ public class IRI {
 
     /**
      * Reads the logging configuration file and logging level from system properties. You can set this values as
-     * arguments to the jvm by passing "-Dlogback.configurationFile=/path/to/config.xml -Dlogging-level=DEBUG" to
-     * the Java VM. If no system properties are specified the logback default values and logging-level INFO will
+     * arguments to the jvm by passing <code>-Dlogback.configurationFile=/path/to/config.xml -Dlogging-level=DEBUG</code>
+     * to the Java VM. If no system properties are specified the logback default values and logging-level INFO will
      * be used.
      */
     private static void configureLogging() {
@@ -157,6 +157,15 @@ public class IRI {
             return iotaConfig;
         }
 
+        /**
+         * Parses the command line arguments for a config file that can be provided by parameter <code>-c</code>
+         * or parameter <code>--config</code>. If no filename was provided we fall back to <code>iota.ini</code> file.
+         * If no <code>iota.ini</code> file can be found return null.
+         *
+         * @param args command line arguments passed to main method
+         * @return File given by command line argument. If no file was provided return <code>iota.ini</code>. Returns
+         * null, if <code>iota.ini</code> does not exist.
+         */
         private static File chooseConfigFile(String[] args) {
             int index = Math.max(ArrayUtils.indexOf(args, "-c"), ArrayUtils.indexOf(args, "--config"));
             if (index != -1) {

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -31,6 +31,12 @@ public class IRI {
         IRILauncher.main(args);
     }
 
+    /**
+     * Reads the logging configuration file and logging level from system properties. You can set this values as
+     * arguments to the jvm by passing "-Dlogback.configurationFile=/path/to/config.xml -Dlogging-level=DEBUG" to
+     * the Java VM. If no system properties are specified the logback default values and logging-level INFO will
+     * be used.
+     */
     private static void configureLogging() {
         String config = System.getProperty("logback.configurationFile");
         String level = System.getProperty("logging-level", "").toUpperCase();

--- a/src/main/java/com/iota/iri/LedgerValidator.java
+++ b/src/main/java/com/iota/iri/LedgerValidator.java
@@ -48,7 +48,7 @@ public class LedgerValidator {
      * @param latestSnapshotIndex                index of the latest snapshot to traverse to
      * @param milestone                          marker to indicate whether to stop only at confirmed transactions
      * @return {state}                           the addresses that have a balance changed since the last diff check
-     * @throws Exception
+     * @throws Exception                         if transaction could not be found by hash
      */
     public Map<Hash,Long> getLatestDiff(final Set<Hash> visitedNonMilestoneSubtangleHashes, Hash tip, int latestSnapshotIndex, boolean milestone) throws Exception {
         Map<Hash, Long> state = new HashMap<>();
@@ -135,7 +135,7 @@ public class LedgerValidator {
      * // old @param hash start of the update tree
      * @param hash tail to traverse from
      * @param index milestone index
-     * @throws Exception
+     * @throws Exception if transaction could not be loaded from hash
      */
     private void updateSnapshotMilestone(Hash hash, int index) throws Exception {
         Set<Hash> visitedHashes = new HashSet<>();
@@ -162,8 +162,8 @@ public class LedgerValidator {
     /**
      * Descends through transactions, trunk and branch, beginning at {tip}, until it reaches a transaction marked as
      * confirmed, or until it reaches a transaction that has already been added to the transient consistent set.
-     * @param tip
-     * @throws Exception
+     * @param tip the tip for that a confirmed/already added transaction should be found.
+     * @throws Exception if transaction could not be found by hash.
      */
     private void updateConsistentHashes(final Set<Hash> visitedHashes, Hash tip, int index) throws Exception {
         final Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(tip));
@@ -185,7 +185,7 @@ public class LedgerValidator {
      * perhaps by database corruption, it will delete the milestone confirmed and all that follow.
      * It then starts at the earliest consistent milestone index with a confirmed, and analyzes the tangle until it
      * either reaches the latest solid subtangle milestone, or until it reaches an inconsistent milestone.
-     * @throws Exception
+     * @throws Exception if snapshot could not be build.
      */
     protected void init() throws Exception {
         MilestoneViewModel latestConsistentMilestone = buildSnapshot();
@@ -202,7 +202,7 @@ public class LedgerValidator {
      * solid milestone confirmed. It gets the earliest confirmed, and while checking for consistency, patches the next
      * newest confirmed diff into its map.
      * @return              the most recent consistent milestone with a confirmed.
-     * @throws Exception
+     * @throws Exception    if first milestone could not be found in tangle.
      */
     private MilestoneViewModel buildSnapshot() throws Exception {
         MilestoneViewModel consistentMilestone = null;

--- a/src/main/java/com/iota/iri/Snapshot.java
+++ b/src/main/java/com/iota/iri/Snapshot.java
@@ -34,7 +34,7 @@ public class Snapshot {
             String snapshotFile = config.getSnapshotFile();
             if (!config.isTestnet() && !SignedFiles.isFileSignatureValid(snapshotFile, config.getSnapshotSignatureFile(),
                     SNAPSHOT_PUBKEY, SNAPSHOT_PUBKEY_DEPTH, SNAPSHOT_INDEX)) {
-                throw new IOException("Snapshot signature failed.");
+                throw new IllegalStateException("Snapshot signature failed.");
             }
             Map<Hash, Long> initialState = initInitialState(snapshotFile);
             initialSnapshot = new Snapshot(initialState, 0);
@@ -75,7 +75,8 @@ public class Snapshot {
         try (InputStream snapshotStream = getSnapshotStream(snapshotFile)) {
             bufferedInputStream = new BufferedInputStream(snapshotStream);
             BufferedReader reader = new BufferedReader(new InputStreamReader(bufferedInputStream));
-            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+            String line;
+            while ((line = reader.readLine()) != null) {
                 String[] parts = line.split(";", 2);
                 if (parts.length >= 2) {
                     String key = parts[0];
@@ -149,7 +150,7 @@ public class Snapshot {
             if (entry.getValue() <= 0) {
 
                 if (entry.getValue() < 0) {
-                    log.info("Skipping negative value for address: %s: %d", entry.getKey(), entry.getValue());
+                    log.info("Skipping negative value for address: {}: {}", entry.getKey(), entry.getValue());
                     return false;
                 }
 

--- a/src/main/java/com/iota/iri/conf/ConfigFactory.java
+++ b/src/main/java/com/iota/iri/conf/ConfigFactory.java
@@ -10,11 +10,21 @@ import com.iota.iri.conf.deserializers.CustomBoolDeserializer;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
+/**
+ * Creates the global {@link IotaConfig} object with iri specific settings.
+ */
 public class ConfigFactory {
 
+    /**
+     * Creates the {@link IotaConfig} object for {@link TestnetConfig} or {@link MainnetConfig}.
+     *
+     * @param isTestnet true if {@link TestnetConfig} should be created.
+     * @return return the {@link IotaConfig} configuration.
+     */
     public static IotaConfig createIotaConfig(boolean isTestnet) {
         IotaConfig iotaConfig;
         if (isTestnet) {
@@ -26,8 +36,18 @@ public class ConfigFactory {
         return iotaConfig;
     }
 
-    public static IotaConfig createFromFile(File configFile, boolean testnet) throws IOException,
-            IllegalArgumentException {
+    /**
+     * Creates the {@link IotaConfig} object for {@link TestnetConfig} or {@link MainnetConfig} from config file. Parse
+     * the config file for <code>TESTNET=true</code>. If <code>TESTNET=true</code> is found we creates the
+     * {@link TestnetConfig} object, else creates the {@link MainnetConfig}.
+     *
+     * @param configFile A property file with configuration options.
+     * @param testnet When true a {@link TestnetConfig} is created.
+     * @return return the {@link IotaConfig} configuration.
+     *
+     * @throws IOException When config file could not be found.
+     */
+    public static IotaConfig createFromFile(File configFile, boolean testnet) throws IOException {
         IotaConfig iotaConfig;
 
         try (FileInputStream confStream = new FileInputStream(configFile)) {

--- a/src/main/java/com/iota/iri/conf/SnapshotConfig.java
+++ b/src/main/java/com/iota/iri/conf/SnapshotConfig.java
@@ -41,7 +41,7 @@ public interface SnapshotConfig extends Config {
     long getSnapshotTime();
 
     /**
-     * return {@value Descriptions#SNAPSHOT_FILE}
+     * @return {@value Descriptions#SNAPSHOT_FILE}
      */
     String getSnapshotFile();
 

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -629,6 +629,7 @@ public class API {
       * @param depth Number of bundles to go back to determine the transactions for approval.
       * @param reference Hash of transaction to start random-walk from, used to make sure the tips returned reference a given transaction in their past.
       * @return {@link com.iota.iri.service.dto.GetTransactionsToApproveResponse}
+      * @throws Exception if DB fails to retrieve transaction to be approved.
       **/
     public synchronized List<Hash> getTransactionsToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
 
@@ -669,6 +670,7 @@ public class API {
       * The trytes to be used for this call are returned by <code>attachToTangle</code>.
       *
       * @param trytes List of raw data of transactions to be rebroadcast.
+      * @throws Exception if transaction could not be stored.
       **/
     public void storeTransactionsStatement(final List<String> trytes) throws Exception {
         final List<TransactionViewModel> elements = new LinkedList<>();

--- a/src/main/java/com/iota/iri/service/ValidationException.java
+++ b/src/main/java/com/iota/iri/service/ValidationException.java
@@ -11,6 +11,7 @@ public class ValidationException extends Exception {
 
     /**
      * Initializes a new instance of the ValidationException with the specified detail message.
+     * @param msg message shown in exception details.
      */
     public ValidationException(String msg) {
         super(msg);

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -12,7 +12,7 @@ public class GetNeighborsResponse extends AbstractResponse {
      *  numberOfAllTransactions, numberOfRandomTransactionRequests, 
      *  numberOfNewTransactions, numberOfInvalidTransactions, numberOfSentTransactions
      * 
-     * @see {@link com.iota.iri.service.dto.GetNeighborsResponse.Neighbor}
+     * @see com.iota.iri.service.dto.GetNeighborsResponse.Neighbor
      * @return the neighbors
      */
     public Neighbor[] getNeighbors() {

--- a/src/main/java/com/iota/iri/storage/PersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/PersistenceProvider.java
@@ -44,8 +44,8 @@ public interface PersistenceProvider {
 
     /**
      * Atomically delete all {@code models}.
-     * @param models key value pairs that to be expunged from the db
-     * @throws Exception
+     * @param models key value pairs that to be expunged from the db.
+     * @throws Exception if data could not be expunged from the db.
      */
     void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception;
 

--- a/src/main/java/com/iota/iri/utils/collections/interfaces/UnIterableMap.java
+++ b/src/main/java/com/iota/iri/utils/collections/interfaces/UnIterableMap.java
@@ -3,7 +3,6 @@ package com.iota.iri.utils.collections.interfaces;
 import java.util.Collection;
 import java.util.Map;
 
-
 /**
  * Similar to {@link Map} but hides key retrieval functionality.
  * Thus one can't iterate over key or entries.
@@ -14,50 +13,62 @@ import java.util.Map;
  */
 public interface UnIterableMap<K,V> {
 
-
     /**
-     * {See {@link Map#size()}}
+     * @see Map#size()
+     * @return {@link Map#size()}
      */
     int size();
 
     /**
-     * {See {@link Map#isEmpty()}}
+     * @see Map#isEmpty()
+     * @return {@link Map#isEmpty()}
      */
     boolean isEmpty();
 
     /**
-     * {See {@link Map#containsKey(Object)}}
+     * @see Map#containsKey(Object)
+     * @param key {@link Map#containsKey(Object)}
+     * @return {@link Map#containsKey(Object)}
      */
     boolean containsKey(K key);
 
     /**
-     * {See {@link Map#containsValue(Object)}}
+     * @see Map#containsValue(Object)
+     * @param value {@link Map#containsValue(Object)}
+     * @return {@link Map#containsValue(Object)}
      */
     boolean containsValue(V value);
 
     /**
-     *
-     * {See {@link Map#get}}
+     * @see Map#get(Object)
+     * @param key {@link Map#get(Object)}
+     * @return {@link Map#get(Object)}
      */
     V get(K key);
 
     /**
-     * {See {@link Map#put}
+     * @see Map#put(Object, Object)
+     * @param key {@link Map#put(Object, Object)}
+     * @param value {@link Map#put(Object, Object)}
+     * @return {@link Map#put(Object, Object)}
      */
     V put(K key, V value);
 
     /**
-     * {See {@link Map#keySet()}}
+     * @see Map#remove(Object)
+     * @param key {@link Map#remove(Object)}
+     * @return {@link Map#remove(Object)}
      */
     V remove(K key);
 
     /**
-     * {See {@link Map#clear()}}
+     * @see Map#clear()
      */
     void clear();
 
     /**
-     * {See {@link Map#values}
+     * @see Map#values()
+     * @return {@link Map#values()}
      */
     Collection<V> values();
 }

--- a/src/test/java/com/iota/iri/conf/ConfigFactoryTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigFactoryTest.java
@@ -1,0 +1,93 @@
+package com.iota.iri.conf;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class ConfigFactoryTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void createIotaConfigTestnet() {
+        IotaConfig iotaConfig = ConfigFactory.createIotaConfig(true);
+        assertTrue(iotaConfig instanceof TestnetConfig);
+        assertTrue(iotaConfig.isTestnet());
+    }
+
+    @Test
+    public void createIotaConfigMainnet() {
+        IotaConfig iotaConfig = ConfigFactory.createIotaConfig(false);
+        assertTrue(iotaConfig instanceof MainnetConfig);
+        assertFalse(iotaConfig.isTestnet());
+    }
+
+    @Test
+    public void createFromFileTestnetWithTestnetTrueAndFalse() throws IOException {
+        // lets assume in our configFile is TESTNET=true
+        File configFile = createTestnetConfigFile("true");
+
+        // but the parameter is set to testnet=false
+        IotaConfig iotaConfig = ConfigFactory.createFromFile(configFile, false);
+        assertTrue(iotaConfig instanceof TestnetConfig);
+        assertTrue(iotaConfig.isTestnet());
+    }
+
+    @Test
+    public void createFromFileTestnetWithTestnetTrueAndTrue() throws IOException {
+        // lets assume in our configFile is TESTNET=true
+        File configFile = createTestnetConfigFile("true");
+
+        // but the parameter is set to testnet=true
+        IotaConfig iotaConfig = ConfigFactory.createFromFile(configFile, true);
+        assertTrue(iotaConfig instanceof TestnetConfig);
+        assertTrue(iotaConfig.isTestnet());
+    }
+
+    @Test
+    public void createFromFileTestnetWithTestnetFalseAndTrue() throws IOException {
+        // lets assume in our configFile is TESTNET=false
+        File configFile = createTestnetConfigFile("false");
+
+        // but the parameter is set to testnet=true
+        IotaConfig iotaConfig = ConfigFactory.createFromFile(configFile, true);
+        assertTrue(iotaConfig instanceof TestnetConfig);
+        assertTrue(iotaConfig.isTestnet());
+    }
+
+    @Test
+    public void createFromFileTestnetWithTestnetFalseAndFalse() throws IOException {
+        // lets assume in our configFile is TESTNET=false
+        File configFile = createTestnetConfigFile("false");
+
+        // but the parameter is set to testnet=true
+        IotaConfig iotaConfig = ConfigFactory.createFromFile(configFile, false);
+        assertTrue(iotaConfig instanceof MainnetConfig);
+        assertFalse(iotaConfig.isTestnet());
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void createFromFileTestnetWithFileNotFound() throws IOException {
+        File configFile = new File("doesNotExist.ini");
+        ConfigFactory.createFromFile(configFile, false);
+    }
+
+    private File createTestnetConfigFile(String testnet) throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty("TESTNET", testnet);
+        File configFile = folder.newFile("myCustomIotaConfig.ini");
+        FileOutputStream fileOutputStream = new FileOutputStream(configFile);
+        properties.store(fileOutputStream, "Testconfig file created by Unit test!");
+        fileOutputStream.close();
+        return configFile;
+    }
+}


### PR DESCRIPTION
# Description

I fixed the generation of javadoc generation. The maven goal "mvn javadoc:javadoc" does not work before. There where javadoc errors/warnings in the source code and no report was generated.

This PR does two things:
`mvn clean javadoc:javadoc` generates the classic html **javadoc** files in `target/site/apidocs`
`mvn clean site ` generates the iota project **markdown** files in `target/site/apidocs`

Fixes #996 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

# How Has This Been Tested?

## Test 1:

- Run `mvn clean javadoc:javadoc`

Expected result:
A folder `target/site/apidocs` must be generated and must include **javadoc** html files.

## Test 2:

- Prerequisites - iri-mdx-doclet (https://github.com/iotaledger/iri-mdx-doclet)
- Run `mvn clean site`

Expected result:
A folder `target/site/apidocs` must be generated and must include javadoc **markdown** files.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
