### PR TITLE
Added check for genisis transaction

### DIFF
--- a/src/main/java/com/iota/iri/network/impl/TransactionRequesterWorkerImpl.java
+++ b/src/main/java/com/iota/iri/network/impl/TransactionRequesterWorkerImpl.java
@@ -109,7 +109,8 @@ public class TransactionRequesterWorkerImpl implements TransactionRequesterWorke
         try {
             if (transactionRequester.numberOfTransactionsToRequest() >= REQUESTER_THREAD_ACTIVATION_THRESHOLD) {
                 TransactionViewModel transaction = getTransactionToSendWithRequest();
-                if (transaction != null && transaction.getType() != TransactionViewModel.PREFILLED_SLOT) {
+                if (transaction != null && (transaction.getType() != TransactionViewModel.PREFILLED_SLOT
+                        || transaction.getHash().equals(Hash.NULL_HASH))) {
                     for (Neighbor neighbor : node.getNeighbors()) {
                         try {
                             // automatically adds the hash of a requested transaction when sending a packet


### PR DESCRIPTION
# Description
If the node does not have tips (during startup/syncing for example), we send the genesis transaction.
Due to this being all 9's, its type is `PREFILLED_SLOT`, therefor we never actually broadcast the request.

Fixes #1306 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Running nodes from downloaded db dont sync, unless this extra check is done

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
