### PR TITLE
Fix: test existence of spent addresses db do not point to correct folder

### DIFF
--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -231,18 +231,19 @@ public class SnapshotProviderImpl implements SnapshotProvider {
     }
 
     private void assertSpentAddressesDbExist() throws SpentAddressesException {
+        String spentAddressesDbPath = config.getSpentAddressesDbPath();
         try {
-            File spentAddressFolder = new File(SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH);
+            File spentAddressFolder = new File(spentAddressesDbPath);
             //If there is at least one file in the db the check should pass
             if (Files.newDirectoryStream(spentAddressFolder.toPath(), "*.sst").iterator().hasNext()) {
                 return;
             }
         }
         catch (IOException e){
-            throw new SpentAddressesException("Can't load " + SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH + " folder", e);
+            throw new SpentAddressesException("Can't load " + spentAddressesDbPath + " folder", e);
         }
 
-        throw new SpentAddressesException(SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH + " folder has no sst files");
+        throw new SpentAddressesException(spentAddressesDbPath + " folder has no sst files");
     }
 
     /**


### PR DESCRIPTION
# Description

In #1274 the `assertSpentAddressesDbExist()` method was changed incorrectly.
Now it is fixed to assert the content of the correct directory.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran in debug mode and tested

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
