### PR TITLE
add code coverage for regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
   apt:
     packages:
     - jq
-    - libxml2-utils 
 
 matrix:
   allow_failures:
@@ -32,7 +31,7 @@ script:
   - git merge $TRAVIS_BRANCH
   - mvn integration-test -Dlogging-level=INFO
   #run jar sanity tests
-  - VERSION=`echo -e 'setns x=http://maven.apache.org/POM/4.0.0\ncat /x:project/x:version/text()' | xmllint --shell pom.xml | grep -v / | tr -d -` 
+  - VERSION=$(mvn help:evaluate -Dexpression=project.version | grep '^[0-9.]*')
   - echo $VERSION
   - git clone https://github.com/iotaledger/iri-regression-tests.git
   - cd iri-regression-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ script:
   #run jar sanity tests
   - VERSION=$(mvn help:evaluate -Dexpression=project.version | grep '^[0-9.]*')
   - echo $VERSION
+  #jacoco prep (appends to mvn run)
+  - JACOCO_V=$(mvn help:evaluate -Dexpression=jacoco.version | grep '^[0-9.]*')
+  - export _JAVA_OPTIONS="$_JAVA_OPTIONS -javaagent:$HOME/.m2/repository/org/jacoco/org.jacoco.agent/$JACOCO_V/org.jacoco.agent-$JACOCO_V-runtime.jar=destfile=$PWD/target/jacoco.exec,output=file,append=true,dumponexit=true"
+  - echo $_JAVA_OPTIONS
   - git clone https://github.com/iotaledger/iri-regression-tests.git
   - cd iri-regression-tests
   - git checkout -f master
@@ -42,6 +46,8 @@ script:
   - cp -rf ../target iri/target
   - bash run_all_stable_tests.sh $VERSION
   - cd ..
+  #jacoco append to report
+  - mvn jacoco:report
 
 after_success:
   #codacy-coverage send report. Uses Travis Env variable (CODACY_PROJECT_TOKEN)

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ script:
   - git merge $TRAVIS_BRANCH
   - mvn integration-test -Dlogging-level=INFO
   #run jar sanity tests
-  - VERSION=$(mvn help:evaluate -Dexpression=project.version | grep '^[0-9.]*')
+  - VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -E '^[0-9.]+')
   - echo $VERSION
   #jacoco prep (appends to mvn run)
-  - JACOCO_V=$(mvn help:evaluate -Dexpression=jacoco.version | grep '^[0-9.]*')
+  - JACOCO_V=$(mvn help:evaluate -Dexpression=jacoco.version | grep -E '^[0-9.]+')
   - export _JAVA_OPTIONS="$_JAVA_OPTIONS -javaagent:$HOME/.m2/repository/org/jacoco/org.jacoco.agent/$JACOCO_V/org.jacoco.agent-$JACOCO_V-runtime.jar=destfile=$PWD/target/jacoco.exec,output=file,append=true,dumponexit=true"
   - echo $_JAVA_OPTIONS
   - git clone https://github.com/iotaledger/iri-regression-tests.git

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <java-version>1.8</java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <undertow.version>1.4.26.Final</undertow.version>
+        <jacoco.version>0.7.9</jacoco.version>
         <!-- Setting the checkstyle.config.location here will make checkstyle use this file in every maven target.
              This variable will be load by checkstyle plugin automatically. It is more global than setting the
              configLocation attribute on every maven goal. -->
@@ -414,7 +415,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
# Description

This PR adds jacoco as a java agent and appends to the coverage report from the unit tests.
also, versions are now interpreted semantically by Maven.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- locally running the tests and plotting coverage report to see additional line hits
- on Travis passing tests
- pushing reports to Codacy


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
