### PR TITLE
Add configurable variables for spent addresses DB

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -95,6 +95,8 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected int localSnapshotsIntervalUnsynced = Defaults.LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED;
     protected int localSnapshotsDepth = Defaults.LOCAL_SNAPSHOTS_DEPTH;
     protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
+    protected String spentAddressesDbPath = Defaults.SPENT_ADDRESSES_DB_PATH;
+    protected String spentAddressesDbLogPath = Defaults.SPENT_ADDRESSES_DB_LOG_PATH;
 
     public BaseIotaConfig() {
         //empty constructor
@@ -593,6 +595,28 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     @Override
+    public String getSpentAddressesDbPath() {
+        return spentAddressesDbPath;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--spent-addresses-db-path"}, description = SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_PATH)
+    protected void setSpentAddressesDbPath(String spentAddressesDbPath) {
+        this.spentAddressesDbPath = spentAddressesDbPath;
+    }
+
+    @Override
+    public String getSpentAddressesDbLogPath() {
+        return spentAddressesDbLogPath;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--spent-addresses-db-log-path"}, description = SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH)
+    protected void setSpentAddressesDbLogPath(String spentAddressesDbLogPath) {
+        this.spentAddressesDbLogPath = spentAddressesDbLogPath;
+    }
+
+    @Override
     public boolean isZmqEnabled() {
         return zmqEnabled;
     }
@@ -811,6 +835,8 @@ public abstract class BaseIotaConfig implements IotaConfig {
         int LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = 1000;
         int LOCAL_SNAPSHOTS_DEPTH = 100;
         int LOCAL_SNAPSHOTS_DEPTH_MIN = 100;
+        String SPENT_ADDRESSES_DB_PATH = "spent-addresses-db";
+        String SPENT_ADDRESSES_DB_LOG_PATH = "spent-addresses-log";
         
         String LOCAL_SNAPSHOTS_BASE_PATH = "mainnet";
         String SNAPSHOT_FILE = "/snapshotMainnet.txt";

--- a/src/main/java/com/iota/iri/conf/SnapshotConfig.java
+++ b/src/main/java/com/iota/iri/conf/SnapshotConfig.java
@@ -70,6 +70,16 @@ public interface SnapshotConfig extends Config {
      */
     String getPreviousEpochSpentAddressesFiles();
 
+    /**
+     * @return {@value Descriptions#SPENT_ADDRESSES_DB_PATH}
+     */
+    String getSpentAddressesDbPath();
+
+    /**
+     * @return {@value Descriptions#SPENT_ADDRESSES_DB_LOG_PATH}
+     */
+    String getSpentAddressesDbLogPath();
+
     interface Descriptions {
 
         String LOCAL_SNAPSHOTS_ENABLED = "Flag that determines if local snapshots are enabled.";
@@ -88,5 +98,7 @@ public interface SnapshotConfig extends Config {
                 "leaves (private keys) that the coordinator can use to sign a message.";
         String PREVIOUS_EPOCH_SPENT_ADDRESSES_FILE = "The file that contains the list of all used addresses " +
                 "from previous epochs";
+        String SPENT_ADDRESSES_DB_PATH = "The folder where the spent addresses DB saves its data.";
+        String SPENT_ADDRESSES_DB_LOG_PATH = "The folder where the spent addresses DB saves its logs.";
     }
 }

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -232,17 +232,17 @@ public class SnapshotProviderImpl implements SnapshotProvider {
 
     private void assertSpentAddressesDbExist() throws SpentAddressesException {
         try {
-            File spentAddressFolder = new File(SpentAddressesProvider.SPENT_ADDRESSES_DB);
+            File spentAddressFolder = new File(SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH);
             //If there is at least one file in the db the check should pass
             if (Files.newDirectoryStream(spentAddressFolder.toPath(), "*.sst").iterator().hasNext()) {
                 return;
             }
         }
         catch (IOException e){
-            throw new SpentAddressesException("Can't load " + SpentAddressesProvider.SPENT_ADDRESSES_DB + " folder", e);
+            throw new SpentAddressesException("Can't load " + SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH + " folder", e);
         }
 
-        throw new SpentAddressesException(SpentAddressesProvider.SPENT_ADDRESSES_DB + " folder has no sst files");
+        throw new SpentAddressesException(SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH + " folder has no sst files");
     }
 
     /**

--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
@@ -9,16 +9,6 @@ import java.util.Collection;
  */
 public interface SpentAddressesProvider {
     /**
-     * Folder where we store spent address data
-     */
-    String SPENT_ADDRESSES_DB = "spent-addresses-db";
-
-    /**
-     * Folder where we store spent address logs
-     */
-    String SPENT_ADDRESSES_LOG = "spent-addresses-log";
-    
-    /**
      * Checks if this address hash has been spent from
      * 
      * @param addressHash The address to check for

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -36,16 +36,6 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
     private SnapshotConfig config;
 
     /**
-     * Creates a new instance of SpentAddressesProvider
-     */
-    public SpentAddressesProviderImpl() {
-        this.rocksDBPersistenceProvider = new RocksDBPersistenceProvider(SPENT_ADDRESSES_DB,
-                SPENT_ADDRESSES_LOG, 1000,
-                new HashMap<String, Class<? extends Persistable>>(1)
-                {{put("spent-addresses", SpentAddress.class);}}, null);
-    }
-
-    /**
      * Starts the SpentAddressesProvider by reading the previous spent addresses from files.
      *
      * @param config The snapshot configuration used for file location
@@ -56,6 +46,12 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
             throws SpentAddressesException {
         this.config = config;
         try {
+            this.rocksDBPersistenceProvider = new RocksDBPersistenceProvider(
+                    config.getSpentAddressesDbPath(),
+                    config.getSpentAddressesDbLogPath(),
+                    1000,
+                    new HashMap<String, Class<? extends Persistable>>(1)
+                    {{put("spent-addresses", SpentAddress.class);}}, null);
             this.rocksDBPersistenceProvider.init();
             readPreviousEpochsSpentAddresses();
         }


### PR DESCRIPTION
# Description

The `SPENT_ADDRESSES_DB` and `SPENT_ADDRESSES_LOG` paths are currently hardcoded. This PR makes them configurable similarly to `DB_PATH` and `DB_LOG_PATH`.

Fix #1268

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
