### PR TITLE
Fix unknown IXI command response

### DIFF
--- a/src/main/java/com/iota/iri/IXI.java
+++ b/src/main/java/com/iota/iri/IXI.java
@@ -196,7 +196,7 @@ public class IXI {
 
         if (matcher.find()) {
             Map<String, CallableRequest<AbstractResponse>> ixiMap = ixiAPI.get(matcher.group(1));
-            if (ixiMap != null) {
+            if (ixiMap != null && ixiMap.containsKey(matcher.group(2))) {
                 return ixiMap.get(matcher.group(2)).call(request);
             }
         }

--- a/src/test/java/com/iota/iri/IXITest.java
+++ b/src/test/java/com/iota/iri/IXITest.java
@@ -1,5 +1,6 @@
 package com.iota.iri;
 
+import com.iota.iri.service.CallableRequest;
 import com.iota.iri.service.dto.AbstractResponse;
 import com.iota.iri.service.dto.ErrorResponse;
 import org.hamcrest.CoreMatchers;
@@ -7,6 +8,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -27,6 +32,12 @@ public class IXITest {
         ixiDir.create();
         ixi = new IXI();
         ixi.init(ixiDir.getRoot().getAbsolutePath());
+
+        Field ixiApiField = ixi.getClass().getDeclaredField("ixiAPI");
+        ixiApiField.setAccessible(true);
+        Map<String, Map<String, CallableRequest<AbstractResponse>>> ixiAPI =
+                (Map<String, Map<String, CallableRequest<AbstractResponse>>>) ixiApiField.get(ixi);
+        ixiAPI.put("IXI", new HashMap<>());
     }
 
     /**
@@ -70,7 +81,7 @@ public class IXITest {
     }
 
     /**
-     * If an does not match the command pattern, expect an unknown command error message.
+     * If the given command does not exist, expect an unknown command error message.
      */
     @Test
     public void processCommandUnknown() {
@@ -79,4 +90,13 @@ public class IXITest {
         assertTrue("Wrong error message returned in response", response.toString().contains("Command [unknown] is unknown"));
     }
 
+    /**
+     * If an IXI module does not have the given command, expect an unknown command error message.
+     */
+    @Test
+    public void processIXICommandUnknown() {
+        AbstractResponse response = ixi.processCommand("IXI.unknown", null);
+        assertThat("Wrong type of response", response, CoreMatchers.instanceOf(ErrorResponse.class));
+        assertTrue("Wrong error message returned in response", response.toString().contains("Command [IXI.unknown] is unknown"));
+    }
 }


### PR DESCRIPTION
# Description

Calling an unknown command of a known IXI returns `{"duration":0}`. This change will return the standard error message `Command [Foo.bar] is unknown`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes