### PR TITLE
remove unused variable that could lead to unclear behaviour

### DIFF
--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -18,7 +18,6 @@ public class TestnetConfig extends BaseIotaConfig {
     protected int numberOfKeysInMilestone = Defaults.KEYS_IN_MILESTONE;
     protected int transactionPacketSize = Defaults.PACKET_SIZE;
     protected int requestHashSize = Defaults.REQUEST_HASH_SIZE;
-    protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
 
     public TestnetConfig() {
         super();


### PR DESCRIPTION
# Description

`localSnapshotsBasePath` is the name of a field in `BaseIotaConfig` already.
and, thankfully,  it is not used in `TestnetConfig`.

https://sonarcloud.io/project/issues?id=alon-e_iri&issues=AWZT3V41BfefbO9Hm7SD&open=AWZT3V41BfefbO9Hm7SD

## Type of change

- Bug fix (a non-breaking change which fixes an issue)