### PR TITLE
add a plugin to create reproducible builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 
 after_success:
   #digest of packaged jar
-  - sha256sum target/*.jar*
+  - test $TRAVIS_JDK_VERSION = "oraclejdk8" && sha256sum target/*.jar*
   #codacy-coverage send report. Uses Travis Env variable (CODACY_PROJECT_TOKEN)
   - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && wget -O codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[0].browser_download_url')
   - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && java -jar codacy-coverage-reporter-assembly-latest.jar report -l Java -r target/site/jacoco/jacoco.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
   - mvn jacoco:report
 
 after_success:
+  #digest of packaged jar
+  - sha256sum target/*.jar*
   #codacy-coverage send report. Uses Travis Env variable (CODACY_PROJECT_TOKEN)
   - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && wget -O codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[0].browser_download_url')
   - test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_JDK_VERSION = "oraclejdk8" && java -jar codacy-coverage-reporter-assembly-latest.jar report -l Java -r target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <version>0.7</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
     </build>


### PR DESCRIPTION
# Description

reproducible builds:

```bash
dev:
$ mvn clean package
$ sha256sum target/iri-1.5.5.jar 
6b60bbaf34c67e70b6bd7d7ee6ae7a9c1a9fb0f1d4c4d7a7e4293910f5140fd3  target/iri-1.5.5.jar

$ mvn clean package
$ sha256sum target/iri-1.5.5.jar 
e49e47850371c937cc8fda78392a8c2a2fb13c69540ffe2994ac71abe34d64c1  target/iri-1.5.5.jar

----

after fix:
$ mvn clean package
$ sha256sum target/iri-1.5.5.jar 
06f7f2c4714d45de710a67670b59bfbe6202ad54c77663518e221662cc887ab2  target/iri-1.5.5.jar

$ mvn clean package
$ sha256sum target/iri-1.5.5.jar 
06f7f2c4714d45de710a67670b59bfbe6202ad54c77663518e221662cc887ab2  target/iri-1.5.5.jar
```

Fixes #1193

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- see description