### PR TITLE
add "numberOfStaleTransactions" to getNeighbors API call

### DIFF
--- a/src/main/java/com/iota/iri/network/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/Neighbor.java
@@ -14,6 +14,7 @@ public abstract class Neighbor {
     private long numberOfInvalidTransactions;
     private long randomTransactionRequests;
     private long numberOfSentTransactions;
+    private long numberOfStaleTransactions;
 
     private boolean flagged = false;
     public boolean isFlagged() {
@@ -84,11 +85,15 @@ public abstract class Neighbor {
     public void incInvalidTransactions() {
     	numberOfInvalidTransactions++;
     }
-    
+
+    void incStaleTransactions() {
+        numberOfStaleTransactions++;
+    }
+
     public void incSentTransactions() {
         numberOfSentTransactions++;
     }
-    
+
     public long getNumberOfAllTransactions() {
 		return numberOfAllTransactions;
 	}
@@ -96,7 +101,11 @@ public abstract class Neighbor {
     public long getNumberOfInvalidTransactions() {
 		return numberOfInvalidTransactions;
 	}
-    
+
+    public long getNumberOfStaleTransactions() {
+        return numberOfStaleTransactions;
+    }
+
     public long getNumberOfNewTransactions() {
 		return numberOfNewTransactions;
 	}
@@ -108,5 +117,5 @@ public abstract class Neighbor {
 	public long getNumberOfSentTransactions() {
 	    return numberOfSentTransactions;
 	}
-    
+
 }

--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -255,7 +255,7 @@ public class Node {
                     } catch (Exception e1) {
                         log.error(e1.getMessage());
                     }
-                    neighbor.incInvalidTransactions();
+                    neighbor.incStaleTransactions();
                 } catch (final RuntimeException e) {
                     log.error(e.getMessage());
                     log.error("Received an Invalid TransactionViewModel. Dropping it...");

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -22,11 +22,16 @@ public class GetNeighborsResponse extends AbstractResponse {
     static class Neighbor {
 
         private String address;
-        public long numberOfAllTransactions, numberOfRandomTransactionRequests, numberOfNewTransactions, numberOfInvalidTransactions, numberOfSentTransactions;
+        public long numberOfAllTransactions,
+                numberOfRandomTransactionRequests,
+                numberOfNewTransactions,
+                numberOfInvalidTransactions,
+                numberOfStaleTransactions,
+                numberOfSentTransactions;
         public String connectionType;
 
         /**
-         * The address of your peer
+         * The address of your neighbor
          * 
          * @return the address
          */
@@ -53,7 +58,7 @@ public class GetNeighborsResponse extends AbstractResponse {
         }
 
         /**
-         * Invalid transactions your peer has sent you. 
+         * Invalid transactions your neighbor has sent you. 
          * These are transactions with invalid signatures or overall schema.
          * 
          * @return the number
@@ -61,9 +66,19 @@ public class GetNeighborsResponse extends AbstractResponse {
         public long getNumberOfInvalidTransactions() {
             return numberOfInvalidTransactions;
         }
-        
+
         /**
-         * Amount of transactions send through your peer
+         * Stale transactions your neighbor has sent you.
+         * These are transactions with a timestamp older than your latest snapshot.
+         *
+         * @return the number
+         */
+        public long getNumberOfStaleTransactions() {
+            return numberOfStaleTransactions;
+        }
+
+        /**
+         * Amount of transactions send through your neighbor
          * 
          * @return the number
          */
@@ -72,7 +87,7 @@ public class GetNeighborsResponse extends AbstractResponse {
         }
 
         /**
-         * The method type your peer is using to connect (TCP / UDP)
+         * The method type your neighbor is using to connect (TCP / UDP)
          * 
          * @return the connection type
          */
@@ -86,6 +101,7 @@ public class GetNeighborsResponse extends AbstractResponse {
             ne.address = n.getAddress().getHostString() + ":" + port;
             ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
             ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
+            ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();
             ne.numberOfNewTransactions = n.getNumberOfNewTransactions();
             ne.numberOfRandomTransactionRequests = n.getNumberOfRandomTransactionRequests();
             ne.numberOfSentTransactions = n.getNumberOfSentTransactions();


### PR DESCRIPTION
# Description

Seperates "numberOfInvalidTransactions" and "numberOfStaleTransactions" in `getNeighbors`

```
{
  "neighbors": [
    {
      "address": "localhost:12345",
      "numberOfAllTransactions": 0,
      "numberOfRandomTransactionRequests": 0,
      "numberOfNewTransactions": 0,
      "numberOfInvalidTransactions": 0,
      "numberOfStaleTransactions": 0,
      "numberOfSentTransactions": 0,
      "connectionType": "tcp"
    }
  ],
  "duration": 1
}
```

Fixes #1018 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

- Tested locally

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
