### PR TITLE
Parallelize GTTA API

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -833,7 +833,7 @@ public class API {
       * @return {@link com.iota.iri.service.dto.GetTransactionsToApproveResponse}
       * @throws Exception When tip selection has failed. Currently caught and returned as an {@link ErrorResponse}.
       **/
-    private synchronized AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
+    private AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
         if (depth < 0 || depth > instance.configuration.getMaxDepth()) {
             return ErrorResponse.create("Invalid depth input");
         }


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

The `synchronized` keyword has been removed for improving the response time and throughput of the GTTA requests.
The pull request is based on the experiment result of issue #973.

IRI 1.5.3 - with synchronization
![gtta parallel test on testnet - 1 5 3](https://user-images.githubusercontent.com/6748200/50194636-bfc69e80-0376-11e9-812c-27c423e8d378.png)

Maximum response time: 23731 ms
Throughput: 2,373.699 / minute

IRI 1.5.5 - without synchronization
![gtta parallel test on testnet - no sync](https://user-images.githubusercontent.com/6748200/50194641-c228f880-0376-11e9-8182-afba25668173.png)

Maximum response time: 3694 ms
Throughput: 15,011.258 / minute

## Type of change

- Performance

# How Has This Been Tested?

- Use `jMeter` to send a 1000 GTTA calls with the same depth(15) at the same time and log the time it takes to response to all of them.


# Checklist:

_Please delete items that are not relevant._
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code