### PR TITLE
Changed Hashes generic to always Transaction

### DIFF
--- a/src/main/java/com/iota/iri/model/persistables/Hashes.java
+++ b/src/main/java/com/iota/iri/model/persistables/Hashes.java
@@ -26,7 +26,7 @@ public class Hashes implements Persistable {
         if(bytes != null) {
             set = new LinkedHashSet<>(bytes.length / (1 + Hash.SIZE_IN_BYTES) + 1);
             for (int i = 0; i < bytes.length; i += 1 + Hash.SIZE_IN_BYTES) {
-                set.add(HashFactory.GENERIC.create(this.getClass(), bytes, i, Hash.SIZE_IN_BYTES));
+                set.add(HashFactory.TRANSACTION.create(bytes, i, Hash.SIZE_IN_BYTES));
             }
         }
     }


### PR DESCRIPTION
# Description
`Hashes` always contain a set of `TransactionHash`es.
Read() will thus need to make `TransactionHash`. and not the `Hash` of the class type.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
ran Unit tests 


# Checklist:

_Please delete items that are not relevant._
- [ ] New and existing unit tests pass locally with my changes
