### PR TITLE
Fresh transactionToRequest

### DIFF
--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -82,6 +82,11 @@ public class TransactionRequester {
         }
     }
 
+    /**
+     * This method removes the oldest transaction in the transactionsToRequest Set.
+     *
+     * It used when the queue capacity is reached, and new transactions would be dropped as a result.
+     */
     private void popEldestTransactionToRequest() {
         Iterator<Hash> iterator = transactionsToRequest.iterator();
         if (iterator.hasNext()) {
@@ -122,13 +127,13 @@ public class TransactionRequester {
         synchronized (syncObj) {
             // repeat while we have transactions that shall be requested
             while (requestSet.size() != 0) {
-                // remove the first item in our set for further examination
+                // get the first item in our set for further examination
                 Iterator<Hash> iterator = requestSet.iterator();
                 hash = iterator.next();
 
                 // if we have received the transaction in the mean time ....
                 if (TransactionViewModel.exists(tangle, hash)) {
-                    // We remove the transaction from the queue since we got it
+                    // we remove the transaction from the queue since we got it
                     iterator.remove();
                     // ... dump a log message ...
                     log.info("Removed existing tx from request list: " + hash);

--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -71,11 +71,22 @@ public class TransactionRequester {
                     transactionsToRequest.remove(hash);
                     milestoneTransactionsToRequest.add(hash);
                 } else {
-                    if(!milestoneTransactionsToRequest.contains(hash) && !transactionsToRequestIsFull()) {
+                    if(!milestoneTransactionsToRequest.contains(hash)) {
+                        if (transactionsToRequestIsFull()) {
+                            popEldestTransactionToRequest();
+                        }
                         transactionsToRequest.add(hash);
                     }
                 }
             }
+        }
+    }
+
+    private void popEldestTransactionToRequest() {
+        Iterator<Hash> iterator = transactionsToRequest.iterator();
+        if (iterator.hasNext()) {
+            iterator.next();
+            iterator.remove();
         }
     }
 

--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -87,7 +87,8 @@ public class TransactionRequester {
      *
      * It used when the queue capacity is reached, and new transactions would be dropped as a result.
      */
-    private void popEldestTransactionToRequest() {
+    // @VisibleForTesting
+    void popEldestTransactionToRequest() {
         Iterator<Hash> iterator = transactionsToRequest.iterator();
         if (iterator.hasNext()) {
             iterator.next();

--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -114,10 +114,11 @@ public class TransactionRequester {
                 // remove the first item in our set for further examination
                 Iterator<Hash> iterator = requestSet.iterator();
                 hash = iterator.next();
-                iterator.remove();
 
                 // if we have received the transaction in the mean time ....
                 if (TransactionViewModel.exists(tangle, hash)) {
+                    // We remove the transaction from the queue since we got it
+                    iterator.remove();
                     // ... dump a log message ...
                     log.info("Removed existing tx from request list: " + hash);
                     messageQ.publish("rtl %s", hash);
@@ -125,11 +126,6 @@ public class TransactionRequester {
                     // ... and continue to the next element in the set
                     continue;
                 }
-
-                // ... otherwise -> re-add it at the end of the set ...
-                //
-                // Note: we always have enough space since we removed the element before
-                requestSet.add(hash);
 
                 // ... and abort our loop to continue processing with the element we found
                 break;

--- a/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
@@ -118,7 +118,7 @@ public class TransactionRequesterTest {
         assertEquals("Queue capacity breached!!", capacity, txReq.numberOfTransactionsToRequest());
         // None of the eldest transactions should be in the pool
         for (int i = 0; i < 3; i++) {
-            assertFalse(txReq.isTransactionRequested(eldest.get(i), false));
+            assertFalse("Old transaction has been requested", txReq.isTransactionRequested(eldest.get(i), false));
         }
     }
 

--- a/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
@@ -91,7 +91,7 @@ public class TransactionRequesterTest {
 
         txReq.popEldestTransactionToRequest();
         // Check that the transaction is there no more
-        assertEquals(false, txReq.isTransactionRequested(eldest, false));
+        assertFalse(txReq.isTransactionRequested(eldest, false));
     }
 
     @Test
@@ -117,7 +117,7 @@ public class TransactionRequesterTest {
         assertEquals(capacity, txReq.numberOfTransactionsToRequest());
         // None of the eldest transactions should be in the pool
         for (int i = 0; i < 3; i++) {
-            assertEquals(false, txReq.isTransactionRequested(eldest.get(i), false));
+            assertFalse(txReq.isTransactionRequested(eldest.get(i), false));
         }
     }
 

--- a/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
@@ -115,7 +115,7 @@ public class TransactionRequesterTest {
         }
 
         //check that limit wasn't breached
-        assertEquals(capacity, txReq.numberOfTransactionsToRequest());
+        assertEquals("Queue capacity breached!!", capacity, txReq.numberOfTransactionsToRequest());
         // None of the eldest transactions should be in the pool
         for (int i = 0; i < 3; i++) {
             assertFalse(txReq.isTransactionRequested(eldest.get(i), false));

--- a/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
@@ -1,8 +1,8 @@
-package com.iota.iri.controllers;
+package com.iota.iri.network;
 
 import com.iota.iri.conf.MainnetConfig;
+import com.iota.iri.controllers.TransactionViewModelTest;
 import com.iota.iri.model.Hash;
-import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.impl.SnapshotProviderImpl;
 import com.iota.iri.storage.Tangle;
@@ -11,7 +11,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -82,10 +81,6 @@ public class TransactionRequesterTest {
 
     @Test
     public void popEldestTransactionToRequest() throws Exception {
-        // Make private method invokable
-        Method popEldestToRequestTransaction = TransactionRequester.class.getDeclaredMethod("popEldestTransactionToRequest");
-        popEldestToRequestTransaction.setAccessible(true);
-
         TransactionRequester txReq = new TransactionRequester(tangle, snapshotProvider, mq);
         // Add some Txs to the pool and see if the method pops the eldest one
         Hash eldest = TransactionViewModelTest.getRandomTransactionHash();
@@ -94,7 +89,7 @@ public class TransactionRequesterTest {
         txReq.requestTransaction(TransactionViewModelTest.getRandomTransactionHash(), false);
         txReq.requestTransaction(TransactionViewModelTest.getRandomTransactionHash(), false);
 
-        popEldestToRequestTransaction.invoke(txReq, null);
+        txReq.popEldestTransactionToRequest();
         // Check that the transaction is there no more
         assertEquals(false, txReq.isTransactionRequested(eldest, false));
     }

--- a/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/network/TransactionRequesterTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
# Description
Keep the `transactionToRequest` Set of the `TransactionRequester` fresh with new inbound transactions instead of keeping stale ones when at capacity.

Fixes #1313 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Unsynced node that lag greatly behind seem to sync faster since we do not pile up stale transations anymore. 

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
