### PR TITLE
Refactor: Removed grace time from solid entry points generation

### DIFF
--- a/src/main/java/com/iota/iri/network/TCPNeighbor.java
+++ b/src/main/java/com/iota/iri/network/TCPNeighbor.java
@@ -14,12 +14,12 @@ import java.util.concurrent.TimeUnit;
 /**
  * Created by paul on 4/15/17.
  */
- 
+
  /**
- * This class Extends {@link Neighbor} base class with TCP specific functionality. 
+ * This class Extends {@link Neighbor} base class with TCP specific functionality.
  * It keeps reference of Source and Sink while maintaining a sendQueue for keeping
- * outgoing requests. 
- * 
+ * outgoing requests.
+ *
  */
 public class TCPNeighbor extends Neighbor {
     private static final Logger log = LoggerFactory.getLogger(Neighbor.class);
@@ -93,7 +93,7 @@ public class TCPNeighbor extends Neighbor {
         synchronized (sendQueue) {
             if (sendQueue.remainingCapacity() == 0) {
                 sendQueue.poll();
-                log.info("Sendqueue full...dropped 1 tx");
+                log.debug("Sendqueue full...dropped 1 tx");
             }
             byte[] bytes = packet.getData().clone();
             sendQueue.add(ByteBuffer.wrap(bytes));

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
@@ -43,11 +43,6 @@ public class SnapshotServiceImpl implements SnapshotService {
     private static final Logger log = LoggerFactory.getLogger(SnapshotServiceImpl.class);
 
     /**
-     * If transactions got orphaned we wait this additional time (in seconds) until we consider them orphaned.
-     */
-    private static final int ORPHANED_TRANSACTION_GRACE_TIME = 3600;
-
-    /**
      * Maximum age in milestones since creation of solid entry points.
      *
      * Since it is possible to artificially keep old solid entry points alive by periodically attaching new transactions
@@ -491,7 +486,7 @@ public class SnapshotServiceImpl implements SnapshotService {
     private boolean isOrphaned(Tangle tangle, TransactionViewModel transaction,
             TransactionViewModel referenceTransaction, Set<Hash> processedTransactions) throws SnapshotException {
 
-        long arrivalTime = transaction.getArrivalTime() / 1000L + ORPHANED_TRANSACTION_GRACE_TIME;
+        long arrivalTime = transaction.getArrivalTime() / 1000L;
         if (arrivalTime > referenceTransaction.getTimestamp()) {
             return false;
         }


### PR DESCRIPTION
# Description

This PR removes the grace time from the solid entry points generation. It was added in the past to work around the back referencing transaction issue. Since the issue can not be solved by just keeping the solid entry points alive for a little longer time and needs to be addressed separately (we will use cuckoo filters for this later on), it can and should be removed.

Especially in scenarios where we have a lot of TPS and a side tangle (like it happened today) it can slow the snapshot generation noticable and disrupt the operation of the node.

Note: This PR also changes the info message when the sendqueue is full to being a debug message because it can otherwise spam the CLI output making it very hard to debug problems and see important messages of the console output.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
