### PR TITLE
Refactor: Moved export folder creation from IRI to FileExportProvider

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -47,6 +47,7 @@ public class IRI {
                 break;
             default:
                 level = "INFO";
+                break;
         }
         System.getProperties().put("logging-level", level);
         System.out.println("Logging - property 'logging-level' set to: [" + level + "]");
@@ -70,27 +71,6 @@ public class IRI {
             ixi = new IXI(iota);
             api = new API(iota, ixi);
             shutdownHook();
-
-            if (config.isExport()) {
-                File exportDir = new File("export");
-                if (!exportDir.exists()) {
-                    log.info("Create directory 'export'");
-                    try {
-                        exportDir.mkdir();
-                    } catch (SecurityException e) {
-                        log.error("Could not create directory", e);
-                    }
-                }
-                exportDir = new File("export-solid");
-                if (!exportDir.exists()) {
-                    log.info("Create directory 'export-solid'");
-                    try {
-                        exportDir.mkdir();
-                    } catch (SecurityException e) {
-                        log.error("Could not create directory", e);
-                    }
-                }
-            }
 
             try {
                 iota.init();

--- a/src/main/java/com/iota/iri/storage/FileExportProvider.java
+++ b/src/main/java/com/iota/iri/storage/FileExportProvider.java
@@ -6,12 +6,13 @@ import com.iota.iri.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -22,32 +23,50 @@ import static com.iota.iri.controllers.TransactionViewModel.TRINARY_SIZE;
  */
 public class FileExportProvider implements PersistenceProvider {
     private static final Logger log = LoggerFactory.getLogger(FileExportProvider.class);
+    private static final String FOLDER_EXPORT = "export";
+    private static final String FOLDER_EXPORT_SOLID = "export-solid";
     private static long lastFileNumber = 0L;
-    private final static Object lock = new Object();
+    private static final Object lock = new Object();
+
+    Path createDirectory(Path exportPath) {
+        if (exportPath == null) {
+            throw new IllegalArgumentException("exportPath should not be null");
+        }
+        if (!Files.exists(exportPath)) {
+            log.info("Create directory '{}'", exportPath);
+            try {
+                return Files.createDirectory(exportPath);
+            } catch (IOException e) {
+                log.error("Could not create directory", e);
+            }
+        }
+        return exportPath;
+    }
 
     @Override
-    public void init() throws Exception {
-
+    public void init() {
+        createDirectory(Paths.get(FOLDER_EXPORT));
+        createDirectory(Paths.get(FOLDER_EXPORT_SOLID));
     }
 
     @Override
     public boolean isAvailable() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void shutdown() {
-
+        // not yet implemented
     }
 
     @Override
-    public boolean save(Persistable model, Indexable index) throws Exception {
+    public boolean save(Persistable model, Indexable index) {
         return false;
     }
 
     @Override
-    public void delete(Class<?> model, Indexable index) throws Exception {
-
+    public void delete(Class<?> model, Indexable index) {
+        // not yet implemented
     }
 
     @Override
@@ -61,22 +80,12 @@ public class FileExportProvider implements PersistenceProvider {
             log.error("Model is not instance of Transaction");
             return false;
         }
-
-        // create export folder and export file
-        File exportFile = new File("export", String.valueOf(getFileNumber()) + ".tx");
-        if(!exportFile.getParentFile().exists() && exportFile.getParentFile().mkdirs()) {
-            log.error("Export folder can not be created");
-            return false;
-        }
-
-        // print data to file
         Transaction transaction = ((Transaction) model);
+        File exportFile = new File(FOLDER_EXPORT, String.valueOf(getFileNumber()) + ".tx");
         try(PrintWriter writer = new PrintWriter(exportFile, StandardCharsets.UTF_8.name())) {
             writer.println(index.toString());
             writer.println(Converter.trytes(trits(transaction)));
             writer.println(transaction.sender);
-            writer.println("Height: ");
-
             return true;
         } catch (UnsupportedEncodingException | FileNotFoundException e) {
             log.error("File export failed", e);
@@ -87,82 +96,78 @@ public class FileExportProvider implements PersistenceProvider {
     }
 
     @Override
-    public boolean exists(Class<?> model, Indexable key) throws Exception {
+    public boolean exists(Class<?> model, Indexable key) {
         return false;
     }
 
     @Override
-    public Pair<Indexable, Persistable> latest(Class<?> model, Class<?> indexModel) throws Exception {
+    public Pair<Indexable, Persistable> latest(Class<?> model, Class<?> indexModel) {
         return null;
     }
 
     @Override
-    public Set<Indexable> keysWithMissingReferences(Class<?> modelClass, Class<?> other) throws Exception {
+    public Set<Indexable> keysWithMissingReferences(Class<?> modelClass, Class<?> other) {
+        return new HashSet<>();
+    }
+
+    @Override
+    public Persistable get(Class<?> model, Indexable index) {
         return null;
     }
 
     @Override
-    public Persistable get(Class<?> model, Indexable index) throws Exception {
-        return null;
-    }
-
-    @Override
-    public boolean mayExist(Class<?> model, Indexable index) throws Exception {
+    public boolean mayExist(Class<?> model, Indexable index) {
         return false;
     }
 
     @Override
-    public long count(Class<?> model) throws Exception {
+    public long count(Class<?> model) {
         return 0;
     }
 
     @Override
     public Set<Indexable> keysStartingWith(Class<?> modelClass, byte[] value) {
+        return new HashSet<>();
+    }
+
+    @Override
+    public Persistable seek(Class<?> model, byte[] key) {
         return null;
     }
 
     @Override
-    public Persistable seek(Class<?> model, byte[] key) throws Exception {
+    public Pair<Indexable, Persistable> next(Class<?> model, Indexable index) {
         return null;
     }
 
     @Override
-    public Pair<Indexable, Persistable> next(Class<?> model, Indexable index) throws Exception {
+    public Pair<Indexable, Persistable> previous(Class<?> model, Indexable index) {
         return null;
     }
 
     @Override
-    public Pair<Indexable, Persistable> previous(Class<?> model, Indexable index) throws Exception {
+    public Pair<Indexable, Persistable> first(Class<?> model, Class<?> indexModel) {
         return null;
     }
 
     @Override
-    public Pair<Indexable, Persistable> first(Class<?> model, Class<?> indexModel) throws Exception {
-        return null;
-    }
-
-    public boolean merge(Persistable model, Indexable index) throws Exception {
+    public boolean saveBatch(List<Pair<Indexable, Persistable>> models) {
         return false;
     }
 
     @Override
-    public boolean saveBatch(List<Pair<Indexable, Persistable>> models) throws Exception {
-        return false;
+    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) {
+        // not yet implemented
     }
 
     @Override
-    public void deleteBatch(Collection<Pair<Indexable, ? extends Class<? extends Persistable>>> models) throws Exception {
-
+    public void clear(Class<?> column) {
+        // not yet implemented
     }
 
     @Override
-    public void clear(Class<?> column) throws Exception {
-
-    }
-
-    @Override
-    public void clearMetadata(Class<?> column) throws Exception {
-
+    public void clearMetadata(Class<?> column) {
+        // not yet implemented
     }
 
     private static long getFileNumber() {

--- a/src/main/java/com/iota/iri/storage/FileExportProvider.java
+++ b/src/main/java/com/iota/iri/storage/FileExportProvider.java
@@ -51,7 +51,7 @@ public class FileExportProvider implements PersistenceProvider {
 
     @Override
     public boolean isAvailable() {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     @Override

--- a/src/test/java/com/iota/iri/storage/FileExportProviderTest.java
+++ b/src/test/java/com/iota/iri/storage/FileExportProviderTest.java
@@ -1,0 +1,49 @@
+package com.iota.iri.storage;
+
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.Transaction;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FileExportProviderTest {
+
+    FileExportProvider fileExportProvider;
+
+    @Before
+    public void setUp() {
+        this.fileExportProvider = new FileExportProvider();
+    }
+
+    @Test
+    public void updateSenderIsNull() {
+        assertFalse(this.fileExportProvider.update(null, null, null));
+    }
+
+    @Test
+    public void updateWithoutSender() {
+        assertFalse(this.fileExportProvider.update(null, null, "failString"));
+    }
+
+    @Test
+    public void updateWithoutTransaction() {
+        assertFalse(this.fileExportProvider.update(null, null, "sender"));
+    }
+
+    @Test
+    public void update() {
+        Transaction transaction = new Transaction();
+        transaction.sender = "testSender";
+        Indexable index = new Hash("D9XCNSCCAJGLWSQOQAQNFWANPYKYMCQ9VCOMROLDVLONPPLDFVPIZNAPVZLQMPFYJPAHUKIAEKNCQIYJZ");
+        assertTrue(this.fileExportProvider.update(transaction, index, "sender"));
+    }
+
+    @Test
+    public void updateException() {
+        Transaction transaction = new Transaction();
+        transaction.sender = "testSender";
+        assertFalse(this.fileExportProvider.update(transaction, null, "sender"));
+    }
+
+}

--- a/src/test/java/com/iota/iri/storage/FileExportProviderTest.java
+++ b/src/test/java/com/iota/iri/storage/FileExportProviderTest.java
@@ -3,17 +3,27 @@ package com.iota.iri.storage;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.Transaction;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.*;
 
 public class FileExportProviderTest {
-
-    FileExportProvider fileExportProvider;
+    @Rule
+    public TemporaryFolder temporaryFolder = new  TemporaryFolder();
+    private FileExportProvider fileExportProvider;
 
     @Before
     public void setUp() {
         this.fileExportProvider = new FileExportProvider();
+        this.fileExportProvider.init();
     }
 
     @Test
@@ -44,6 +54,26 @@ public class FileExportProviderTest {
         Transaction transaction = new Transaction();
         transaction.sender = "testSender";
         assertFalse(this.fileExportProvider.update(transaction, null, "sender"));
+    }
+
+    @Test
+    public void createDirectory() throws IOException {
+        String tempPath = new File(temporaryFolder.getRoot().getPath(), "testFolder").getPath();
+        Path newFolder = this.fileExportProvider.createDirectory(Paths.get(tempPath));
+        assertTrue(Files.exists(newFolder));
+    }
+
+    @Test
+    public void createDirectoryAlreadyExists() {
+        String tempPath = new File(temporaryFolder.getRoot().getPath(), "testFolderExists").getPath();
+        Path newFolder = this.fileExportProvider.createDirectory(Paths.get(tempPath));
+        Path existingFolder = this.fileExportProvider.createDirectory(newFolder);
+        assertSame(existingFolder, newFolder);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createDirectoryWithNull() {
+        this.fileExportProvider.createDirectory(null);
     }
 
 }


### PR DESCRIPTION
# Description

I moved the export folder creation to FileExportProvider. The responsibility for creating folder, when using the --export flag has nothing to do with starting iri. The logic and handling of folder and filecreation should be part of the  FileExportProvider.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

mvn clean install
and
startet iri with --export flag without issues

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
