### PR TITLE
add 'coordinatorAddress' to 'getNodeInfo' response.

### DIFF
--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -38,6 +38,7 @@ Feature: Test API calls on Machine 1
 		|time						|
 		|tips						|
 		|transactionsToRequest				|
+		|coordinatorAddress					|
 
 
 	Scenario: GetNeighbors is called

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -38,7 +38,7 @@ Feature: Test API calls on Machine 1
 		|time						|
 		|tips						|
 		|transactionsToRequest				|
-		|coordinatorAddress					|
+		|coordinatorAddress				|
 
 
 	Scenario: GetNeighbors is called

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -728,7 +728,8 @@ public class API {
                 instance.node.howManyNeighbors(), instance.node.queuedTransactionsSize(),
                 System.currentTimeMillis(), instance.tipsViewModel.size(),
                 instance.transactionRequester.numberOfTransactionsToRequest(),
-                features);
+                features,
+                instance.configuration.getCoordinator());
     }
 
     /**

--- a/src/main/java/com/iota/iri/service/dto/GetNodeInfoResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNodeInfoResponse.java
@@ -27,12 +27,13 @@ public class GetNodeInfoResponse extends AbstractResponse {
     private int transactionsToRequest;
     
     private String[] features;
+    private String coordinatorAddress;
 
 	public static AbstractResponse create(String appName, String appVersion, int jreAvailableProcessors, long jreFreeMemory,
 	        String jreVersion, long maxMemory, long totalMemory, Hash latestMilestone, int latestMilestoneIndex,
 	        Hash latestSolidSubtangleMilestone, int latestSolidSubtangleMilestoneIndex, int milestoneStartIndex,
 	        int neighbors, int packetsQueueSize, long currentTimeMillis, int tips, 
-	        int numberOfTransactionsToRequest,  String[] features) {
+	        int numberOfTransactionsToRequest,  String[] features, String coordinatorAddress) {
 		final GetNodeInfoResponse res = new GetNodeInfoResponse();
 		res.appName = appName;
 		res.appVersion = appVersion;
@@ -57,6 +58,7 @@ public class GetNodeInfoResponse extends AbstractResponse {
 		res.transactionsToRequest = numberOfTransactionsToRequest;
 		
 		res.features = features;
+		res.coordinatorAddress = coordinatorAddress;
 		return res;
 	}
 
@@ -225,5 +227,14 @@ public class GetNodeInfoResponse extends AbstractResponse {
 	 */
 	public String[] getFeatures() {
 	    return features;
+	}
+
+	/**
+	 * The address of the Coordinator being followed by this node.
+	 *
+	 * @return The tips.
+	 */
+	public String getCoordinatorAddress() {
+		return coordinatorAddress;
 	}
 }


### PR DESCRIPTION
# Description
adds  'coordinatorAddress' to 'getNodeInfo' response:
```
curl localhost:14265 \
  -X POST \
  -H 'Content-Type: application/json' \
  -H 'X-IOTA-API-Version: 1' \
  -d '{"command": "getNodeInfo"}' | jq
{
  "appName": "IRI Testnet",
  "appVersion": "1.5.5",
  "jreAvailableProcessors": 4,
...
  "coordinatorAddress": "HQUUXGMQOVHJFJPOELGYJ9EJYSCLQDGH9F9VYYQAJPR9DRYEYPBFWXTHEVHRMKGHRKJYXIQOLRVOLSXJJ",
  "duration": 21
}

```

Fixes #1056 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
- locally running a node
- changing Coo address and rerunning tests.


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
