### PR TITLE
Caches the reply to request tx to avoid redundant processing

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -422,6 +422,10 @@ public class Node {
             try {
                 sendPacket(sendingPacket, transactionViewModel, neighbor);
 
+                ByteBuffer digest = getBytesDigest(transactionViewModel.getBytes());
+                synchronized (recentSeenBytes) {
+                    recentSeenBytes.put(digest, transactionViewModel.getHash());
+                }
             } catch (Exception e) {
                 log.error("Error fetching transaction to request.", e);
             }

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -224,14 +224,11 @@ public class Node {
                 try {
 
                     //Transaction bytes
-
-                    MessageDigest digest = MessageDigest.getInstance("SHA-256");
-                    digest.update(receivedData, 0, TransactionViewModel.SIZE);
-                    ByteBuffer byteHash = ByteBuffer.wrap(digest.digest());
+                    ByteBuffer digest = getBytesDigest(receivedData);
 
                     //check if cached
                     synchronized (recentSeenBytes) {
-                        cached = (receivedTransactionHash = recentSeenBytes.get(byteHash)) != null;
+                        cached = (receivedTransactionHash = recentSeenBytes.get(digest)) != null;
                     }
 
                     if (!cached) {
@@ -241,7 +238,7 @@ public class Node {
                         transactionValidator.runValidation(receivedTransactionViewModel, transactionValidator.getMinWeightMagnitude());
 
                         synchronized (recentSeenBytes) {
-                            recentSeenBytes.put(byteHash, receivedTransactionHash);
+                            recentSeenBytes.put(digest, receivedTransactionHash);
                         }
 
                         //if valid - add to receive queue (receivedTransactionViewModel, neighbor)
@@ -636,6 +633,12 @@ public class Node {
     public void shutdown() throws InterruptedException {
         shuttingDown.set(true);
         executor.awaitTermination(6, TimeUnit.SECONDS);
+    }
+
+    private ByteBuffer getBytesDigest(byte[] receivedData) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(receivedData, 0, TransactionViewModel.SIZE);
+        return ByteBuffer.wrap(digest.digest());
     }
 
     // helpers methods


### PR DESCRIPTION
# Description
analyzing what happens when a new node tries to sync:

let `N` be the synced node & `n` be the new node.
```
N                      n
    <- ?|h(tx)   -      //n requests tx
    - tx|h(?)   ->      //N replies with tx
    <- tx|h(tx2) -      //n, which just found out about `tx` broadcasts it to every one (and request something else)
```
so in this case `N` will analyze the last packet - i.e. will hash it to check MWM etc.
this is redundant in this case, and is a burdun on `N`.
in my test (8 core) both nodes consumed 400%.
and profiling showed 85% of the CPU is spent in `Curl.transform`

proposed solution:
however, it's simple to see that `n->N tx` can be anticipated, I mean `N` just sent it to `n`.
so y proposal is for `N` to add `tx` to its `recentSeenBytes` list as if it already received it.
this would make `N` skip the hashing and validation.

---
this result is dramatic:
1. CPU consumption: `N` ~75% ; `n` ~550%
2. profiling: 27% transform, 22% rock.get, 15% UDP socket! - much more balanced.
3. `n` syncs 150% faster.
4. while `toReply` still gets high, the `toProcess` stays low.

Fixes #586 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Testing 2 nodes - `N` synced and `n` a fresh node, and comparing CPU usage and hotspots.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
