### PR TITLE
SolidificationConfig for the tipsolidifier

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -152,7 +152,7 @@ public class Iota {
                 latestMilestoneTracker, messageQ, configuration);
         replicator = new Replicator(node, configuration);
         udpReceiver = new UDPReceiver(node, configuration);
-        tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel);
+        tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel, configuration);
         tipsSelector = createTipSelector(configuration);
 
         injectDependencies();

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -710,11 +710,6 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected void setTipSolidifierEnabled(boolean tipSolidifierEnabled) {
         this.tipSolidifierEnabled = tipSolidifierEnabled;
     }
-
-    @Parameter(names = "--disable-tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER)
-    protected void setTipSolidifierEnabled() {
-        this.tipSolidifierEnabled = false;
-    }
     
     @Override
     public int getBelowMaxDepthTransactionLimit() {

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -705,13 +705,13 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     @JsonProperty
-    @Parameter(names = "--tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER_ENABLED, 
+    @Parameter(names = "--tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER, 
         arity = 1)
     protected void setTipSolidifierEnabled(boolean tipSolidifierEnabled) {
         this.tipSolidifierEnabled = tipSolidifierEnabled;
     }
 
-    @Parameter(names = "--disable-tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER_ENABLED)
+    @Parameter(names = "--disable-tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER)
     protected void setTipSolidifierEnabled() {
         this.tipSolidifierEnabled = false;
     }

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -80,7 +80,10 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected int maxDepth = Defaults.MAX_DEPTH;
     protected double alpha = Defaults.ALPHA;
     private int maxAnalyzedTransactions = Defaults.MAX_ANALYZED_TXS;
-
+    
+    //Tip Solidification
+    protected boolean tipSolidifierEnabled = Defaults.TIP_SOLIDIFIER_ENABLED;
+    
     //PearlDiver
     protected int powThreads = Defaults.POW_THREADS;
 
@@ -695,7 +698,24 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected void setAlpha(double alpha) {
         this.alpha = alpha;
     }
+    
+    @Override
+    public boolean isTipSolidifierEnabled() {
+        return tipSolidifierEnabled;
+    }
 
+    @JsonProperty
+    @Parameter(names = "--tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER_ENABLED, 
+        arity = 1)
+    protected void setTipSolidifierEnabled(boolean tipSolidifierEnabled) {
+        this.tipSolidifierEnabled = tipSolidifierEnabled;
+    }
+
+    @Parameter(names = "--disable-tip-solidifier", description = SolidificationConfig.Descriptions.TIP_SOLIDIFIER_ENABLED)
+    protected void setTipSolidifierEnabled() {
+        this.tipSolidifierEnabled = false;
+    }
+    
     @Override
     public int getBelowMaxDepthTransactionLimit() {
         return maxAnalyzedTransactions;
@@ -773,6 +793,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
         //TipSel
         int MAX_DEPTH = 15;
         double ALPHA = 0.001d;
+        
+        //Tip solidification
+        boolean TIP_SOLIDIFIER_ENABLED = true;
 
         //PearlDiver
         int POW_THREADS = 0;

--- a/src/main/java/com/iota/iri/conf/IotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/IotaConfig.java
@@ -10,7 +10,7 @@ import java.io.File;
  *  In charge of how we parse the configuration from given inputs.
  */
 public interface IotaConfig extends APIConfig, NodeConfig,
-        IXIConfig, DbConfig, ConsensusConfig, ZMQConfig, TipSelConfig, PearlDiverConfig {
+        IXIConfig, DbConfig, ConsensusConfig, ZMQConfig, TipSelConfig, PearlDiverConfig, SolidificationConfig {
     File CONFIG_FILE = new File("iota.ini");
 
     /**

--- a/src/main/java/com/iota/iri/conf/SolidificationConfig.java
+++ b/src/main/java/com/iota/iri/conf/SolidificationConfig.java
@@ -1,0 +1,22 @@
+package com.iota.iri.conf;
+
+/**
+ * 
+ * Configurations that should be used for the tip solidification process, 
+ * You can also completely disable the process.
+ */
+public interface SolidificationConfig extends Config {
+
+    /**
+     * @return {@value Descriptions#TIP_SOLIDIFIER_ENABLED}
+     */
+    boolean isTipSolidifierEnabled();
+    
+    /**
+     * Field descriptions
+     */
+    interface Descriptions {
+
+        String TIP_SOLIDIFIER_ENABLED = "Flag that determines if tip solidification is enabled.";
+    }
+}

--- a/src/main/java/com/iota/iri/conf/SolidificationConfig.java
+++ b/src/main/java/com/iota/iri/conf/SolidificationConfig.java
@@ -8,7 +8,9 @@ package com.iota.iri.conf;
 public interface SolidificationConfig extends Config {
 
     /**
-     * @return {@value Descriptions#TIP_SOLIDIFIER_ENABLED}
+     * Default Value: {@value BaseIotaConfig.Defaults#TIP_SOLIDIFIER_ENABLED}
+     * 
+     * @return {@value SolidificationConfig.Descriptions#TIP_SOLIDIFIER}
      */
     boolean isTipSolidifierEnabled();
     
@@ -17,6 +19,6 @@ public interface SolidificationConfig extends Config {
      */
     interface Descriptions {
 
-        String TIP_SOLIDIFIER_ENABLED = "Flag that determines if tip solidification is enabled.";
+        String TIP_SOLIDIFIER = "Scan the current tips and attempt to mark them as solid";
     }
 }

--- a/src/main/java/com/iota/iri/service/Feature.java
+++ b/src/main/java/com/iota/iri/service/Feature.java
@@ -39,7 +39,14 @@ public enum Feature {
     /**
      * This node has the zero message queue enabled for fetching/reading "activities" on the node
      */
-    ZMQ("zeroMessageQueue");
+    ZMQ("zeroMessageQueue"),
+    
+    /**
+     * This node will solidify its tips. 
+     * A solid tip is a transaction which is not approved by another transaction
+     * and the transactions it approves are known and solid as well.
+     */
+    SOLID_TIPS("tipSolidification");
     
     private String name;
 
@@ -71,6 +78,9 @@ public enum Feature {
         }
         if (configuration.isZmqEnabled()) {
             features.add(ZMQ);
+        }
+        if (configuration.isTipSolidifierEnabled()) {
+            features.add(SOLID_TIPS);
         }
         
         List<Feature> apiFeatures = new ArrayList<Feature>(Arrays.asList(new Feature[] {

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -1,6 +1,7 @@
 package com.iota.iri.service;
 
 import com.iota.iri.TransactionValidator;
+import com.iota.iri.conf.SolidificationConfig;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
@@ -14,20 +15,28 @@ public class TipsSolidifier {
     private final Tangle tangle;
     private final TipsViewModel tipsViewModel;
     private final TransactionValidator transactionValidator;
-
+    private final SolidificationConfig config;
+    
     private boolean shuttingDown = false;
     private int RESCAN_TX_TO_REQUEST_INTERVAL = 750;
     private Thread solidityRescanHandle;
+    
 
     public TipsSolidifier(final Tangle tangle,
                           final TransactionValidator transactionValidator,
-                          final TipsViewModel tipsViewModel) {
+                          final TipsViewModel tipsViewModel,
+                          final SolidificationConfig config) {
         this.tangle = tangle;
         this.transactionValidator = transactionValidator;
         this.tipsViewModel = tipsViewModel;
+        this.config = config;
     }
 
     public void init() {
+        if (!enabled()) {
+            return;
+        }
+        
         solidityRescanHandle = new Thread(() -> {
 
             long lastTime = 0;
@@ -36,7 +45,7 @@ public class TipsSolidifier {
                     scanTipsForSolidity();
                     if (log.isDebugEnabled()) {
                         long now = System.currentTimeMillis();
-                        if ((now - lastTime) > 10000L) {
+                        if ((now - lastTime) > getLogDelay()) {
                             lastTime = now;
                             log.debug("#Solid/NonSolid: {}/{}", tipsViewModel.solidSize(), tipsViewModel.nonSolidSize());
                         }
@@ -45,7 +54,7 @@ public class TipsSolidifier {
                     log.error("Error during solidity scan : {}", e);
                 }
                 try {
-                    Thread.sleep(RESCAN_TX_TO_REQUEST_INTERVAL);
+                    Thread.sleep(getRescanInterval());
                 } catch (InterruptedException e) {
                     log.error("Solidity rescan interrupted.");
                 }
@@ -71,6 +80,10 @@ public class TipsSolidifier {
     }
 
     public void shutdown() {
+        if (!enabled()) {
+            return;
+        }
+        
         shuttingDown = true;
         try {
             if (solidityRescanHandle != null && solidityRescanHandle.isAlive()) {
@@ -80,5 +93,17 @@ public class TipsSolidifier {
             log.error("Error in shutdown", e);
         }
 
+    }
+    
+    private boolean enabled() {
+        return config.isTipSolidifierEnabled();
+    }
+    
+    private int getRescanInterval() {
+        return RESCAN_TX_TO_REQUEST_INTERVAL;
+    }
+    
+    private long getLogDelay() {
+        return 10000L;
     }
 }

--- a/src/main/java/com/iota/iri/service/TipsSolidifier.java
+++ b/src/main/java/com/iota/iri/service/TipsSolidifier.java
@@ -11,6 +11,9 @@ import org.slf4j.LoggerFactory;
 
 public class TipsSolidifier {
 
+    private static final int RESCAN_TX_TO_REQUEST_INTERVAL = 750;
+    private static final long LOG_DELAY = 10000l;
+    
     private final Logger log = LoggerFactory.getLogger(TipsSolidifier.class);
     private final Tangle tangle;
     private final TipsViewModel tipsViewModel;
@@ -18,7 +21,6 @@ public class TipsSolidifier {
     private final SolidificationConfig config;
     
     private boolean shuttingDown = false;
-    private int RESCAN_TX_TO_REQUEST_INTERVAL = 750;
     private Thread solidityRescanHandle;
     
 
@@ -45,7 +47,7 @@ public class TipsSolidifier {
                     scanTipsForSolidity();
                     if (log.isDebugEnabled()) {
                         long now = System.currentTimeMillis();
-                        if ((now - lastTime) > getLogDelay()) {
+                        if ((now - lastTime) > LOG_DELAY) {
                             lastTime = now;
                             log.debug("#Solid/NonSolid: {}/{}", tipsViewModel.solidSize(), tipsViewModel.nonSolidSize());
                         }
@@ -54,7 +56,7 @@ public class TipsSolidifier {
                     log.error("Error during solidity scan : {}", e);
                 }
                 try {
-                    Thread.sleep(getRescanInterval());
+                    Thread.sleep(RESCAN_TX_TO_REQUEST_INTERVAL);
                 } catch (InterruptedException e) {
                     log.error("Solidity rescan interrupted.");
                 }
@@ -97,13 +99,5 @@ public class TipsSolidifier {
     
     private boolean enabled() {
         return config.isTipSolidifierEnabled();
-    }
-    
-    private int getRescanInterval() {
-        return RESCAN_TX_TO_REQUEST_INTERVAL;
-    }
-    
-    private long getLogDelay() {
-        return 10000L;
     }
 }

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -100,6 +100,7 @@ public class ConfigTest {
         Assert.assertEquals("max peers", 10, iotaConfig.getMaxPeers());
         Assert.assertEquals("dns refresher", false, iotaConfig.isDnsRefresherEnabled());
         Assert.assertEquals("dns resolution", false, iotaConfig.isDnsResolutionEnabled());
+        Assert.assertEquals("tip solidification", true, iotaConfig.isTipSolidifierEnabled());
         Assert.assertEquals("ixi-dir", "/ixi", iotaConfig.getIxiDir());
         Assert.assertEquals("db path", "/db", iotaConfig.getDbPath());
         Assert.assertEquals("zmq enabled", true, iotaConfig.isZmqEnabled());
@@ -135,6 +136,7 @@ public class ConfigTest {
                 "--max-peers", "10",
                 "--dns-refresher", "false",
                 "--dns-resolution", "false",
+                "--tip-solidifier", "false",
                 "--ixi-dir", "/ixi",
                 "--db-path", "/db",
                 "--db-log-path", "/dblog",
@@ -168,6 +170,7 @@ public class ConfigTest {
         Assert.assertEquals("max peers", 10, iotaConfig.getMaxPeers());
         Assert.assertEquals("dns refresher", false, iotaConfig.isDnsRefresherEnabled());
         Assert.assertEquals("dns resolution", false, iotaConfig.isDnsResolutionEnabled());
+        Assert.assertEquals("tip solidification", false, iotaConfig.isTipSolidifierEnabled());
         Assert.assertEquals("ixi-dir", "/ixi", iotaConfig.getIxiDir());
         Assert.assertEquals("db path", "/db", iotaConfig.getDbPath());
         Assert.assertEquals("zmq enabled", true, iotaConfig.isZmqEnabled());


### PR DESCRIPTION
# Description
This PR adds the ability for node owners to disable tip solidification.
The reason behind it is that it potentially takes a lot of resources, so you should be able to disable it.
 If it is enabled, it will now show up in the `getNodeInfo['features']` list as "tipSolidification".

Fixes #1242 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
- Unit tests
- getNodeInfo, correctly enabled/disabled in features list

