### PR TITLE
Local_Snapshots_Pruning_Enabled should depend on Local_Snapshots_Enabled config

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -1,16 +1,18 @@
 package com.iota.iri.conf;
 
+import com.iota.iri.IRI;
+import com.iota.iri.utils.IotaUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.iota.iri.IRI;
-import com.iota.iri.utils.IotaUtils;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 
 /*
   Note: the fields in this class are being deserialized from Jackson so they must follow Java Bean convention.
@@ -465,7 +467,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
 
     @Override
     public boolean getLocalSnapshotsPruningEnabled() {
-        return this.localSnapshotsPruningEnabled;
+        return this.localSnapshotsEnabled && this.localSnapshotsPruningEnabled;
     }
 
     @JsonProperty


### PR DESCRIPTION
# Description

Local snapshot pruning configuration should always be false if Local snapshot is not enabled.
Fixes the problem that getNodeInfo may report that Pruning is enabled while Local Snapshots is disabled.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing unit tests have passed


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
