### PR TITLE
Don't throw on missed spent address. Persist it and warn

### DIFF
--- a/src/main/java/com/iota/iri/model/persistables/SpentAddress.java
+++ b/src/main/java/com/iota/iri/model/persistables/SpentAddress.java
@@ -3,7 +3,7 @@ package com.iota.iri.model.persistables;
 import com.iota.iri.storage.Persistable;
 
 public class SpentAddress implements Persistable {
-    public boolean exists = false;
+    private boolean exists = false;
 
     @Override
     public byte[] bytes() {
@@ -27,5 +27,9 @@ public class SpentAddress implements Persistable {
     @Override
     public boolean merge() {
         return false;
+    }
+
+    public boolean exists() {
+        return exists;
     }
 }

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -90,7 +90,7 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
     @Override
     public boolean containsAddress(Hash addressHash) throws SpentAddressesException {
         try {
-            return ((SpentAddress) rocksDBPersistenceProvider.get(SpentAddress.class, addressHash)).exists;
+            return ((SpentAddress) rocksDBPersistenceProvider.get(SpentAddress.class, addressHash)).exists();
         } catch (Exception e) {
             throw new SpentAddressesException(e);
         }

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesServiceImpl.java
@@ -61,19 +61,10 @@ public class SpentAddressesServiceImpl implements SpentAddressesService {
         try {
             Set<Hash> hashes = AddressViewModel.load(tangle, addressHash).getHashes();
             for (Hash hash : hashes) {
-                final TransactionViewModel tx = TransactionViewModel.fromHash(tangle, hash);
+                TransactionViewModel tx = TransactionViewModel.fromHash(tangle, hash);
                 // Check for spending transactions
-                if (tx.value() < 0) {
-                    // Transaction is confirmed
-                    if (tx.snapshotIndex() != 0) {
-                        return true;
-                    }
-
-                    // Transaction is pending
-                    Optional<Hash> tail = tailFinder.findTailFromTx(tx);
-                    if (tail.isPresent()) {
-                        return isBundleValid(tail.get());
-                    }
+                if (wasTransactionSpentFrom(tx)) {
+                    return true;
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
# Description

When traversing approved transactions that should be pruned, of we found one that we didn't know about its spending address already, then persist the address and send out a warning.

Also some small refactoring has been made

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
