### PR TITLE
Fix: Removed intertwined locks to prevent deadlocks

### DIFF
--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
@@ -462,17 +462,13 @@ public class SnapshotServiceImpl implements SnapshotService {
 
         snapshotProvider.writeSnapshotToDisk(newSnapshot, config.getLocalSnapshotsBasePath());
 
-        snapshotProvider.getInitialSnapshot().lockWrite();
         snapshotProvider.getLatestSnapshot().lockWrite();
-
-        snapshotProvider.getInitialSnapshot().update(newSnapshot);
-
         snapshotProvider.getLatestSnapshot().setInitialHash(newSnapshot.getHash());
         snapshotProvider.getLatestSnapshot().setInitialIndex(newSnapshot.getIndex());
         snapshotProvider.getLatestSnapshot().setInitialTimestamp(newSnapshot.getTimestamp());
-
-        snapshotProvider.getInitialSnapshot().unlockWrite();
         snapshotProvider.getLatestSnapshot().unlockWrite();
+
+        snapshotProvider.getInitialSnapshot().update(newSnapshot);
     }
 
     /**


### PR DESCRIPTION
# Description

Since the locking of the two Snapshot was intertwined it could happen that we ran into a deadlock situation where the node freezes and doesn't process anything anymore. This PR changes this so the modification of the two snapshots happens without intertwining the locks.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
