### PR TITLE
Regression: Fix Machine 1 Broadcast Test 

### DIFF
--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -237,6 +237,8 @@ Feature: Test API calls on Machine 1
 		|tag        |TEST9TAG9ONE			|string         |
 		|value      |0					|int            |
 
+		And we wait "5" second/seconds
+
 		And "findTransactions" is called on "nodeB" with:
 		|keys       |values             |type           |
 		|tags       |TEST9TAG9ONE       |list           |

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -237,7 +237,8 @@ Feature: Test API calls on Machine 1
 		|tag        |TEST9TAG9ONE			|string         |
 		|value      |0					|int            |
 
-		And we wait "5" second/seconds
+        #Give the transaction time to propagate
+		And we wait "3" second/seconds
 
 		And "findTransactions" is called on "nodeB" with:
 		|keys       |values             |type           |


### PR DESCRIPTION
# Description
There was an issue with the broadcast regression test. The transaction wasn't given any time to be processed by the sending node's neighbours, causing the transaction to not exist when searched for. This PR adds a delay in `machine1` broadcast regression test so that the transaction has time to be processed and then found on the second node.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Documentation Fix

# How Has This Been Tested?
The branch was created from the `dev-localsnapshots` branch, and the delay was placed inside. The new branch was then built and tested in buildkite and passed. 

# Checklist:
- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
