### PR TITLE
IXI add stack trace of scriptEngine eval to help to debug Nashorn scripts

### DIFF
--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -255,7 +255,7 @@ public class IXI {
         try {
             scriptEngine.eval(ixiModuleReader, bindings);
         } catch (ScriptException e) {
-            log.error("Script error");
+            log.error("Script error", e);
         }
         try {
             ixiModuleReader.close();


### PR DESCRIPTION
# Description

When an IXI module fails IRI only shows:
```
09/27 19:16:40.694 [main] ERROR com.iota.iri.IXI - Script error
```
this is not informative enough, and the `scriptEngine` actually gives an informative stack trace, for example:
```
09/27 19:16:40.694 [main] ERROR com.iota.iri.IXI - Script error
javax.script.ScriptException: TypeError: Cannot read property "latestSnapshot" from undefined in <eval> at line number 3
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- locally while debugging regression on snapshot.ixi