### PR TITLE
Regression ciglue.sh: avoid git fatal error when cloning TIAB

### DIFF
--- a/python-regression/ciglue.sh
+++ b/python-regression/ciglue.sh
@@ -12,7 +12,9 @@ ERROR=0
 K8S_NAMESPACE=$(kubectl config get-contexts $(kubectl config current-context) | tail -n+2 | awk '{print $5}')
 IMAGE=$1
 
-git clone --depth 1 https://github.com/iotaledger/tiab tiab
+if [ ! -d tiab ]; then
+  git clone --depth 1 https://github.com/iotaledger/tiab tiab
+fi
 
 virtualenv -p python2 venv
 source venv/bin/activate


### PR DESCRIPTION
Avoid throwing a fatal error when TIAB has been cloned already.