### PR TITLE
IRI can read global snapshot files from current working directory

### DIFF
--- a/src/main/java/com/iota/iri/SignedFiles.java
+++ b/src/main/java/com/iota/iri/SignedFiles.java
@@ -31,7 +31,7 @@ public class SignedFiles {
         int i;
 
         try (BufferedReader reader = new BufferedReader(
-                IotaIOUtils.getFileStreamFromCwdOrResource(signatureFilePath))) {
+                IotaIOUtils.getFileStreamFromFileOrResource(signatureFilePath))) {
 
             String line;
             for (i = 0; i < 3 && (line = reader.readLine()) != null; i++) {
@@ -57,7 +57,7 @@ public class SignedFiles {
     }
 
     private static byte[] digestFile(String filePath, Sponge curl) throws IOException {
-        try (BufferedReader reader = new BufferedReader(IotaIOUtils.getFileStreamFromCwdOrResource(filePath))) {
+        try (BufferedReader reader = new BufferedReader(IotaIOUtils.getFileStreamFromFileOrResource(filePath))) {
             byte[] buffer = new byte[Curl.HASH_LENGTH * 3];
 
             reader.lines().forEach(line -> {

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -95,6 +95,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected String snapshotFile = Defaults.SNAPSHOT_FILE;
     protected String snapshotSignatureFile = Defaults.SNAPSHOT_SIG_FILE;
     protected long snapshotTime = Defaults.GLOBAL_SNAPSHOT_TIME;
+    protected int milestoneStartIndex = Defaults.MILESTONE_START_INDEX;
 
     public BaseIotaConfig() {
         //empty constructor
@@ -600,7 +601,13 @@ public abstract class BaseIotaConfig implements IotaConfig {
 
     @Override
     public int getMilestoneStartIndex() {
-        return Defaults.MILESTONE_START_INDEX;
+        return milestoneStartIndex;
+    }
+
+    @JsonProperty
+    @Parameter(names = "--milestone-start", description = SnapshotConfig.Descriptions.MILESTONE_START_INDEX)
+    protected void setMilestoneStartIndex(int milestoneStartIndex) {
+        this.milestoneStartIndex = milestoneStartIndex;
     }
 
     @Override

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -92,6 +92,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected int localSnapshotsIntervalUnsynced = Defaults.LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED;
     protected int localSnapshotsDepth = Defaults.LOCAL_SNAPSHOTS_DEPTH;
     protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
+    protected String snapshotFile = Defaults.SNAPSHOT_FILE;
+    protected String snapshotSignatureFile = Defaults.SNAPSHOT_SIG_FILE;
+    protected long snapshotTime = Defaults.GLOBAL_SNAPSHOT_TIME;
 
     public BaseIotaConfig() {
         //empty constructor
@@ -559,17 +562,35 @@ public abstract class BaseIotaConfig implements IotaConfig {
 
     @Override
     public long getSnapshotTime() {
-        return Defaults.GLOBAL_SNAPSHOT_TIME;
+        return snapshotTime;
+    }
+
+    @JsonProperty
+    @Parameter(names = "--snapshot-timestamp", description = SnapshotConfig.Descriptions.SNAPSHOT_TIME)
+    protected void setSnapshotTime(long snapshotTime) {
+        this.snapshotTime = snapshotTime;
     }
 
     @Override
     public String getSnapshotFile() {
-        return Defaults.SNAPSHOT_FILE;
+        return snapshotFile;
+    }
+
+    @JsonProperty
+    @Parameter(names = "--snapshot", description = SnapshotConfig.Descriptions.SNAPSHOT_FILE)
+    protected void setSnapshotFile(String snapshotFile) {
+        this.snapshotFile = snapshotFile;
     }
 
     @Override
     public String getSnapshotSignatureFile() {
-        return Defaults.SNAPSHOT_SIG_FILE;
+        return snapshotSignatureFile;
+    }
+
+    @JsonProperty
+    @Parameter(names = "--snapshot-sig", description = SnapshotConfig.Descriptions.SNAPSHOT_SIGNATURE_FILE)
+    protected void setSnapshotSignatureFile(String snapshotSignatureFile) {
+        this.snapshotSignatureFile = snapshotSignatureFile;
     }
 
     @Override

--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -1,17 +1,15 @@
 package com.iota.iri.conf;
 
+import java.util.Objects;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Objects;
 
 public class TestnetConfig extends BaseIotaConfig {
 
     protected String coordinator = Defaults.COORDINATOR_ADDRESS;
     protected boolean dontValidateTestnetMilestoneSig = Defaults.DONT_VALIDATE_MILESTONE_SIG;
-    protected String snapshotFile = Defaults.SNAPSHOT_FILE;
-    protected String snapshotSignatureFile = Defaults.SNAPSHOT_SIG;
     protected long snapshotTime = Defaults.SNAPSHOT_TIME;
     protected int mwm = Defaults.MWM;
     protected int milestoneStartIndex = Defaults.MILESTONE_START_INDEX;
@@ -24,6 +22,8 @@ public class TestnetConfig extends BaseIotaConfig {
         dbPath = Defaults.DB_PATH;
         dbLogPath = Defaults.DB_LOG_PATH;
         localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
+        snapshotFile = Defaults.SNAPSHOT_FILE;
+        snapshotSignatureFile = Defaults.SNAPSHOT_SIG;
     }
 
     @Override
@@ -51,39 +51,6 @@ public class TestnetConfig extends BaseIotaConfig {
     @Parameter(names = "--testnet-no-coo-validation", description = MilestoneConfig.Descriptions.DONT_VALIDATE_TESTNET_MILESTONE_SIG)
     protected void setDontValidateTestnetMilestoneSig(boolean dontValidateTestnetMilestoneSig) {
         this.dontValidateTestnetMilestoneSig = dontValidateTestnetMilestoneSig;
-    }
-
-    @Override
-    public String getSnapshotFile() {
-        return snapshotFile;
-    }
-
-    @JsonProperty
-    @Parameter(names = "--snapshot", description = SnapshotConfig.Descriptions.SNAPSHOT_FILE)
-    protected void setSnapshotFile(String snapshotFile) {
-        this.snapshotFile = snapshotFile;
-    }
-
-    @Override
-    public String getSnapshotSignatureFile() {
-        return snapshotSignatureFile;
-    }
-
-    @JsonProperty
-    @Parameter(names = "--snapshot-sig", description = SnapshotConfig.Descriptions.SNAPSHOT_SIGNATURE_FILE)
-    protected void setSnapshotSignatureFile(String snapshotSignatureFile) {
-        this.snapshotSignatureFile = snapshotSignatureFile;
-    }
-
-    @Override
-    public long getSnapshotTime() {
-        return snapshotTime;
-    }
-
-    @JsonProperty
-    @Parameter(names = "--snapshot-timestamp", description = SnapshotConfig.Descriptions.SNAPSHOT_TIME)
-    protected void setSnapshotTime(long snapshotTime) {
-        this.snapshotTime = snapshotTime;
     }
 
     @Override

--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -65,17 +65,6 @@ public class TestnetConfig extends BaseIotaConfig {
     }
 
     @Override
-    public int getMilestoneStartIndex() {
-        return milestoneStartIndex;
-    }
-
-    @JsonProperty
-    @Parameter(names = "--milestone-start", description = SnapshotConfig.Descriptions.MILESTONE_START_INDEX)
-    protected void setMilestoneStartIndex(int milestoneStartIndex) {
-        this.milestoneStartIndex = milestoneStartIndex;
-    }
-
-    @Override
     public int getNumberOfKeysInMilestone() {
         return numberOfKeysInMilestone;
     }

--- a/src/main/java/com/iota/iri/conf/TestnetConfig.java
+++ b/src/main/java/com/iota/iri/conf/TestnetConfig.java
@@ -10,7 +10,6 @@ public class TestnetConfig extends BaseIotaConfig {
 
     protected String coordinator = Defaults.COORDINATOR_ADDRESS;
     protected boolean dontValidateTestnetMilestoneSig = Defaults.DONT_VALIDATE_MILESTONE_SIG;
-    protected long snapshotTime = Defaults.SNAPSHOT_TIME;
     protected int mwm = Defaults.MWM;
     protected int milestoneStartIndex = Defaults.MILESTONE_START_INDEX;
     protected int numberOfKeysInMilestone = Defaults.KEYS_IN_MILESTONE;
@@ -24,6 +23,7 @@ public class TestnetConfig extends BaseIotaConfig {
         localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
         snapshotFile = Defaults.SNAPSHOT_FILE;
         snapshotSignatureFile = Defaults.SNAPSHOT_SIG;
+        snapshotTime = Defaults.SNAPSHOT_TIME;
     }
 
     @Override

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -237,7 +237,7 @@ public class SnapshotProviderImpl implements SnapshotProvider {
 
             SnapshotState snapshotState;
             try {
-                snapshotState = readSnapshotState(IotaIOUtils.getFileStreamFromCwdOrResource(config.getSnapshotFile()));
+                snapshotState = readSnapshotState(IotaIOUtils.getFileStreamFromFileOrResource(config.getSnapshotFile()));
             } catch (IOException e) {
                 throw new SnapshotException("failed to load global snapshot");
             }

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -271,11 +271,12 @@ public class SnapshotProviderImpl implements SnapshotProvider {
     //region SNAPSHOT STATE RELATED UTILITY METHODS ////////////////////////////////////////////////////////////////////
 
     /**
-     * This method reads the balances from the given snapshot state file.
+     * This method reads the balances from the given snapshot state reader.
      *
      * The format of the input is pairs of "address;balance" separated by newlines. It simply reads the input line by
      * line, adding the corresponding values to the map.
      *
+     * @param inputStreamReader reader of the ledger state stream
      * @return the unserialized version of the snapshot state state file
      * @throws SnapshotException if anything goes wrong while reading the state file
      */

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -9,10 +9,21 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Utility class that helps access IO
+ */
 public class IotaIOUtils extends IOUtils {
 
     private static final Logger log = LoggerFactory.getLogger(IotaIOUtils.class);
 
+    /**
+     * Looks up a file in the current working directory. If not available checks to see it is available
+     * as a resource bundled in the Jar.
+     *
+     * @param path the relative path of the file\resource we are looking up. Should be prefixed with {@code \}.
+     * @return A stream reader of the file\resource
+     * @throws IOException if no file was loaded
+     */
     public static InputStreamReader getFileStreamFromCwdOrResource(String path) throws IOException {
         String cwdPath = Paths.get("").toAbsolutePath().toString();
         File file = new File(cwdPath + path);

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -1,6 +1,10 @@
 package com.iota.iri.utils;
 
 
+import java.io.*;
+import java.nio.file.Paths;
+import java.util.Objects;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,6 +12,25 @@ import org.slf4j.LoggerFactory;
 public class IotaIOUtils extends IOUtils {
 
     private static final Logger log = LoggerFactory.getLogger(IotaIOUtils.class);
+
+    public static InputStreamReader getFileStreamFromCwdOrResource(String path) throws IOException {
+        String cwdPath = Paths.get("").toAbsolutePath().toString();
+        File file = new File(cwdPath + path);
+        try {
+            if (file.exists()) {
+                log.info(path + " has been found in the current working directory");
+                return new FileReader(file);
+            }
+            else {
+                InputStream resourceAsStream = IotaIOUtils.class.getResourceAsStream(path);
+                Objects.requireNonNull(resourceAsStream, path + " resource is missing");
+                log.info(path + " has been found as a jar resource");
+                return new InputStreamReader(resourceAsStream);
+            }
+        } catch (NullPointerException e) {
+            throw new IOException("Can't load resource " + path, e);
+        }
+    }
 
     public static void closeQuietly(AutoCloseable... autoCloseables) {
         for (AutoCloseable it : autoCloseables) {

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -2,7 +2,6 @@ package com.iota.iri.utils;
 
 
 import java.io.*;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 import org.apache.commons.io.IOUtils;
@@ -25,8 +24,7 @@ public class IotaIOUtils extends IOUtils {
      * @throws IOException if no file was loaded
      */
     public static InputStreamReader getFileStreamFromCwdOrResource(String path) throws IOException {
-        String cwdPath = Paths.get("").toAbsolutePath().toString();
-        File file = new File(cwdPath + path);
+        File file = new File(path);
         try {
             if (file.exists()) {
                 log.info(path + " has been found in the current working directory");

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -27,7 +27,7 @@ public class IotaIOUtils extends IOUtils {
         File file = new File(path);
         try {
             if (file.exists()) {
-                log.info(path + " has been found in the current working directory");
+                log.info(path + " has been found in the configured path in the file system");
                 return new FileReader(file);
             }
             else {

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -23,7 +23,7 @@ public class IotaIOUtils extends IOUtils {
      * @return A stream reader of the file\resource
      * @throws IOException if no file was loaded
      */
-    public static InputStreamReader getFileStreamFromCwdOrResource(String path) throws IOException {
+    public static InputStreamReader getFileStreamFromFileOrResource(String path) throws IOException {
         File file = new File(path);
         try {
             if (file.exists()) {

--- a/src/test/java/com/iota/iri/utils/IotaIOUtilsTest.java
+++ b/src/test/java/com/iota/iri/utils/IotaIOUtilsTest.java
@@ -1,9 +1,12 @@
 package com.iota.iri.utils;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -12,18 +15,21 @@ import static org.junit.Assert.assertThat;
 
 public class IotaIOUtilsTest {
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void testGetFileStreamFromCwd() throws IOException {
-        //We could have created a temporary file but then there may be permission problems
-        String path = "/checkstyle.xml";
+        File test = folder.newFile("test");
+        String path = test.getPath();
         assertThat(path + " is being treated as resource and not a local file",
-                IotaIOUtils.getFileStreamFromCwdOrResource(path), instanceOf(FileReader.class));
+                IotaIOUtils.getFileStreamFromFileOrResource(path), instanceOf(FileReader.class));
     }
 
     @Test
     public void testGetFileStreamFromResource() throws IOException {
         String path = "/snapshotMainnet.sig";
         assertThat(path + " is being treated as a local file and not a resource",
-                IotaIOUtils.getFileStreamFromCwdOrResource(path), not(instanceOf(FileReader.class)));
+                IotaIOUtils.getFileStreamFromFileOrResource(path), not(instanceOf(FileReader.class)));
     }
 }

--- a/src/test/java/com/iota/iri/utils/IotaIOUtilsTest.java
+++ b/src/test/java/com/iota/iri/utils/IotaIOUtilsTest.java
@@ -1,0 +1,29 @@
+package com.iota.iri.utils;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+
+public class IotaIOUtilsTest {
+
+    @Test
+    public void testGetFileStreamFromCwd() throws IOException {
+        //We could have created a temporary file but then there may be permission problems
+        String path = "/checkstyle.xml";
+        assertThat(path + " is being treated as resource and not a local file",
+                IotaIOUtils.getFileStreamFromCwdOrResource(path), instanceOf(FileReader.class));
+    }
+
+    @Test
+    public void testGetFileStreamFromResource() throws IOException {
+        String path = "/snapshotMainnet.sig";
+        assertThat(path + " is being treated as a local file and not a resource",
+                IotaIOUtils.getFileStreamFromCwdOrResource(path), not(instanceOf(FileReader.class)));
+    }
+}


### PR DESCRIPTION
# Description

In order to share global state more easily with the community without performing a release, we want to be able to load snapshot data from the current working directory.
With the changes here we will first search for files in the current working directory before we try to load them from the jar.

This current PR itself won't suffice because we still need to load metadata about the signature (i.e. merkle tree leaf used). A later PR will solve this.


## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Was ran from jar locally and tested with files in current working directory.

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
****