### PR TITLE
Make PearlDiver threads configurable

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -79,6 +79,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected double alpha = Defaults.ALPHA;
     private int maxAnalyzedTransactions = Defaults.MAX_ANALYZED_TXS;
 
+    //PearlDiver
+    protected int powThreads = Defaults.POW_THREADS;
+
     //Snapshot
     protected boolean localSnapshotsEnabled = Defaults.LOCAL_SNAPSHOTS_ENABLED;
     protected boolean localSnapshotsPruningEnabled = Defaults.LOCAL_SNAPSHOTS_PRUNING_ENABLED;
@@ -676,6 +679,17 @@ public abstract class BaseIotaConfig implements IotaConfig {
         this.maxAnalyzedTransactions = maxAnalyzedTransactions;
     }
 
+    @Override
+    public int getPowThreads() {
+        return powThreads;
+    }
+
+    @JsonProperty
+    @Parameter(names = "--pow-threads", description = PearlDiverConfig.Descriptions.POW_THREADS)
+    protected void setPowThreads(int powThreads) {
+        this.powThreads = powThreads;
+    }
+
     public interface Defaults {
         //API
         int API_PORT = 14265;
@@ -731,6 +745,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
         //TipSel
         int MAX_DEPTH = 15;
         double ALPHA = 0.001d;
+
+        //PearlDiver
+        int POW_THREADS = 0;
 
         //Coo
         String COORDINATOR_ADDRESS =

--- a/src/main/java/com/iota/iri/conf/IotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/IotaConfig.java
@@ -10,7 +10,7 @@ import java.io.File;
  *  In charge of how we parse the configuration from given inputs.
  */
 public interface IotaConfig extends APIConfig, NodeConfig,
-        IXIConfig, DbConfig, ConsensusConfig, ZMQConfig, TipSelConfig {
+        IXIConfig, DbConfig, ConsensusConfig, ZMQConfig, TipSelConfig, PearlDiverConfig {
     File CONFIG_FILE = new File("iota.ini");
 
     /**

--- a/src/main/java/com/iota/iri/conf/PearlDiverConfig.java
+++ b/src/main/java/com/iota/iri/conf/PearlDiverConfig.java
@@ -1,0 +1,19 @@
+package com.iota.iri.conf;
+
+/**
+ * Configurations for PearlDiver proof-of-work hasher.
+ */
+public interface PearlDiverConfig extends Config {
+
+    /**
+     * @return {@value PearlDiverConfig.Descriptions#POW_THREADS}
+     */
+    int getPowThreads();
+
+    /**
+    * Field descriptions
+    */
+    interface Descriptions {
+        String POW_THREADS = "Number of threads to use for proof-of-work calculation";
+    }
+}

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1099,7 +1099,7 @@ public class API {
                 Converter.copyTrits(MAX_TIMESTAMP_VALUE,transactionTrits,TransactionViewModel.ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_OFFSET,
                         TransactionViewModel.ATTACHMENT_TIMESTAMP_UPPER_BOUND_TRINARY_SIZE);
 
-                if (!pearlDiver.search(transactionTrits, minWeightMagnitude, 0)) {
+                if (!pearlDiver.search(transactionTrits, minWeightMagnitude, instance.configuration.getPowThreads())) {
                     transactionViewModels.clear();
                     break;
                 }


### PR DESCRIPTION
# Description

Add configuration variable for the number of PoW threads, for manual control.

Fixes #1016 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Deployed to production IOTA node, verified specified number of threads were used by CPU load.

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (where?)
- [X] New and existing unit tests pass locally with my changes
