### PR TITLE
Don't start node if local snapshot is loaded but there is no spent ad…

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -196,9 +196,11 @@ public class Iota {
     }
 
     private void injectDependencies() throws SnapshotException, TransactionPruningException, SpentAddressesException {
+        //snapshot provider must be initialized first
+        //because we check whether spent addresses data exists
+        snapshotProvider.init(configuration);
         spentAddressesProvider.init(configuration);
         spentAddressesService.init(tangle, snapshotProvider, spentAddressesProvider);
-        snapshotProvider.init(configuration);
         snapshotService.init(tangle, snapshotProvider, spentAddressesService, spentAddressesProvider, configuration);
         if (localSnapshotManager != null) {
             localSnapshotManager.init(snapshotProvider, snapshotService, transactionPruner, configuration);

--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
@@ -8,6 +8,15 @@ import java.util.Collection;
  * Find, mark and store spent addresses
  */
 public interface SpentAddressesProvider {
+    /**
+     * Folder where we store spent address data
+     */
+    String SPENT_ADDRESSES_DB = "spent-addresses-db";
+
+    /**
+     * Folder where we store spent address logs
+     */
+    String SPENT_ADDRESSES_LOG = "spent-addresses-log";
     
     /**
      * Checks if this address hash has been spent from

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -39,8 +39,8 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
      * Creates a new instance of SpentAddressesProvider
      */
     public SpentAddressesProviderImpl() {
-        this.rocksDBPersistenceProvider = new RocksDBPersistenceProvider("spent-addresses-db",
-                "spent-addresses-log", 1000,
+        this.rocksDBPersistenceProvider = new RocksDBPersistenceProvider(SPENT_ADDRESSES_DB,
+                SPENT_ADDRESSES_LOG, 1000,
                 new HashMap<String, Class<? extends Persistable>>(1)
                 {{put("spent-addresses", SpentAddress.class);}}, null);
     }


### PR DESCRIPTION
# Description
Ensures that we have spent addresses data before we load a local snapshot

Fixes #1260 

## Type of change
- Bug fix
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Isolated node has been run with and without spent address db to ensure that the node exits

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
