### PR TITLE
Fix: Node requested old transactions forever

### DIFF
--- a/src/main/java/com/iota/iri/network/impl/TransactionRequesterWorkerImpl.java
+++ b/src/main/java/com/iota/iri/network/impl/TransactionRequesterWorkerImpl.java
@@ -147,6 +147,9 @@ public class TransactionRequesterWorkerImpl implements TransactionRequesterWorke
      */
     private TransactionViewModel getTransactionToSendWithRequest() throws Exception {
         Hash tip = tipsViewModel.getRandomSolidTipHash();
+        if (tip == null) {
+            tip = tipsViewModel.getRandomNonSolidTipHash();
+        }
 
         return TransactionViewModel.fromHash(tangle, tip == null ? Hash.NULL_HASH : tip);
     }


### PR DESCRIPTION
# Description

Because of a bug in the checkSolidity function and a problem with the bottom->top solidifier (missing cuckoo filter) the node started requesting very old transactions and never stopped which at some point overwhelmed the requester (and increased the resource consumption).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
