### PR TITLE
Return early when validating a bundle that has a known invalid status

### DIFF
--- a/src/main/java/com/iota/iri/BundleValidator.java
+++ b/src/main/java/com/iota/iri/BundleValidator.java
@@ -1,8 +1,8 @@
 package com.iota.iri;
 
+import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.hash.*;
 import com.iota.iri.model.Hash;
-import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Converter;
 
@@ -12,10 +12,11 @@ public class BundleValidator {
 
     public static List<List<TransactionViewModel>> validate(Tangle tangle, Hash tailHash) throws Exception {
         TransactionViewModel tail = TransactionViewModel.fromHash(tangle, tailHash);
-        List<List<TransactionViewModel>> transactions = new LinkedList<>();
-        if (tail.getCurrentIndex() != 0) {
-            return transactions;
+        if (tail.getCurrentIndex() != 0 || tail.getValidity() == -1) {
+            return Collections.EMPTY_LIST;
         }
+
+        List<List<TransactionViewModel>> transactions = new LinkedList<>();
         final Map<Hash, TransactionViewModel> bundleTransactions = loadTransactionsFromTangle(tangle, tail);
 
         for (TransactionViewModel transactionViewModel : bundleTransactions.values()) {


### PR DESCRIPTION
# Description

Return early when validating a bundle that was already processed.
No functionality was changed.
It is just a quick fix that saves time loading from disk.

- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?
All current unit tests have passed

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
