### PR TITLE
Fix unwanted dns reverse resolving in dns refresher

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -186,7 +186,7 @@ public class Node {
 
                     try {
                         neighbors.forEach(n -> {
-                            final String hostname = n.getAddress().getHostName();
+                            final String hostname = n.getAddress().getHostString();
                             checkIp(hostname).ifPresent(ip -> {
                                 log.info("DNS Checker: Validating DNS Address '{}' with '{}'", hostname, ip);
                                 messageQ.publish("dnscv %s %s", hostname, ip);


### PR DESCRIPTION
# Description

The dns refresher does a reverse lookup. If the reverse lookup is successful, neighbors that were added with their IP will be resolved via their DNS name after the lookup. 

By turning off the reverse lookup only neighbors that are added by domain name get periodically checked and updated in the dns resolver thread.

The fix was quite easy by replacing the `getHostName` method that does a reverse lookup with `getHostString` that doesn't do a reverse lookup (see JDK javadocs). This is only a minor change that shouldn't have any side effects.

Fixes # (issue) - no issue submitted

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

As the dns refresher code is not easily unit-testable, therefore I did an end to end test for UDP neighbors by running a patched node only. There might be a similar issue in `ReplicatorSourceProcessor` but as I do not use TCP I did not look into it.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
