### PR TITLE
fix milestones signatures are not validated on testnet (since config …

### DIFF
--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public class TestnetConfig extends BaseIotaConfig {
 
     protected String coordinator = Defaults.COORDINATOR_ADDRESS;
-    protected boolean dontValidateTestnetMilestoneSig = Defaults.VALIDATE_MILESTONE_SIG;
+    protected boolean dontValidateTestnetMilestoneSig = Defaults.DONT_VALIDATE_MILESTONE_SIG;
     protected String snapshotFile = Defaults.SNAPSHOT_FILE;
     protected String snapshotSignatureFile = Defaults.SNAPSHOT_SIG;
     protected long snapshotTime = Defaults.SNAPSHOT_TIME;
@@ -160,7 +160,7 @@ public class TestnetConfig extends BaseIotaConfig {
 
     public interface Defaults {
         String COORDINATOR_ADDRESS = "EQQFCZBIHRHWPXKMTOLMYUYPCN9XLMJPYZVFJSAY9FQHCCLWTOLLUGKKMXYFDBOOYFBLBI9WUEILGECYM";
-        boolean VALIDATE_MILESTONE_SIG = true;
+        boolean DONT_VALIDATE_MILESTONE_SIG = false;
         String SNAPSHOT_FILE = "/snapshotTestnet.txt";
         int REQUEST_HASH_SIZE = 49;
         String SNAPSHOT_SIG = "/snapshotTestnet.sig";

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -142,7 +142,7 @@ public class ConfigTest {
                 //we ignore this on mainnet
                 "--mwm", "4",
                 "--testnet-coordinator", "TTTTTTTTT",
-                "--test-no-coo-validation",
+                "--testnet-no-coo-validation",
                 //this should be ignored everywhere
                 "--fake-config"
         };
@@ -173,7 +173,8 @@ public class ConfigTest {
         Assert.assertEquals("zmq enabled", true, iotaConfig.isZmqEnabled());
         Assert.assertEquals("mwm", 4, iotaConfig.getMwm());
         Assert.assertEquals("coo", "TTTTTTTTT", iotaConfig.getCoordinator());
-        Assert.assertEquals("--test-no-coo-validation", true, iotaConfig.isDontValidateTestnetMilestoneSig());
+        Assert.assertEquals("--testnet-no-coo-validation", true,
+                iotaConfig.isDontValidateTestnetMilestoneSig());
     }
 
     @Test

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -278,6 +278,13 @@ public class ConfigTest {
                         Assert.assertThat(configNames, IsCollectionContaining.hasItem(config)));
     }
 
+    @Test
+    public void testDontValidateMIlestoneSigDefaultValue() {
+        IotaConfig iotaConfig = ConfigFactory.createIotaConfig(true);
+        Assert.assertFalse("By default testnet should be validating milestones",
+                iotaConfig.isDontValidateTestnetMilestoneSig());
+    }
+
     private String deriveNameFromSetter(Method setter) {
         JsonIgnore jsonIgnore = setter.getAnnotation(JsonIgnore.class);
         if (jsonIgnore != null) {


### PR DESCRIPTION
# Description

Gives the config `DONT_VALIDATE_TESTNET_MILESTONE_SIG` the correct default value `false`.

Fixes #1028

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit Test added that ascertains correct default value. 


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
