### PR TITLE
Change the minimum value for LOCAL_SNAPSHOTS_PRUNING_DELAY

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -805,7 +805,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
         boolean LOCAL_SNAPSHOTS_ENABLED = true;
         boolean LOCAL_SNAPSHOTS_PRUNING_ENABLED = true;
         
-        int LOCAL_SNAPSHOTS_PRUNING_DELAY = 50000;
+        int LOCAL_SNAPSHOTS_PRUNING_DELAY = 40000;
         int LOCAL_SNAPSHOTS_PRUNING_DELAY_MIN = 10000;
         int LOCAL_SNAPSHOTS_INTERVAL_SYNCED = 10;
         int LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = 1000;

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -806,7 +806,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
         boolean LOCAL_SNAPSHOTS_PRUNING_ENABLED = true;
         
         int LOCAL_SNAPSHOTS_PRUNING_DELAY = 50000;
-        int LOCAL_SNAPSHOTS_PRUNING_DELAY_MIN = 40000;
+        int LOCAL_SNAPSHOTS_PRUNING_DELAY_MIN = 10000;
         int LOCAL_SNAPSHOTS_INTERVAL_SYNCED = 10;
         int LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = 1000;
         int LOCAL_SNAPSHOTS_DEPTH = 100;

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -107,6 +107,8 @@ public class ConfigTest {
         Assert.assertNotEquals("mwm", 4, iotaConfig.getMwm());
         Assert.assertNotEquals("coo", iotaConfig.getCoordinator(), "TTTTTTTTT");
         Assert.assertEquals("--testnet-no-coo-validation", false, iotaConfig.isDontValidateTestnetMilestoneSig());
+        //Test default value
+        Assert.assertEquals("--local-snapshots-pruning-delay", 40000, iotaConfig.getLocalSnapshotsPruningDelay());
     }
 
     @Test
@@ -267,7 +269,7 @@ public class ConfigTest {
 
 
     @Test(expected = IllegalArgumentException.class)
-    public void pruningSnpashotDelayBelowMin() throws IOException {
+    public void pruningSnapshotDelayBelowMin() throws IOException {
         String iniContent = new StringBuilder()
                 .append("[IRI]").append(System.lineSeparator())
                 .append("LOCAL_SNAPSHOTS_PRUNING_DELAY = 9999")
@@ -279,7 +281,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void pruningSnpashotDelayIsMin() throws IOException {
+    public void pruningSnapshotDelayIsMin() throws IOException {
         String iniContent = new StringBuilder()
                 .append("[IRI]").append(System.lineSeparator())
                 .append("LOCAL_SNAPSHOTS_PRUNING_DELAY = 10000")

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -265,6 +265,32 @@ public class ConfigTest {
         ConfigFactory.createFromFile(configFile, false);
     }
 
+
+    @Test(expected = IllegalArgumentException.class)
+    public void pruningSnpashotDelayBelowMin() throws IOException {
+        String iniContent = new StringBuilder()
+                .append("[IRI]").append(System.lineSeparator())
+                .append("LOCAL_SNAPSHOTS_PRUNING_DELAY = 9999")
+                .toString();
+        try (Writer writer = new FileWriter(configFile)) {
+            writer.write(iniContent);
+        }
+        ConfigFactory.createFromFile(configFile, false);
+    }
+
+    @Test
+    public void pruningSnpashotDelayIsMin() throws IOException {
+        String iniContent = new StringBuilder()
+                .append("[IRI]").append(System.lineSeparator())
+                .append("LOCAL_SNAPSHOTS_PRUNING_DELAY = 10000")
+                .toString();
+        try (Writer writer = new FileWriter(configFile)) {
+            writer.write(iniContent);
+        }
+        IotaConfig iotaConfig = ConfigFactory.createFromFile(configFile, false);
+        Assert.assertEquals("unexpected pruning delay", 10000, iotaConfig.getLocalSnapshotsPruningDelay());
+    }
+
     @Test
     public void backwardsIniCompatibilityTest() {
         Collection<String> configNames = IotaUtils.getAllSetters(TestnetConfig.class)


### PR DESCRIPTION
# Description

Change the minimum value for LOCAL_SNAPSHOTS_PRUNING_DELAY to 10,000

Fixes #1265 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests added to check for failure when we configure value below minimum

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
