### PR TITLE
Fixed wrong Hash objects used

### DIFF
--- a/src/main/java/com/iota/iri/Snapshot.java
+++ b/src/main/java/com/iota/iri/Snapshot.java
@@ -83,7 +83,7 @@ public class Snapshot {
                 if (parts.length >= 2) {
                     String key = parts[0];
                     String value = parts[1];
-                    state.put(HashFactory.TRANSACTION.create(key), Long.valueOf(value));
+                    state.put(HashFactory.ADDRESS.create(key), Long.valueOf(value));
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -269,7 +269,7 @@ public class TransactionViewModel {
             byte[] tagBytes = Converter.allocateBytesForTrits(OBSOLETE_TAG_TRINARY_SIZE);
             Converter.bytes(trits(), OBSOLETE_TAG_TRINARY_OFFSET, tagBytes, 0, OBSOLETE_TAG_TRINARY_SIZE);
 
-            transaction.obsoleteTag = HashFactory.TAG.create(tagBytes, 0, TAG_SIZE_IN_BYTES);
+            transaction.obsoleteTag = HashFactory.OBSOLETETAG.create(tagBytes, 0, TAG_SIZE_IN_BYTES);
         }
         return transaction.obsoleteTag;
     }

--- a/src/main/java/com/iota/iri/model/StateDiff.java
+++ b/src/main/java/com/iota/iri/model/StateDiff.java
@@ -22,7 +22,7 @@ public class StateDiff implements Persistable {
         state = new HashMap<>();
         if(bytes != null) {
             for (i = 0; i < bytes.length; i += Hash.SIZE_IN_BYTES + Long.BYTES) {
-                state.put(HashFactory.TRANSACTION.create(bytes, i, Hash.SIZE_IN_BYTES),
+                state.put(HashFactory.ADDRESS.create(bytes, i, Hash.SIZE_IN_BYTES),
                         Serializer.getLong(Arrays.copyOfRange(bytes, i + Hash.SIZE_IN_BYTES, i + Hash.SIZE_IN_BYTES + Long.BYTES)));
             }
         }

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -996,7 +996,7 @@ public class API {
         if (tips == null || tips.size() == 0) {
             hashes = Collections.singletonList(instance.milestoneTracker.latestSolidSubtangleMilestone);
         } else {
-            hashes = tips.stream().map(address -> (HashFactory.ADDRESS.create(address)))
+            hashes = tips.stream().map(address -> (HashFactory.TRANSACTION.create(address)))
                     .collect(Collectors.toCollection(LinkedList::new));
         }
         try {

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -996,7 +996,7 @@ public class API {
         if (tips == null || tips.size() == 0) {
             hashes = Collections.singletonList(instance.milestoneTracker.latestSolidSubtangleMilestone);
         } else {
-            hashes = tips.stream().map(address -> (HashFactory.TRANSACTION.create(address)))
+            hashes = tips.stream().map(tip -> (HashFactory.TRANSACTION.create(tip)))
                     .collect(Collectors.toCollection(LinkedList::new));
         }
         try {

--- a/src/test/java/com/iota/iri/SnapshotTest.java
+++ b/src/test/java/com/iota/iri/SnapshotTest.java
@@ -44,7 +44,7 @@ public class SnapshotTest {
     @Test
     public void patch() {
         Map.Entry<Hash, Long> firstOne = initSnapshot.state.entrySet().iterator().next();
-        Hash someHash = HashFactory.TRANSACTION.create("PSRQPWWIECDGDDZXHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS");
+        Hash someHash = HashFactory.ADDRESS.create("PSRQPWWIECDGDDZXHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS");
         Map<Hash, Long> diff = new HashMap<>();
         diff.put(firstOne.getKey(), -firstOne.getValue());
         diff.put(someHash, firstOne.getValue());
@@ -56,14 +56,14 @@ public class SnapshotTest {
     public void applyShouldFail() {
         Snapshot latestSnapshot = initSnapshot.clone();
         Map<Hash, Long> badMap = new HashMap<>();
-        badMap.put(HashFactory.TRANSACTION.create("PSRQPWWIECDGDDZEHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS"), 100L);
-        badMap.put(HashFactory.TRANSACTION.create("ESRQPWWIECDGDDZEHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS"), -100L);
+        badMap.put(HashFactory.ADDRESS.create("PSRQPWWIECDGDDZEHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS"), 100L);
+        badMap.put(HashFactory.ADDRESS.create("ESRQPWWIECDGDDZEHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS"), -100L);
         Map<Hash, Long> patch = latestSnapshot.patchedDiff(badMap);
         assertFalse("should be inconsistent", Snapshot.isConsistent(latestSnapshot.patchedDiff(badMap)));
     }
 
     private Map<Hash, Long> getModifiedMap() {
-        Hash someHash = HashFactory.TRANSACTION.create("PSRQPWWIECDGDDZXHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS");
+        Hash someHash = HashFactory.ADDRESS.create("PSRQPWWIECDGDDZXHGJNMEVJNSVOSMECPPVRPEVRZFVIZYNNXZNTOTJOZNGCZNQVSPXBXTYUJUOXYASLS");
         Map<Hash, Long> newMap;
         newMap = new HashMap<>();
         Iterator<Map.Entry<Hash, Long>> iterator = newMap.entrySet().iterator();


### PR DESCRIPTION
# Description

Various Hashes were created from the wrong hash type, this has been fixed.

Fixes #1079 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Manual verify if all uses of the `HashFactory` and `NULL_HASH`

# Checklist:
- [ ] New and existing unit tests pass locally with my changes
