### PR TITLE
Make pmd comments ignore tests and add checks against unused code

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -81,6 +81,9 @@
 
     <rule ref="category/java/documentation.xml/CommentRequired" deprecated="true">
         <properties>
+            <!-- Ignore @Test methods -->
+            <property name="violationSuppressXPath"
+                      value="//MethodDeclaration/../Annotation/MarkerAnnotation/Name[@Image='Test']" />
             <property name="protectedMethodCommentRequirement" value="Ignored"/>
             <property name="fieldCommentRequirement" value="Ignored"/>
         </properties>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -57,6 +57,11 @@
     <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue" deprecated="true"/>
     <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals" deprecated="true"/>
     <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" deprecated="true"/>
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" deprecated="true"/>
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" deprecated="true"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" deprecated="true"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" deprecated="true"/>
+    <rule ref="category/java/bestpractices.xml/UnusedImports" deprecated="true"/>
 
     <rule ref="category/java/codestyle.xml/ExtendsObject" deprecated="true"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier" name="UnnecessaryFinalModifier" deprecated="true"/>
@@ -64,7 +69,6 @@
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" deprecated="true"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" deprecated="true"/>
     <rule ref="category/java/codestyle.xml/DuplicateImports" deprecated="true"/>
-    <rule ref="category/java/bestpractices.xml/UnusedImports" deprecated="true"/>
     <rule ref="category/java/codestyle.xml/MIsLeadingVariableName" name="MisleadingVariableName" deprecated="true"/>
     <rule ref="category/java/codestyle.xml/SuspiciousConstantFieldName" deprecated="true"/>
 


### PR DESCRIPTION
# Description
Pmd (Codacy):
1. Won't comment on test classes that are uncommented.
2. Will alert against unused variables and methods.

Relates to #1020 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
Pmd has been run against a Test class and a Production class.
It only alerted on missing documentation against the production class.