### PR TITLE
Hotfix for the solidification bug of the Local Snapshots branch

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -240,6 +240,20 @@ public class Iota {
      * Exceptions during shutdown are not caught.
      */
     public void shutdown() throws Exception {
+        // shutdown in reverse starting order (to not break any dependencies)
+        milestoneSolidifier.shutdown();
+        seenMilestonesRetriever.shutdown();
+        latestSolidMilestoneTracker.shutdown();
+        latestMilestoneTracker.shutdown();
+
+        if (configuration.getLocalSnapshotsEnabled()) {
+            if (configuration.getLocalSnapshotsPruningEnabled()) {
+                transactionPruner.shutdown();
+            }
+
+            localSnapshotManager.shutdown();
+        }
+
         tipsSolidifier.shutdown();
         node.shutdown();
         udpReceiver.shutdown();
@@ -248,20 +262,8 @@ public class Iota {
         tangle.shutdown();
         messageQ.shutdown();
 
-        // shutdown in reverse starting order (to not break any dependencies)
-        milestoneSolidifier.shutdown();
-        seenMilestonesRetriever.shutdown();
-        latestSolidMilestoneTracker.shutdown();
-        latestMilestoneTracker.shutdown();
+        // free the resources of the snapshot provider last because all other instances need it
         snapshotProvider.shutdown();
-
-        if (configuration.getLocalSnapshotsEnabled()) {
-            localSnapshotManager.shutdown();
-
-            if (configuration.getLocalSnapshotsPruningEnabled()) {
-                transactionPruner.shutdown();
-            }
-        }
     }
 
     private void initializeTangle() {

--- a/src/main/java/com/iota/iri/service/ledger/LedgerService.java
+++ b/src/main/java/com/iota/iri/service/ledger/LedgerService.java
@@ -60,19 +60,18 @@ public interface LedgerService {
     boolean isBalanceDiffConsistent(Set<Hash> approvedHashes, Map<Hash, Long> diff, Hash tip) throws LedgerException;
 
     /**
-     * Generates the accumulated balance changes of the transactions that are "approved" by the given milestone.<br />
+     * Generates the accumulated balance changes of the unconfirmed transactions that are directly or indirectly
+     * referenced by the given transaction.<br />
      * <br />
-     * It simply iterates over all approvees that still belong to the given milestone and that have not been
-     * processed already (by being part of the {@code visitedNonMilestoneSubtangleHashes} set) and collects their
-     * balance changes.<br />
+     * It simply iterates over all approvees that have not been confirmed yet and that have not been processed already
+     * (by being part of the {@code visitedNonMilestoneSubtangleHashes} set) and collects their balance changes.<br />
      *
      * @param visitedTransactions a set of transaction hashes that shall be considered to be visited already
-     * @param milestoneHash the milestone  that is examined regarding its approved transactions
-     * @param latestSolidMilestoneIndex the latest solid milestone index
+     * @param transactionHash the transaction that marks the start of the dag traversal and that has its approovees
+     *                        examined
      * @return a map of the balance changes (addresses associated to their balance) or {@code null} if the balance could
      *         not be generated due to inconsistencies
      * @throws LedgerException if anything unexpected happens while generating the balance changes
      */
-    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash milestoneHash,
-            int latestSolidMilestoneIndex) throws LedgerException;
+    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash transactionHash) throws LedgerException;
 }

--- a/src/main/java/com/iota/iri/service/ledger/LedgerService.java
+++ b/src/main/java/com/iota/iri/service/ledger/LedgerService.java
@@ -60,8 +60,8 @@ public interface LedgerService {
     boolean isBalanceDiffConsistent(Set<Hash> approvedHashes, Map<Hash, Long> diff, Hash tip) throws LedgerException;
 
     /**
-     * Generates the accumulated balance changes of the unconfirmed transactions that are directly or indirectly
-     * referenced by the given transaction.<br />
+     * Generates the accumulated balance changes of the transactions that are directly or indirectly referenced by the
+     * given transaction relative to the referenced milestone.<br />
      * <br />
      * It simply iterates over all approvees that have not been confirmed yet and that have not been processed already
      * (by being part of the {@code visitedNonMilestoneSubtangleHashes} set) and collects their balance changes.<br />
@@ -73,5 +73,6 @@ public interface LedgerService {
      *         not be generated due to inconsistencies
      * @throws LedgerException if anything unexpected happens while generating the balance changes
      */
-    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash transactionHash) throws LedgerException;
+    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash transactionHash, int milestoneIndex)
+            throws LedgerException;
 }

--- a/src/main/java/com/iota/iri/service/ledger/LedgerService.java
+++ b/src/main/java/com/iota/iri/service/ledger/LedgerService.java
@@ -68,11 +68,11 @@ public interface LedgerService {
      *
      * @param visitedTransactions a set of transaction hashes that shall be considered to be visited already
      * @param milestoneHash the milestone  that is examined regarding its approved transactions
-     * @param milestoneIndex the milestone index
+     * @param latestSolidMilestoneIndex the latest solid milestone index
      * @return a map of the balance changes (addresses associated to their balance) or {@code null} if the balance could
      *         not be generated due to inconsistencies
      * @throws LedgerException if anything unexpected happens while generating the balance changes
      */
-    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash milestoneHash, int milestoneIndex) throws
-            LedgerException;
+    Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash milestoneHash,
+            int latestSolidMilestoneIndex) throws LedgerException;
 }

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -135,8 +135,8 @@ public class LedgerServiceImpl implements LedgerService {
     }
 
     @Override
-    public Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash milestoneHash, int milestoneIndex)
-            throws LedgerException {
+    public Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Hash milestoneHash,
+            int latestSolidMilestoneIndex) throws LedgerException {
 
         Map<Hash, Long> state = new HashMap<>();
         Set<Hash> countedTx = new HashSet<>();
@@ -150,12 +150,12 @@ public class LedgerServiceImpl implements LedgerService {
         Hash transactionPointer;
         while ((transactionPointer = nonAnalyzedTransactions.poll()) != null) {
             if (visitedTransactions.add(transactionPointer)) {
-
                 try {
                     final TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle,
                             transactionPointer);
 
-                    if (milestoneService.transactionBelongsToMilestone(transactionViewModel, milestoneIndex)) {
+                    if (milestoneService.transactionBelongsToMilestone(transactionViewModel,
+                            latestSolidMilestoneIndex + 1)) {
 
                         if (transactionViewModel.getType() == TransactionViewModel.PREFILLED_SLOT) {
                             return null;

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -153,8 +153,7 @@ public class LedgerServiceImpl implements LedgerService {
                 try {
                     final TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle,
                             transactionPointer);
-                    // only take transactions into account that have not been confirmed, yet (that are not included in
-                    // the ledger state)
+                    // only take transactions into account that have not been confirmed by the referenced milestone, yet
                     if (!milestoneService.isTransactionConfirmed(transactionViewModel, milestoneIndex)) {
                         if (transactionViewModel.getType() == TransactionViewModel.PREFILLED_SLOT) {
                             return null;

--- a/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
@@ -51,18 +51,29 @@ public interface MilestoneService {
     void updateMilestoneIndexOfMilestoneTransactions(Hash milestoneHash, int newIndex) throws MilestoneException;
 
     /**
-     * Checks if the given transaction "belongs" to the milestone with the given index.<br />
+     * Checks if the given transaction was confirmed by the milestone with the given index (or any of its
+     * predecessors).<br />
      * <br />
-     * We determine if a transaction still belongs to the milestone with the given index by examining its {@code
-     * snapshotIndex} value. For this method to work we require that the previous milestones have been processed already
-     * (which is enforce by the {@link com.iota.iri.service.milestone.LatestSolidMilestoneTracker} which applies the
-     * milestones in the order that they are issued by the coordinator).<br />
+     * We determine if the transaction was confirmed by examining its {@code snapshotIndex} value. For this method to
+     * work we require that the previous milestones have been processed already (which is enforced by the {@link
+     * com.iota.iri.service.milestone.LatestSolidMilestoneTracker} which applies the milestones in the order that they
+     * are issued by the coordinator).<br />
      *
      * @param transaction the transaction that shall be examined
      * @param milestoneIndex the milestone index that we want to check against
      * @return {@code true} if the transaction belongs to the milestone and {@code false} otherwise
      */
-    boolean transactionBelongsToMilestone(TransactionViewModel transaction, int milestoneIndex);
+    boolean isTransactionConfirmed(TransactionViewModel transaction, int milestoneIndex);
+
+    /**
+     * Does the same as {@link #isTransactionConfirmed(TransactionViewModel, int)} but defaults to the latest solid
+     * milestone index for the {@code milestoneIndex} which means that the transaction has been included in our current
+     * ledger state.<br />
+     *
+     * @param transaction the transaction that shall be examined
+     * @return {@code true} if the transaction belongs to the milestone and {@code false} otherwise
+     */
+    boolean isTransactionConfirmed(TransactionViewModel transaction);
 
     /**
      * Retrieves the milestone index of the given transaction by decoding the {@code OBSOLETE_TAG}.<br />

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
@@ -210,7 +210,7 @@ public class MilestoneServiceImpl implements MilestoneService {
             DAGHelper.get(tangle).traverseApprovees(
                 milestoneHash,
                 currentTransaction -> {
-                    // if the transaction was confirmed by a previous milestone -> check if we have a back-referencing
+                    // if the transaction was confirmed by a PREVIOUS milestone -> check if we have a back-referencing
                     // transaction and abort the traversal
                     if (isTransactionConfirmed(currentTransaction, correctIndex - 1)) {
                         patchSolidEntryPointsIfNecessary(snapshotProvider.getInitialSnapshot(), currentTransaction);


### PR DESCRIPTION
# Description

While refactoring the code we introduced a small but severe bug where the generateBalanceDiff method of the LedgerService traversed one milestone too far, booking balances twice.

In addition it fixes the shutdown() order (IRI crashed before - not being able to shutdown all instances in time because some of the legacy shutdown-methods take a really long time to terminate). The shutdown-methods of the new classes terminate instantly.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes