### PR TITLE
Fix remove source port check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.iota</groupId>
     <artifactId>iri</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6-SNAPSHOT</version>
 
     <name>IRI</name>
     <description>IOTA Reference Implementation</description>
@@ -180,6 +180,13 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <version>1.72</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/iota/iri/network/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/Neighbor.java
@@ -1,5 +1,7 @@
 package com.iota.iri.network;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -16,14 +18,11 @@ public abstract class Neighbor {
     private long numberOfSentTransactions;
     private long numberOfStaleTransactions;
 
-    private boolean flagged = false;
+    private final boolean flagged;
     public boolean isFlagged() {
         return flagged;
     }
-    public void setFlagged(boolean flagged) {
-        this.flagged = flagged;
-    }
-    
+
     private final static AtomicInteger numPeers = new AtomicInteger(0);
     public static int getNumPeers() {
         return numPeers.get();
@@ -31,19 +30,12 @@ public abstract class Neighbor {
     public static void incNumPeers() {
         numPeers.incrementAndGet();
     }
-    public static void decNumPeers() {
-        int v = numPeers.decrementAndGet();
-        if (v < 0) {
-            numPeers.set(0);
-        }
-    }
 
     private final String hostAddress;
 
     public String getHostAddress() {
         return hostAddress;
     }
-
 
     public Neighbor(final InetSocketAddress address, boolean isConfigured) {
         this.address = address;
@@ -54,7 +46,6 @@ public abstract class Neighbor {
     public abstract void send(final DatagramPacket packet);
     public abstract int getPort();
     public abstract String connectionType();
-    public abstract boolean matches(SocketAddress address);
 
     @Override
     public boolean equals(final Object obj) {
@@ -69,7 +60,12 @@ public abstract class Neighbor {
     public InetSocketAddress getAddress() {
 		return address;
 	}
-    
+
+    public boolean matches(SocketAddress address) {
+        // check if socket address (hostname/ip:port or /ip:port) contains ip (== host address)
+        return StringUtils.contains(address.toString(), getHostAddress());
+    }
+
     void incAllTransactions() {
     	numberOfAllTransactions++;
     }

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -69,7 +69,7 @@ public class TCPNeighbor extends Neighbor {
                     this.sink.close();
                     log.info("Sink {} closed", this.getHostAddress());
                 } catch (IOException e) {
-                    log.error("Sink {} close failure", this.getHostAddress(), e);
+                    log.error("Sink {} close failure: {}", this.getHostAddress(), e.toString());
                 }
             }
         }

--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -114,14 +113,4 @@ public class TCPNeighbor extends Neighbor {
         return (this.sendQueue.poll(10000, TimeUnit.MILLISECONDS));
     }
 
-    @Override
-    public boolean matches(SocketAddress address) {
-        if (address.toString().contains(this.getHostAddress())) {
-            int port = this.getSource().getPort();
-            if (address.toString().contains(Integer.toString(port))) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/src/main/java/com/iota/iri/network/UDPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/UDPNeighbor.java
@@ -6,12 +6,12 @@ import org.slf4j.LoggerFactory;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 
 /**
  * Created by paul on 4/15/17.
  */
 public class UDPNeighbor extends Neighbor {
+
     private static final Logger log = LoggerFactory.getLogger(UDPNeighbor.class);
 
     private final DatagramSocket socket;
@@ -45,17 +45,6 @@ public class UDPNeighbor extends Neighbor {
     @Override
     public String connectionType() {
         return "udp";
-    }
-
-    @Override
-    public boolean matches(SocketAddress address) {
-        if (this.getAddress().toString().contains(address.toString())) {
-            int port = this.getAddress().getPort();
-            if (address.toString().contains(Integer.toString(port))) {
-                return true;
-            }
-        }
-        return false;
     }
 
 }

--- a/src/test/java/com/iota/iri/network/UDPNeighborTest.java
+++ b/src/test/java/com/iota/iri/network/UDPNeighborTest.java
@@ -1,0 +1,31 @@
+package com.iota.iri.network;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UDPNeighborTest {
+
+    private UDPNeighbor neighbor = new UDPNeighbor(address("localhost", 42), null, false);
+
+    @Test
+    public void sameIpWhenMatchesThenTrue() {
+        assertThat(neighbor.matches(address("localhost", 42))).isTrue();
+        assertThat(neighbor.matches(address("localhost", 666))).isTrue();
+        assertThat(neighbor.matches(address("127.0.0.1", 42))).isTrue();
+        assertThat(neighbor.matches(address("127.0.0.1", 666))).isTrue();
+    }
+
+    @Test
+    public void differentIpWhenMatchesThenFalse() {
+        assertThat(neighbor.matches(address("foo.bar.com", 42))).isFalse();
+        assertThat(neighbor.matches(address("8.8.8.8", 42))).isFalse();
+    }
+
+    private InetSocketAddress address(String hostOrIp, int port) {
+        return new InetSocketAddress(hostOrIp, port);
+    }
+
+}


### PR DESCRIPTION
# Description

Removed source port check for receiving data from neighbors (TCP and UDP). That allows to receive data from neighbors that use other source ports than target ports.

Hopefully fixes #961 UDP Peering Source Port Problem.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

* Feature is unit tested.
* Feature for UDP is manually end to end tested.
* Feature for TCP is not end to end tested.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Discussion:

* Would be great if someone could end 2 end test this to verify that the fix works not only in my setup.
* I am not sure, if the fix makes sense for TCP. TCP worked properly before in my setup. I can change the fix to UPD only if desired.
* Adding/removing neighbors works as before. No changes there.
