### PR TITLE
Feat: Added an option to fast forward the ledger state

### DIFF
--- a/src/main/java/com/iota/iri/service/ledger/LedgerService.java
+++ b/src/main/java/com/iota/iri/service/ledger/LedgerService.java
@@ -15,6 +15,20 @@ import java.util.Set;
  */
 public interface LedgerService {
     /**
+     * Restores the ledger state after a restart of IRI, which allows us to fast forward to the point where we
+     * stopped before the restart.<br />
+     * <br />
+     * It looks for the last solid milestone that was applied to the ledger in the database and then replays all
+     * milestones leading up to this point by applying them to the latest snapshot. We do not check every single
+     * milestone again but assume that the data in the database is correct. If the database would have any
+     * inconsistencies and the application fails, the latest solid milestone tracker will check and apply the milestones
+     * one by one and repair the corresponding inconsistencies.<br />
+     *
+     * @throws LedgerException if anything unexpected happens while trying to restore the ledger state
+     */
+    void restoreLedgerState() throws LedgerException;
+
+    /**
      * Applies the given milestone to the ledger state.<br />
      * <br />
      * It first marks the transactions that were confirmed by this milestones as confirmed by setting their

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -74,13 +74,10 @@ public class LedgerServiceImpl implements LedgerService {
     @Override
     public void restoreLedgerState() throws LedgerException {
         try {
-            milestoneService.findLatestProcessedSolidMilestoneInDatabase().ifPresent(milestoneViewModel -> {
-                try {
-                    snapshotService.replayMilestones(snapshotProvider.getLatestSnapshot(), milestoneViewModel.index());
-                } catch (SnapshotException e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            Optional<MilestoneViewModel> milestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+            if (milestone.isPresent()) {
+                snapshotService.replayMilestones(snapshotProvider.getLatestSnapshot(), milestone.get().index());
+            }
         } catch (Exception e) {
             throw new LedgerException("unexpected error while restoring the ledger state", e);
         }

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -72,6 +72,21 @@ public class LedgerServiceImpl implements LedgerService {
     }
 
     @Override
+    public void restoreLedgerState() throws LedgerException {
+        try {
+            milestoneService.findLatestProcessedSolidMilestoneInDatabase().ifPresent(milestoneViewModel -> {
+                try {
+                    snapshotService.replayMilestones(snapshotProvider.getLatestSnapshot(), milestoneViewModel.index());
+                } catch (SnapshotException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (Exception e) {
+            throw new LedgerException("unexpected error while restoring the ledger state", e);
+        }
+    }
+
+    @Override
     public boolean applyMilestoneToLedger(MilestoneViewModel milestone) throws LedgerException {
         if(generateStateDiff(milestone)) {
             try {

--- a/src/main/java/com/iota/iri/service/milestone/LatestSolidMilestoneTracker.java
+++ b/src/main/java/com/iota/iri/service/milestone/LatestSolidMilestoneTracker.java
@@ -21,10 +21,10 @@ public interface LatestSolidMilestoneTracker {
      *
      * @throws MilestoneException if anything unexpected happens while updating the latest solid milestone
      */
-    void checkForNewLatestSolidMilestones() throws MilestoneException;
+    void trackLatestSolidMilestone() throws MilestoneException;
 
     /**
-     * This method starts the background worker that automatically calls {@link #checkForNewLatestSolidMilestones()}
+     * This method starts the background worker that automatically calls {@link #trackLatestSolidMilestone()}
      * periodically to keep the latest solid milestone up to date.<br />
      */
     void start();

--- a/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
@@ -14,8 +14,8 @@ import java.util.Optional;
  */
 public interface MilestoneService {
     /**
-     * This method tries to find the latest solid milestone that was previously processed by IRI (before a restart) by
-     * performing a search in the database.<br />
+     * Find the latest solid milestone that was previously processed by IRI (before a restart) by performing a search in
+     * the database.<br />
      * <br />
      * It determines if the milestones were processed by checking the {@code snapshotIndex} value of their corresponding
      * transactions.<br />

--- a/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
@@ -1,8 +1,11 @@
 package com.iota.iri.service.milestone;
 
+import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
+
+import java.util.Optional;
 
 /**
  * Represents the service that contains all the relevant business logic for interacting with milestones.<br />
@@ -10,6 +13,19 @@ import com.iota.iri.model.Hash;
  * This class is stateless and does not hold any domain specific models.<br />
  */
 public interface MilestoneService {
+    /**
+     * This method tries to find the latest solid milestone that was previously processed by IRI (before a restart) by
+     * performing a search in the database.<br />
+     * <br />
+     * It determines if the milestones were processed by checking the {@code snapshotIndex} value of their corresponding
+     * transactions.<br />
+     *
+     * @return the latest solid milestone that was previously processed by IRI or an empty value if no previously
+     *         processed solid milestone can be found
+     * @throws MilestoneException if anything unexpected happend while performing the search
+     */
+    Optional<MilestoneViewModel> findLatestProcessedSolidMilestoneInDatabase() throws MilestoneException;
+
     /**
      * Analyzes the given transaction to determine if it is a valid milestone.<br />
      * <br />

--- a/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneService.java
@@ -14,8 +14,8 @@ import java.util.Optional;
  */
 public interface MilestoneService {
     /**
-     * Find the latest solid milestone that was previously processed by IRI (before a restart) by performing a search in
-     * the database.<br />
+     * Finds the latest solid milestone that was previously processed by IRI (before a restart) by performing a search
+     * in the database.<br />
      * <br />
      * It determines if the milestones were processed by checking the {@code snapshotIndex} value of their corresponding
      * transactions.<br />

--- a/src/main/java/com/iota/iri/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
@@ -167,7 +167,7 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
                 }
             } else {
                 syncLatestMilestoneTracker(snapshotProvider.getLatestSnapshot().getHash(),
-                        snapshotProvider.getLatestSnapshot().getIndex());
+                        currentSolidMilestoneIndex);
             }
         } catch (Exception e) {
             throw new MilestoneException("unexpected error while checking for new latest solid milestones", e);

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
@@ -106,7 +106,7 @@ public class MilestoneServiceImpl implements MilestoneService {
      * <br />
      * We first check the trivial case where the node was fully synced. If no processed solid milestone could be found
      * within the last two milestones of the node, we perform a binary search from present to past, which reduces the
-     * amount of database requests to a minimum (even with huge amount of milestones in the database).<br />
+     * amount of database requests to a minimum (even with a huge amount of milestones in the database).<br />
      */
     @Override
     public Optional<MilestoneViewModel> findLatestProcessedSolidMilestoneInDatabase() throws MilestoneException {

--- a/src/test/java/com/iota/iri/TangleMockUtils.java
+++ b/src/test/java/com/iota/iri/TangleMockUtils.java
@@ -10,7 +10,6 @@ import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Pair;
 import org.mockito.Mockito;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/src/test/java/com/iota/iri/TangleMockUtils.java
+++ b/src/test/java/com/iota/iri/TangleMockUtils.java
@@ -16,9 +16,7 @@ import java.util.Map;
 public class TangleMockUtils {
     //region [mockMilestone] ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index, boolean applied,
-            Map<Hash, Long> balanceDiff) {
-
+    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index) {
         Milestone milestone = new Milestone();
         milestone.hash = hash;
         milestone.index = new IntegerIndex(index);
@@ -31,23 +29,7 @@ public class TangleMockUtils {
             // the exception can not be raised since we mock
         }
 
-        if (!balanceDiff.isEmpty()) {
-            mockStateDiff(tangle, milestone.hash, balanceDiff);
-        }
-
-        Transaction milestoneTransaction = mockTransaction(tangle, milestone.hash);
-        milestoneTransaction.snapshot = applied ? index : 0;
-        milestoneTransaction.milestone = true;
-
         return milestone;
-    }
-
-    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index, boolean applied) {
-        return mockMilestone(tangle, hash, index, applied, new HashMap<>());
-    }
-
-    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index) {
-        return mockMilestone(tangle, hash, index, true, new HashMap<>());
     }
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/iota/iri/TangleMockUtils.java
+++ b/src/test/java/com/iota/iri/TangleMockUtils.java
@@ -13,9 +13,31 @@ import org.mockito.Mockito;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Contains utilities that help to mock the retrieval of database entries from the tangle.<br />
+ * <br />
+ * Mocking the tangle allows us to write unit tests that perform much faster than spinning up a new database for every
+ * test.<br />
+ */
 public class TangleMockUtils {
     //region [mockMilestone] ///////////////////////////////////////////////////////////////////////////////////////////
 
+    /**
+     * Registers a {@link Milestone} in the mocked tangle that can consequently be accessed by the tested classes.<br />
+     * <br />
+     * It first creates the {@link Milestone} with the given details and then mocks the retrieval methods of the tangle
+     * to return this object. In addition to mocking the specific retrieval method for the given hash, we also mock the
+     * retrieval method for the "latest" entity so the mocked tangle returns the elements in the order that they were
+     * mocked / created (which allows the mocked tangle to behave just like a normal one).<br />
+     * <br />
+     * Note: We return the mocked object which allows us to set additional fields or modify it after "injecting" it into
+     *       the mocked tangle.<br />
+     *
+     * @param tangle mocked tangle object that shall retrieve a milestone object when being queried for it
+     * @param hash transaction hash of the milestone
+     * @param index milestone index of the milestone
+     * @return the Milestone object that be returned by the mocked tangle upon request
+     */
     public static Milestone mockMilestone(Tangle tangle, Hash hash, int index) {
         Milestone milestone = new Milestone();
         milestone.hash = hash;
@@ -68,10 +90,6 @@ public class TangleMockUtils {
         }
 
         return stateDiff;
-    }
-
-    public static StateDiff mockStateDiff(Tangle tangle, Hash hash) {
-        return mockStateDiff(tangle, hash, new HashMap<>());
     }
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/iota/iri/TangleMockUtils.java
+++ b/src/test/java/com/iota/iri/TangleMockUtils.java
@@ -1,0 +1,96 @@
+package com.iota.iri;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.IntegerIndex;
+import com.iota.iri.model.StateDiff;
+import com.iota.iri.model.persistables.Milestone;
+import com.iota.iri.model.persistables.Transaction;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.Pair;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TangleMockUtils {
+    //region [mockMilestone] ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index, boolean applied,
+            Map<Hash, Long> balanceDiff) {
+
+        Milestone milestone = new Milestone();
+        milestone.hash = hash;
+        milestone.index = new IntegerIndex(index);
+
+        try {
+            Mockito.when(tangle.load(Milestone.class, new IntegerIndex(index))).thenReturn(milestone);
+            Mockito.when(tangle.getLatest(Milestone.class, IntegerIndex.class)).thenReturn(new Pair<>(milestone.index,
+                    milestone));
+        } catch (Exception e) {
+            // the exception can not be raised since we mock
+        }
+
+        if (!balanceDiff.isEmpty()) {
+            mockStateDiff(tangle, milestone.hash, balanceDiff);
+        }
+
+        Transaction milestoneTransaction = mockTransaction(tangle, milestone.hash);
+        milestoneTransaction.snapshot = applied ? index : 0;
+        milestoneTransaction.milestone = true;
+
+        return milestone;
+    }
+
+    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index, boolean applied) {
+        return mockMilestone(tangle, hash, index, applied, new HashMap<>());
+    }
+
+    public static Milestone mockMilestone(Tangle tangle, Hash hash, int index) {
+        return mockMilestone(tangle, hash, index, true, new HashMap<>());
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //region [mockTransaction] /////////////////////////////////////////////////////////////////////////////////////////
+
+    public static Transaction mockTransaction(Tangle tangle, Hash hash) {
+        Transaction transaction = new Transaction();
+        transaction.bytes = new byte[0];
+        transaction.type = TransactionViewModel.FILLED_SLOT;
+        transaction.parsed = true;
+
+        try {
+            Mockito.when(tangle.load(Transaction.class, hash)).thenReturn(transaction);
+            Mockito.when(tangle.getLatest(Transaction.class, Hash.class)).thenReturn(new Pair<>(hash, transaction));
+        } catch (Exception e) {
+            // the exception can not be raised since we mock
+        }
+
+        return transaction;
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //region [mockStateDiff] ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static StateDiff mockStateDiff(Tangle tangle, Hash hash, Map<Hash, Long> balanceDiff) {
+        StateDiff stateDiff = new StateDiff();
+        stateDiff.state = balanceDiff;
+
+        try {
+            Mockito.when(tangle.load(StateDiff.class, hash)).thenReturn(stateDiff);
+            Mockito.when(tangle.getLatest(StateDiff.class, Hash.class)).thenReturn(new Pair<>(hash, stateDiff));
+        } catch (Exception e) {
+            // the exception can not be raised since we mock
+        }
+
+        return stateDiff;
+    }
+
+    public static StateDiff mockStateDiff(Tangle tangle, Hash hash) {
+        return mockStateDiff(tangle, hash, new HashMap<>());
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+}

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -1,0 +1,202 @@
+package com.iota.iri.service.milestone.impl;
+
+import com.iota.iri.conf.MainnetConfig;
+import com.iota.iri.controllers.MilestoneViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.HashFactory;
+import com.iota.iri.model.IntegerIndex;
+import com.iota.iri.model.persistables.Milestone;
+import com.iota.iri.model.persistables.Transaction;
+import com.iota.iri.service.milestone.MilestoneException;
+import com.iota.iri.service.snapshot.Snapshot;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.snapshot.SnapshotService;
+import com.iota.iri.storage.Indexable;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.Pair;
+import com.iota.iri.zmq.MessageQ;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MilestoneServiceImplTest {
+    //region [BOILERPLATE] /////////////////////////////////////////////////////////////////////////////////////////////
+
+    private static MilestoneServiceImpl milestoneService;
+
+    @Mock
+    private static Tangle tangle;
+
+    @Mock
+    private static SnapshotProvider snapshotProvider;
+
+    @Mock
+    private static SnapshotService snapshotService;
+
+    @Mock
+    private static MessageQ messageQ;
+
+    @BeforeClass
+    public static void setupClass() {
+        tangle = Mockito.mock(Tangle.class);
+        snapshotProvider = Mockito.mock(SnapshotProvider.class);
+        snapshotService = Mockito.mock(SnapshotService.class);
+        messageQ = Mockito.mock(MessageQ.class);
+
+        milestoneService = new MilestoneServiceImpl().init(tangle, snapshotProvider, snapshotService, messageQ,
+                new MainnetConfig());
+
+        mockSnapshotProvider();
+    }
+
+    @Before
+    public void setupTest() {
+        MilestoneViewModel.clear();
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //region [TESTS] ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void findLatestProcessedSolidMilestoneInDatabase_atEnd() throws Exception {
+        // hash / index / processed
+        mockMilestones(
+                "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
+                "BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 2,  false,
+                "CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 3,  false,
+                "JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 10, false,
+                "KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 11, false,
+                "LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 12, true
+        );
+
+        checkLatestProcessedSolidMilestone(12);
+    }
+
+    @Test
+    public void findLatestProcessedSolidMilestoneInDatabase_nearEnd() throws Exception {
+        // hash / index / processed
+        mockMilestones(
+                "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
+                "BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 2,  false,
+                "CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 3,  false,
+                "JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 10, false,
+                "KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 11, true,
+                "LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 12, false
+        );
+
+        checkLatestProcessedSolidMilestone(11);
+    }
+
+    @Test
+    public void findLatestProcessedSolidMilestoneInDatabase_atStart() throws Exception {
+        // hash / index / processed
+        mockMilestones(
+                "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
+                "BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 2,  false,
+                "CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 3,  false,
+                "JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 10, false,
+                "KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 11, false,
+                "LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 12, false
+        );
+
+        checkLatestProcessedSolidMilestone(1);
+    }
+
+    @Test
+    public void findLatestProcessedSolidMilestoneInDatabase_nearStart() throws Exception {
+        // hash / index / processed
+        mockMilestones(
+                "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
+                "BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 2,  true,
+                "CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 3,  false,
+                "JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 10, false,
+                "KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 11, false,
+                "LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 12, false
+        );
+
+        checkLatestProcessedSolidMilestone(2);
+    }
+
+    @Test
+    public void findLatestProcessedSolidMilestoneInDatabase_inMiddle() throws Exception {
+        // hash / index / processed
+        mockMilestones(
+                "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
+                "BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 2,  true,
+                "CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 3,  true,
+                "JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 10, false,
+                "KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 11, false,
+                "LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 12, false
+        );
+
+        checkLatestProcessedSolidMilestone(3);
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //region [UTILITY METHODS] /////////////////////////////////////////////////////////////////////////////////////////
+
+    private static void checkLatestProcessedSolidMilestone(int index) throws MilestoneException {
+        milestoneService.findLatestProcessedSolidMilestoneInDatabase().ifPresent(milestone -> {
+            try {
+                Assert.assertEquals((long) milestone.index(), ((Milestone) tangle.load(Milestone.class,
+                        new IntegerIndex(index))).index.getValue());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static void mockSnapshotProvider() {
+        Snapshot initialSnapshot = Mockito.mock(Snapshot.class);
+
+        Mockito.when(initialSnapshot.getIndex()).thenReturn(0);
+        Mockito.when(snapshotProvider.getInitialSnapshot()).thenReturn(initialSnapshot);
+    }
+
+    private static void mockMilestones(Object... params) throws Exception {
+        Pair<Indexable, Persistable> latestMilestone = null;
+        for (int i = 0; i < params.length / 3; i++) {
+            latestMilestone = mockMilestone(
+                    (String)  params[i * 3    ],
+                    (int)     params[i * 3 + 1],
+                    (boolean) params[i * 3 + 2]
+            );
+        }
+
+        Mockito.when(tangle.getLatest(Milestone.class, IntegerIndex.class)).thenReturn(latestMilestone);
+    }
+
+    private static Pair<Indexable, Persistable> mockMilestone(String hash, int index, boolean applied) throws
+            Exception {
+
+        Milestone latestMilestone = new Milestone();
+        latestMilestone.hash = HashFactory.TRANSACTION.create(hash);
+        latestMilestone.index = new IntegerIndex(index);
+
+        Mockito.when(tangle.load(Milestone.class, new IntegerIndex(index))).thenReturn(latestMilestone);
+
+        Transaction latestMilestoneTransaction = new Transaction();
+        latestMilestoneTransaction.bytes = new byte[0];
+        latestMilestoneTransaction.type = TransactionViewModel.FILLED_SLOT;
+        latestMilestoneTransaction.snapshot = applied ? index : 0;
+        latestMilestoneTransaction.parsed = true;
+
+        Mockito.when(tangle.load(Transaction.class, latestMilestone.hash)).thenReturn(latestMilestoneTransaction);
+
+        return new Pair<>(latestMilestone.index, latestMilestone);
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+}

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -69,7 +69,7 @@ public class MilestoneServiceImplTest {
     //region [TESTS] ///////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test
-    public void findLatestProcessedSolidMilestoneInDatabase_atEnd() throws Exception {
+    public void findLatestProcessedSolidMilestoneInDatabaseAtEnd() throws Exception {
         // hash / index / processed
         mockMilestones(
                 "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
@@ -84,7 +84,7 @@ public class MilestoneServiceImplTest {
     }
 
     @Test
-    public void findLatestProcessedSolidMilestoneInDatabase_nearEnd() throws Exception {
+    public void findLatestProcessedSolidMilestoneInDatabaseNearEnd() throws Exception {
         // hash / index / processed
         mockMilestones(
                 "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
@@ -99,7 +99,7 @@ public class MilestoneServiceImplTest {
     }
 
     @Test
-    public void findLatestProcessedSolidMilestoneInDatabase_atStart() throws Exception {
+    public void findLatestProcessedSolidMilestoneInDatabaseAtStart() throws Exception {
         // hash / index / processed
         mockMilestones(
                 "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
@@ -114,7 +114,7 @@ public class MilestoneServiceImplTest {
     }
 
     @Test
-    public void findLatestProcessedSolidMilestoneInDatabase_nearStart() throws Exception {
+    public void findLatestProcessedSolidMilestoneInDatabaseNearStart() throws Exception {
         // hash / index / processed
         mockMilestones(
                 "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,
@@ -129,7 +129,7 @@ public class MilestoneServiceImplTest {
     }
 
     @Test
-    public void findLatestProcessedSolidMilestoneInDatabase_inMiddle() throws Exception {
+    public void findLatestProcessedSolidMilestoneInDatabaseInMiddle() throws Exception {
         // hash / index / processed
         mockMilestones(
                 "ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 1,  true,

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -8,6 +8,7 @@ import com.iota.iri.model.persistables.Transaction;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.impl.SnapshotMockUtils;
 import com.iota.iri.storage.Tangle;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -66,6 +67,11 @@ public class MilestoneServiceImplTest {
     public void setUp() {
         SnapshotMockUtils.mockSnapshotProvider(snapshotProvider);
 
+        MilestoneViewModel.clear();
+    }
+
+    @After
+    public void tearDown() {
         MilestoneViewModel.clear();
     }
 

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -1,16 +1,13 @@
 package com.iota.iri.service.milestone.impl;
 
 import com.iota.iri.TangleMockUtils;
-import com.iota.iri.conf.ConsensusConfig;
 import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
-import com.iota.iri.service.milestone.MilestoneException;
+import com.iota.iri.model.persistables.Transaction;
 import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.snapshot.SnapshotService;
 import com.iota.iri.service.snapshot.impl.SnapshotMockUtils;
 import com.iota.iri.storage.Tangle;
-import com.iota.iri.zmq.MessageQ;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -26,6 +23,34 @@ import java.util.Optional;
 @RunWith(MockitoJUnitRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class MilestoneServiceImplTest {
+    //region [CONSTANTS FOR THE TEST] //////////////////////////////////////////////////////////////////////////////////
+
+    private enum MockedMilestone {
+        A("ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70001),
+        B("BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70002),
+        C("CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70003),
+        D("JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70010),
+        E("KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70011),
+        F("LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70012);
+
+        private final Hash transactionHash;
+
+        private final int milestoneIndex;
+
+        MockedMilestone(String transactionHash, int milestoneIndex) {
+            this.transactionHash = HashFactory.TRANSACTION.create(transactionHash);
+            this.milestoneIndex = milestoneIndex;
+        }
+
+        public void mockProcessed(Tangle tangle, boolean applied) {
+            TangleMockUtils.mockMilestone(tangle, transactionHash, milestoneIndex);
+            Transaction mockedTransaction = TangleMockUtils.mockTransaction(tangle, transactionHash);
+            mockedTransaction.snapshot = applied ? milestoneIndex : 0;
+        }
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     //region [BOILERPLATE] /////////////////////////////////////////////////////////////////////////////////////////////
 
     @Mock
@@ -33,15 +58,6 @@ public class MilestoneServiceImplTest {
 
     @Mock
     private SnapshotProvider snapshotProvider;
-
-    @Mock
-    private SnapshotService snapshotService;
-
-    @Mock
-    private MessageQ messageQ;
-
-    @Mock
-    private ConsensusConfig config;
 
     @InjectMocks
     private MilestoneServiceImpl milestoneService;
@@ -55,114 +71,105 @@ public class MilestoneServiceImplTest {
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    //region [findLatestProcessedSolidMilestoneInDatabase] /////////////////////////////////////////////////////////////
-
-    private enum MockedMilestone {
-        MILESTONE_1("ARWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70001),
-        MILESTONE_2("BRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70002),
-        MILESTONE_3("CRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70003),
-        MILESTONE_4("JRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70010),
-        MILESTONE_5("KRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70011),
-        MILESTONE_6("LRWY9LWHXEWNL9DTN9IGMIMIVSBQUIEIDSFRYTCSXQARRTVEUFSBWFZRQOJUQNAGQLWHTFNVECELCOFYB", 70012);
-
-        private final Hash transactionHash;
-
-        private final int milestoneIndex;
-
-        MockedMilestone(String transactionHash, int milestoneIndex) {
-            this.transactionHash = HashFactory.TRANSACTION.create(transactionHash);
-            this.milestoneIndex = milestoneIndex;
-        }
-
-        public void mockProcessed(Tangle tangle, boolean applied) {
-            TangleMockUtils.mockMilestone(tangle, transactionHash, milestoneIndex, applied);
-        }
-    }
+    //region [TEST: findLatestProcessedSolidMilestoneInDatabase] ///////////////////////////////////////////////////////
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseNone() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, false);
+        MockedMilestone.A.mockProcessed(tangle, false);
+        MockedMilestone.B.mockProcessed(tangle, false);
+        MockedMilestone.C.mockProcessed(tangle, false);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, false);
+        MockedMilestone.F.mockProcessed(tangle, false);
 
-        assertLatestProcessedSolidMilestoneEquals(null);
+        Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+        if (latestMilestone.isPresent()) {
+            Assert.fail("expected to find no latest processed solid milestone");
+        }
     }
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseAtEnd() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, true);
+        MockedMilestone.A.mockProcessed(tangle, true);
+        MockedMilestone.B.mockProcessed(tangle, false);
+        MockedMilestone.C.mockProcessed(tangle, false);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, false);
+        MockedMilestone.F.mockProcessed(tangle, true);
 
-        assertLatestProcessedSolidMilestoneEquals(MockedMilestone.MILESTONE_6);
+        Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+        if (latestMilestone.isPresent()) {
+            Assert.assertEquals((long) latestMilestone.get().index(), MockedMilestone.F.milestoneIndex);
+        } else {
+            Assert.fail("expected to find a latest processed solid milestone");
+        }
     }
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseNearEnd() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, false);
+        MockedMilestone.A.mockProcessed(tangle, true);
+        MockedMilestone.B.mockProcessed(tangle, false);
+        MockedMilestone.C.mockProcessed(tangle, false);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, true);
+        MockedMilestone.F.mockProcessed(tangle, false);
 
-        assertLatestProcessedSolidMilestoneEquals(MockedMilestone.MILESTONE_5);
+        Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+        if (latestMilestone.isPresent()) {
+            Assert.assertEquals((long) latestMilestone.get().index(), MockedMilestone.E.milestoneIndex);
+        } else {
+            Assert.fail("expected to find a latest processed solid milestone");
+        }
     }
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseAtStart() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, false);
+        MockedMilestone.A.mockProcessed(tangle, true);
+        MockedMilestone.B.mockProcessed(tangle, false);
+        MockedMilestone.C.mockProcessed(tangle, false);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, false);
+        MockedMilestone.F.mockProcessed(tangle, false);
 
-        assertLatestProcessedSolidMilestoneEquals(MockedMilestone.MILESTONE_1);
+        Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+        if (latestMilestone.isPresent()) {
+            Assert.assertEquals((long) latestMilestone.get().index(), MockedMilestone.A.milestoneIndex);
+        } else {
+            Assert.fail("expected to find a latest processed solid milestone");
+        }
     }
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseNearStart() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, false);
+        MockedMilestone.A.mockProcessed(tangle, true);
+        MockedMilestone.B.mockProcessed(tangle, true);
+        MockedMilestone.C.mockProcessed(tangle, false);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, false);
+        MockedMilestone.F.mockProcessed(tangle, false);
 
-        assertLatestProcessedSolidMilestoneEquals(MockedMilestone.MILESTONE_2);
+        Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
+        if (latestMilestone.isPresent()) {
+            Assert.assertEquals((long) latestMilestone.get().index(), MockedMilestone.B.milestoneIndex);
+        } else {
+            Assert.fail("expected to find a latest processed solid milestone");
+        }
     }
 
     @Test
     public void findLatestProcessedSolidMilestoneInDatabaseInMiddle() throws Exception {
-        MockedMilestone.MILESTONE_1.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_2.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_3.mockProcessed(tangle, true);
-        MockedMilestone.MILESTONE_4.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_5.mockProcessed(tangle, false);
-        MockedMilestone.MILESTONE_6.mockProcessed(tangle, false);
+        MockedMilestone.A.mockProcessed(tangle, true);
+        MockedMilestone.B.mockProcessed(tangle, true);
+        MockedMilestone.C.mockProcessed(tangle, true);
+        MockedMilestone.D.mockProcessed(tangle, false);
+        MockedMilestone.E.mockProcessed(tangle, false);
+        MockedMilestone.F.mockProcessed(tangle, false);
 
-        assertLatestProcessedSolidMilestoneEquals(MockedMilestone.MILESTONE_3);
-    }
-
-    private void assertLatestProcessedSolidMilestoneEquals(MockedMilestone mockedMilestone) throws MilestoneException {
         Optional<MilestoneViewModel> latestMilestone = milestoneService.findLatestProcessedSolidMilestoneInDatabase();
         if (latestMilestone.isPresent()) {
-            if (mockedMilestone == null) {
-                Assert.fail("expected to find no latest processed solid milestone");
-            } else {
-                Assert.assertEquals((long) latestMilestone.get().index(), mockedMilestone.milestoneIndex);
-            }
+            Assert.assertEquals((long) latestMilestone.get().index(), MockedMilestone.C.milestoneIndex);
         } else {
-            if (mockedMilestone != null) {
-                Assert.fail("expected to find a latest processed solid milestone");
-            }
+            Assert.fail("expected to find a latest processed solid milestone");
         }
     }
 

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -63,7 +63,7 @@ public class MilestoneServiceImplTest {
     private MilestoneServiceImpl milestoneService;
 
     @Before
-    public void setup() {
+    public void setUp() {
         SnapshotMockUtils.mockSnapshotProvider(snapshotProvider);
 
         MilestoneViewModel.clear();

--- a/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotMockUtils.java
+++ b/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotMockUtils.java
@@ -1,0 +1,64 @@
+package com.iota.iri.service.snapshot.impl;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.snapshot.Snapshot;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SnapshotMockUtils {
+    private static final int DEFAULT_MILESTONE_START_INDEX = 70000;
+
+    private static final Hash DEFAULT_GENESIS_HASH = Hash.NULL_HASH;
+
+    private static final long DEFAULT_GENESIS_TIMESTAMP = 1522146728;
+
+    //region [mockSnapshotProvider] ////////////////////////////////////////////////////////////////////////////////////
+
+    public static SnapshotProvider mockSnapshotProvider(SnapshotProvider snapshotProvider) {
+        return mockSnapshotProvider(snapshotProvider, DEFAULT_MILESTONE_START_INDEX);
+    }
+
+    public static SnapshotProvider mockSnapshotProvider(SnapshotProvider snapshotProvider, int milestoneStartIndex) {
+        return mockSnapshotProvider(snapshotProvider, milestoneStartIndex, DEFAULT_GENESIS_HASH);
+    }
+
+    public static SnapshotProvider mockSnapshotProvider(SnapshotProvider snapshotProvider, int milestoneStartIndex,
+            Hash genesisHash) {
+
+        return mockSnapshotProvider(snapshotProvider, milestoneStartIndex, genesisHash, DEFAULT_GENESIS_TIMESTAMP);
+    }
+
+    public static SnapshotProvider mockSnapshotProvider(SnapshotProvider snapshotProvider, int milestoneStartIndex,
+            Hash genesisHash, long genesisTimestamp) {
+
+        Map<Hash, Long> balances = new HashMap<>();
+        balances.put(Hash.NULL_HASH, TransactionViewModel.SUPPLY);
+
+        return mockSnapshotProvider(snapshotProvider, milestoneStartIndex, genesisHash, genesisTimestamp, balances);
+    }
+
+    public static SnapshotProvider mockSnapshotProvider(SnapshotProvider snapshotProvider, int milestoneStartIndex,
+            Hash genesisHash, long genesisTimestamp, Map<Hash, Long> balances) {
+
+        Map<Hash, Integer> solidEntryPoints = new HashMap<>();
+        solidEntryPoints.put(genesisHash, milestoneStartIndex);
+
+        Snapshot initialSnapshot = new SnapshotImpl(
+                new SnapshotStateImpl(balances),
+                new SnapshotMetaDataImpl(genesisHash, milestoneStartIndex, genesisTimestamp, solidEntryPoints,
+                        new HashMap<>())
+        );
+        Snapshot latestSnapshot = new SnapshotImpl(initialSnapshot);
+
+        Mockito.when(snapshotProvider.getInitialSnapshot()).thenReturn(initialSnapshot);
+        Mockito.when(snapshotProvider.getLatestSnapshot()).thenReturn(latestSnapshot);
+
+        return snapshotProvider;
+    }
+
+    //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
+}

--- a/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotMockUtils.java
+++ b/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotMockUtils.java
@@ -14,6 +14,8 @@ public class SnapshotMockUtils {
 
     private static final Hash DEFAULT_GENESIS_HASH = Hash.NULL_HASH;
 
+    private static final Hash DEFAULT_GENESIS_ADDRESS = Hash.NULL_HASH;
+
     private static final long DEFAULT_GENESIS_TIMESTAMP = 1522146728;
 
     //region [mockSnapshotProvider] ////////////////////////////////////////////////////////////////////////////////////
@@ -36,7 +38,7 @@ public class SnapshotMockUtils {
             Hash genesisHash, long genesisTimestamp) {
 
         Map<Hash, Long> balances = new HashMap<>();
-        balances.put(Hash.NULL_HASH, TransactionViewModel.SUPPLY);
+        balances.put(DEFAULT_GENESIS_ADDRESS, TransactionViewModel.SUPPLY);
 
         return mockSnapshotProvider(snapshotProvider, milestoneStartIndex, genesisHash, genesisTimestamp, balances);
     }


### PR DESCRIPTION
# Description

This PR introduces a way to fast forward the ledger state after a restart of IRI. Previously we had to rescan all milestones to rebuild the ledger state. Especially for nodes that start off with a non-snapshotted database, this could take a really long time (a few hours). In combination with the upcoming refactor of the replayMilestones method this allows us to massively decrease the time and resources that are required for this operation (to a few seconds rather than hours).

## Type of change

- Enhancement (a non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
