### PR TITLE
Fix: Reduce db access and cpu usage needed to persist spent addresses

### DIFF
--- a/src/main/java/com/iota/iri/BundleValidator.java
+++ b/src/main/java/com/iota/iri/BundleValidator.java
@@ -55,7 +55,7 @@ public class BundleValidator {
      * If the bundle is invalid then an empty list will be returned.
      * @throws Exception if a persistence error occured
      */
-    public static List<List<TransactionViewModel>> validate(Tangle tangle, Snapshot initialSnapshot, Hash tailHash) throws Exception {
+    public List<List<TransactionViewModel>> validate(Tangle tangle, Snapshot initialSnapshot, Hash tailHash) throws Exception {
 
         TransactionViewModel tail = TransactionViewModel.fromHash(tangle, tailHash);
         if (tail.getCurrentIndex() != 0 || tail.getValidity() == -1) {
@@ -194,10 +194,10 @@ public class BundleValidator {
     /**
      * Checks that the bundle's inputs and outputs are balanced.
      *
-     * @param transactionViewModels list of transactions that are in a bundle
+     * @param transactionViewModels collection of transactions that are in a bundle
      * @return {@code true} if balanced, {@code false} if unbalanced or {@code transactionViewModels} is empty
      */
-    public static boolean isInconsistent(List<TransactionViewModel> transactionViewModels) {
+    public static boolean isInconsistent(Collection<TransactionViewModel> transactionViewModels) {
         long value = 0;
         for (final TransactionViewModel bundleTransactionViewModel : transactionViewModels) {
             if (bundleTransactionViewModel.value() != 0) {

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -215,7 +215,7 @@ public class Iota {
                 latestMilestoneTracker, messageQ);
         seenMilestonesRetriever.init(tangle, snapshotProvider, transactionRequester);
         milestoneSolidifier.init(snapshotProvider, transactionValidator);
-        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider,
+        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesService,
                 bundleValidator);
         if (transactionPruner != null) {
             transactionPruner.init(tangle, snapshotProvider, spentAddressesService, tipsViewModel, configuration)

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -95,6 +95,8 @@ public class Iota {
 
     public final TransactionRequesterWorkerImpl transactionRequesterWorker;
 
+    public final BundleValidator bundleValidator;
+
     public final Tangle tangle;
     public final TransactionValidator transactionValidator;
     public final TipsSolidifier tipsSolidifier;
@@ -137,6 +139,7 @@ public class Iota {
         transactionRequesterWorker = new TransactionRequesterWorkerImpl();
 
         // legacy code
+        bundleValidator = new BundleValidator();
         tangle = new Tangle();
         messageQ = MessageQ.createWith(configuration);
         tipsViewModel = new TipsViewModel();
@@ -200,19 +203,20 @@ public class Iota {
         //because we check whether spent addresses data exists
         snapshotProvider.init(configuration);
         spentAddressesProvider.init(configuration);
-        spentAddressesService.init(tangle, snapshotProvider, spentAddressesProvider, configuration);
+        spentAddressesService.init(tangle, snapshotProvider, spentAddressesProvider, bundleValidator, configuration);
         snapshotService.init(tangle, snapshotProvider, spentAddressesService, spentAddressesProvider, configuration);
         if (localSnapshotManager != null) {
             localSnapshotManager.init(snapshotProvider, snapshotService, transactionPruner, configuration);
         }
-        milestoneService.init(tangle, snapshotProvider, snapshotService, messageQ, configuration);
+        milestoneService.init(tangle, snapshotProvider, snapshotService, bundleValidator, messageQ, configuration);
         latestMilestoneTracker.init(tangle, snapshotProvider, milestoneService, milestoneSolidifier,
                 messageQ, configuration);
         latestSolidMilestoneTracker.init(tangle, snapshotProvider, milestoneService, ledgerService,
                 latestMilestoneTracker, messageQ);
         seenMilestonesRetriever.init(tangle, snapshotProvider, transactionRequester);
         milestoneSolidifier.init(snapshotProvider, transactionValidator);
-        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider);
+        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider,
+                bundleValidator);
         if (transactionPruner != null) {
             transactionPruner.init(tangle, snapshotProvider, spentAddressesService, tipsViewModel, configuration)
                     .restoreState();

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -212,7 +212,7 @@ public class Iota {
                 latestMilestoneTracker, messageQ);
         seenMilestonesRetriever.init(tangle, snapshotProvider, transactionRequester);
         milestoneSolidifier.init(snapshotProvider, transactionValidator);
-        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService);
+        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider);
         if (transactionPruner != null) {
             transactionPruner.init(tangle, snapshotProvider, spentAddressesService, tipsViewModel, configuration)
                     .restoreState();

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -586,7 +586,7 @@ public class API {
                 state = false;
                 info = "tails are not solid (missing a referenced tx): " + transaction;
                 break;
-            } else if (BundleValidator.validate(instance.tangle, instance.snapshotProvider.getInitialSnapshot(), txVM.getHash()).size() == 0) {
+            } else if (instance.bundleValidator.validate(instance.tangle, instance.snapshotProvider.getInitialSnapshot(), txVM.getHash()).size() == 0) {
                 state = false;
                 info = "tails are not consistent (bundle is invalid): " + transaction;
                 break;

--- a/src/main/java/com/iota/iri/service/ledger/LedgerService.java
+++ b/src/main/java/com/iota/iri/service/ledger/LedgerService.java
@@ -75,7 +75,8 @@ public interface LedgerService {
 
     /**
      * Generates the accumulated balance changes of the transactions that are directly or indirectly referenced by the
-     * given transaction relative to the referenced milestone.<br />
+     * given transaction relative to the referenced milestone. Also persists the spent addresses that were found in the
+     * process<br />
      * <br />
      * It simply iterates over all approvees that have not been confirmed yet and that have not been processed already
      * (by being part of the {@code visitedNonMilestoneSubtangleHashes} set) and collects their balance changes.<br />

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -48,6 +48,8 @@ public class LedgerServiceImpl implements LedgerService {
 
     private SpentAddressesProvider spentAddressesProvider;
 
+    private BundleValidator bundleValidator;
+
     /**
      * Initializes the instance and registers its dependencies.<br />
      * <br />
@@ -67,13 +69,15 @@ public class LedgerServiceImpl implements LedgerService {
      * @return the initialized instance itself to allow chaining
      */
     public LedgerServiceImpl init(Tangle tangle, SnapshotProvider snapshotProvider, SnapshotService snapshotService,
-            MilestoneService milestoneService, SpentAddressesProvider spentAddressesProvider) {
+            MilestoneService milestoneService, SpentAddressesProvider spentAddressesProvider,
+                                  BundleValidator bundleValidator) {
 
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
         this.snapshotService = snapshotService;
         this.milestoneService = milestoneService;
         this.spentAddressesProvider = spentAddressesProvider;
+        this.bundleValidator = bundleValidator;
 
         return this;
     }
@@ -182,7 +186,7 @@ public class LedgerServiceImpl implements LedgerService {
                             if (transactionViewModel.getCurrentIndex() == 0) {
                                 boolean validBundle = false;
 
-                                final List<List<TransactionViewModel>> bundleTransactions = BundleValidator.validate(
+                                final List<List<TransactionViewModel>> bundleTransactions = bundleValidator.validate(
                                         tangle, snapshotProvider.getInitialSnapshot(), transactionViewModel.getHash());
 
                                 for (final List<TransactionViewModel> bundleTransactionViewModels : bundleTransactions) {

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -8,6 +8,7 @@ import com.iota.iri.model.Hash;
 import com.iota.iri.service.ledger.LedgerException;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.milestone.MilestoneService;
+import com.iota.iri.service.snapshot.Snapshot;
 import com.iota.iri.service.snapshot.SnapshotException;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.SnapshotService;
@@ -17,7 +18,6 @@ import com.iota.iri.service.spentaddresses.SpentAddressesProvider;
 import com.iota.iri.storage.Tangle;
 
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -160,7 +160,9 @@ public class LedgerServiceImpl implements LedgerService {
         Map<Hash, Long> state = new HashMap<>();
         Set<Hash> countedTx = new HashSet<>();
 
-        snapshotProvider.getInitialSnapshot().getSolidEntryPoints().keySet().forEach(solidEntryPointHash -> {
+        Snapshot initialSnapshot = snapshotProvider.getInitialSnapshot();
+        Map<Hash, Integer> solidEntryPoints = initialSnapshot.getSolidEntryPoints();
+        solidEntryPoints.keySet().forEach(solidEntryPointHash -> {
             visitedTransactions.add(solidEntryPointHash);
             countedTx.add(solidEntryPointHash);
         });

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneServiceImpl.java
@@ -69,6 +69,8 @@ public class MilestoneServiceImpl implements MilestoneService {
      */
     private ConsensusConfig config;
 
+    private BundleValidator bundleValidator;
+
     /**
      * This method initializes the instance and registers its dependencies.<br />
      * <br />
@@ -88,11 +90,12 @@ public class MilestoneServiceImpl implements MilestoneService {
      * @return the initialized instance itself to allow chaining
      */
     public MilestoneServiceImpl init(Tangle tangle, SnapshotProvider snapshotProvider, SnapshotService snapshotService,
-            MessageQ messageQ, ConsensusConfig config) {
+            BundleValidator bundleValidator, MessageQ messageQ, ConsensusConfig config) {
 
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
         this.snapshotService = snapshotService;
+        this.bundleValidator = bundleValidator;
         this.messageQ = messageQ;
         this.config = config;
 
@@ -173,7 +176,7 @@ public class MilestoneServiceImpl implements MilestoneService {
                 return VALID;
             }
 
-            final List<List<TransactionViewModel>> bundleTransactions = BundleValidator.validate(tangle,
+            final List<List<TransactionViewModel>> bundleTransactions = bundleValidator.validate(tangle,
                     snapshotProvider.getInitialSnapshot(), transactionViewModel.getHash());
 
             if (bundleTransactions.isEmpty()) {

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
@@ -496,14 +496,6 @@ public class SnapshotServiceImpl implements SnapshotService {
     private void persistLocalSnapshot(SnapshotProvider snapshotProvider, Snapshot newSnapshot, SnapshotConfig config)
             throws SnapshotException {
 
-        try {
-            spentAddressesService.persistSpentAddresses(snapshotProvider.getInitialSnapshot().getIndex(),
-                    newSnapshot.getIndex());
-            
-        } catch (Exception e) {
-            throw new SnapshotException(e);
-        }
-
         snapshotProvider.writeSnapshotToDisk(newSnapshot, config.getLocalSnapshotsBasePath());
 
         snapshotProvider.getLatestSnapshot().lockWrite();

--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesService.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesService.java
@@ -21,14 +21,6 @@ public interface SpentAddressesService {
      */
     boolean wasAddressSpentFrom(Hash addressHash) throws SpentAddressesException;
 
-    /**
-     * Calculates and persists all spent addresses in between a range that were validly signed
-     * 
-     * @param fromMilestoneIndex the lower bound milestone index (inclusive)
-     * @param toMilestoneIndex the upper bound milestone index (exclusive)
-     * @throws Exception when anything went wrong whilst calculating.
-     */
-    void persistSpentAddresses(int fromMilestoneIndex, int toMilestoneIndex) throws Exception;
 
     /**
      * Persist all the verifiable spent from a given list of transactions

--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesService.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesService.java
@@ -28,4 +28,12 @@ public interface SpentAddressesService {
      * @throws SpentAddressesException
      */
     void persistSpentAddresses(Collection<TransactionViewModel> transactions) throws SpentAddressesException;
+
+    /**
+     * Persists the spent addresses of all pre-verified valid transactions in an asynchronous manner
+     *
+     * @param transactions <b>Transactions that have their signatures verified beforehand</b>.
+     *                     Non spent transactions will be filtered out when persisting
+     */
+    void persistValidatedSpentAddressesAsync(Collection<TransactionViewModel> transactions);
 }

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesServiceImpl.java
@@ -46,6 +46,8 @@ public class SpentAddressesServiceImpl implements SpentAddressesService {
 
     private MilestoneConfig config;
 
+    private BundleValidator bundleValidator;
+
 
     /**
      * Creates a Spent address service using the Tangle
@@ -55,11 +57,13 @@ public class SpentAddressesServiceImpl implements SpentAddressesService {
      * @param spentAddressesProvider Provider for loading/saving addresses to a database.
      * @return this instance
      */
-    public SpentAddressesServiceImpl init(Tangle tangle, SnapshotProvider snapshotProvider, SpentAddressesProvider spentAddressesProvider,
+    public SpentAddressesServiceImpl init(Tangle tangle, SnapshotProvider snapshotProvider,
+                                          SpentAddressesProvider spentAddressesProvider, BundleValidator bundleValidator,
                                           MilestoneConfig config) {
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
         this.spentAddressesProvider = spentAddressesProvider;
+        this.bundleValidator = bundleValidator;
         this.tailFinder = new TailFinderImpl(tangle);
         this.config = config;
 
@@ -104,7 +108,7 @@ public class SpentAddressesServiceImpl implements SpentAddressesService {
 
     private boolean isBundleValid(Hash tailHash) throws Exception {
         List<List<TransactionViewModel>> validation =
-                BundleValidator.validate(tangle, snapshotProvider.getInitialSnapshot(), tailHash);
+                bundleValidator.validate(tangle, snapshotProvider.getInitialSnapshot(), tailHash);
         return (CollectionUtils.isNotEmpty(validation) && validation.get(0).get(0).getValidity() == 1);
     }
 

--- a/src/main/java/com/iota/iri/utils/IotaUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaUtils.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,4 +58,18 @@ public class IotaUtils {
 	public static <T> List<T> createImmutableList(T... values) {
 		return Collections.unmodifiableList(Arrays.asList(values));
 	}
+
+    /**
+     * Creates a single thread executor service that has an unbounded queue.
+
+     * @param name the name to give to the thread
+     * @return a named single thread executor service
+     *
+     * @see com.iota.iri.utils.thread.BoundedScheduledExecutorService
+     * @see com.iota.iri.utils.thread.DedicatedScheduledExecutorService
+     */
+	public static ExecutorService createNamedSingleThreadExecutor(String name) {
+        return Executors.newSingleThreadExecutor(r -> new Thread(r, name));
+
+    }
 }

--- a/src/test/java/com/iota/iri/TangleMockUtils.java
+++ b/src/test/java/com/iota/iri/TangleMockUtils.java
@@ -7,10 +7,14 @@ import com.iota.iri.model.StateDiff;
 import com.iota.iri.model.persistables.Milestone;
 import com.iota.iri.model.persistables.Transaction;
 import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.Converter;
+import com.iota.iri.utils.IotaUtils;
 import com.iota.iri.utils.Pair;
+
 import org.mockito.Mockito;
 
-import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.*;
 
 /**
  * Contains utilities that help to mock the retrieval of database entries from the tangle.<br />
@@ -53,6 +57,51 @@ public class TangleMockUtils {
         return milestone;
     }
 
+    public static List<TransactionViewModel> mockValidBundle(Tangle tangle,
+                                                             BundleValidator bundleValidator,
+                                                             int numOfNonValueTxs,
+                                                             String... spendsInTrytes) throws Exception {
+        List<TransactionViewModel> bundle = new ArrayList<>();
+        String address = "ADDRESS99";
+        TransactionViewModel tx = null;
+        int lastIndex = spendsInTrytes.length + numOfNonValueTxs - 1;
+        int currentIndex = lastIndex;
+        for (int i = 0; i < spendsInTrytes.length; i++) {
+            byte[] trits = new byte[TransactionViewModel.TRINARY_SIZE];
+            Converter.trits(spendsInTrytes[i], trits, TransactionViewModel.VALUE_TRINARY_OFFSET);
+            address = TransactionTestUtils.nextWord(address);
+            Converter.trits(address, trits, TransactionViewModel.ADDRESS_TRINARY_OFFSET);
+            if (tx != null) {
+                TransactionTestUtils.getTransactionTritsWithTrunkAndBranch(trits, tx.getHash(), Hash.NULL_HASH);
+            }
+            TransactionTestUtils.setLastIndex(trits, lastIndex);
+            TransactionTestUtils.setCurrentIndex(trits, currentIndex--);
+            tx = TransactionTestUtils.createTransactionFromTrits(trits);
+            tx.setMetadata();
+            mockTransaction(tangle, tx);
+            bundle.add(tx);
+        }
+
+        for (int i = 0; i < numOfNonValueTxs; i++) {
+            if (tx == null) {
+                tx = TransactionTestUtils.createBundleHead(currentIndex--);
+            }
+            else {
+                tx = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx, Hash.NULL_HASH);
+            }
+            tx.setMetadata();
+            mockTransaction(tangle, tx);
+            bundle.add(tx);
+        }
+
+        Collections.reverse(bundle);
+        Mockito.when(bundleValidator.validate(Mockito.eq(tangle), Mockito.any(),
+                Mockito.eq(bundle.iterator().next().getHash())))
+                .thenReturn(Arrays.asList(bundle));
+
+        return bundle;
+    }
+
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     //region [mockTransaction] /////////////////////////////////////////////////////////////////////////////////////////
@@ -91,6 +140,21 @@ public class TangleMockUtils {
         }
 
         return transaction;
+    }
+
+    /**
+     * Mocks the tangle object by checking for the hash and returning the transaction.
+     *
+     * @param tangle mocked tangle object that shall retrieve a milestone object when being queried for it
+     * @param tvm the transaction we mock in the tangle
+     * @return The transaction
+     */
+    public static Transaction mockTransaction(Tangle tangle, TransactionViewModel tvm) throws NoSuchFieldException, IllegalAccessException {
+        Transaction transaction;
+        Field transactionField = tvm.getClass().getDeclaredField("transaction");
+        transactionField.setAccessible(true);
+        transaction = (Transaction) transactionField.get(tvm);
+        return mockTransaction(tangle, tvm.getHash(), transaction);
     }
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -173,7 +173,7 @@ public class TransactionValidatorTest {
     rightChildLeaf.updateSolid(true);
     rightChildLeaf.store(tangle, snapshotProvider.getInitialSnapshot());
 
-    TransactionViewModel parent = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(leftChildLeaf.getHash(),
+    TransactionViewModel parent = new TransactionViewModel(getTransactionWithTrunkAndBranch(leftChildLeaf.getHash(),
             rightChildLeaf.getHash()), getRandomTransactionHash());
     parent.updateSolid(false);
     parent.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -182,7 +182,7 @@ public class TransactionValidatorTest {
     parentSibling.updateSolid(false);
     parentSibling.store(tangle, snapshotProvider.getInitialSnapshot());
 
-    TransactionViewModel grandParent = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(parent.getHash(),
+    TransactionViewModel grandParent = new TransactionViewModel(getTransactionWithTrunkAndBranch(parent.getHash(),
             parentSibling.getHash()), getRandomTransactionHash());
     grandParent.updateSolid(false);
     grandParent.store(tangle, snapshotProvider.getInitialSnapshot());

--- a/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionTrits;
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionHash;
-import static com.iota.iri.TransactionTestUtils.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.TransactionTestUtils.getTransactionWithTrunkAndBranch;
 
 import static org.junit.Assert.*;
 
@@ -296,11 +296,11 @@ public class TransactionViewModelTest {
         int count = 4;
         TransactionViewModel[] transactionViewModels = new TransactionViewModel[count];
         Hash hash = getRandomTransactionHash();
-        transactionViewModels[0] = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(Hash.NULL_HASH,
+        transactionViewModels[0] = new TransactionViewModel(getTransactionWithTrunkAndBranch(Hash.NULL_HASH,
                 Hash.NULL_HASH), hash);
         transactionViewModels[0].store(tangle, snapshotProvider.getInitialSnapshot());
         for(int i = 0; ++i < count; ) {
-            transactionViewModels[i] = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash,
+            transactionViewModels[i] = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash,
                     Hash.NULL_HASH), hash = getRandomTransactionHash());
             transactionViewModels[i].store(tangle, snapshotProvider.getInitialSnapshot());
         }
@@ -318,7 +318,7 @@ public class TransactionViewModelTest {
         TransactionViewModel[] transactionViewModels = new TransactionViewModel[count];
         Hash hash = getRandomTransactionHash();
         for(int i = 0; ++i < count; ) {
-            transactionViewModels[i] = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash,
+            transactionViewModels[i] = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash,
                     Hash.NULL_HASH), hash = getRandomTransactionHash());
             transactionViewModels[i].store(tangle, snapshotProvider.getInitialSnapshot());
         }
@@ -366,13 +366,13 @@ public class TransactionViewModelTest {
         int interval1 = 50;
         int interval = interval1*10;
         log.info("Starting Test. #TX: {}", TransactionViewModel.getNumberOfStoredTransactions(tangle));
-        new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(Hash.NULL_HASH, Hash.NULL_HASH), hash).store(tangle, snapshotProvider.getInitialSnapshot());
+        new TransactionViewModel(getTransactionWithTrunkAndBranch(Hash.NULL_HASH, Hash.NULL_HASH), hash).store(tangle, snapshotProvider.getInitialSnapshot());
         TransactionViewModel transactionViewModel;
         boolean pop = false;
         for (i = 0; i++ < max;) {
             hash = getRandomTransactionHash();
             j = hashes.size();
-            transactionViewModel = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hashes.get(seed.nextInt(j)), hashes.get(seed.nextInt(j))), hash);
+            transactionViewModel = new TransactionViewModel(getTransactionWithTrunkAndBranch(hashes.get(seed.nextInt(j)), hashes.get(seed.nextInt(j))), hash);
             start = System.nanoTime();
             transactionViewModel.store(tangle, snapshotProvider.getInitialSnapshot());
             diff = System.nanoTime() - start;

--- a/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
@@ -1,0 +1,88 @@
+package com.iota.iri.service.ledger.impl;
+
+import com.iota.iri.BundleValidator;
+import com.iota.iri.TangleMockUtils;
+import com.iota.iri.TransactionTestUtils;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.ledger.LedgerException;
+import com.iota.iri.service.milestone.MilestoneService;
+import com.iota.iri.service.snapshot.Snapshot;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.snapshot.SnapshotService;
+import com.iota.iri.service.spentaddresses.SpentAddressesException;
+import com.iota.iri.service.spentaddresses.SpentAddressesProvider;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.Converter;
+
+import java.util.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.junit.JUnitRule;
+import org.mockito.internal.util.collections.Sets;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRule;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class LedgerServiceImplTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private LedgerServiceImpl ledgerService = new LedgerServiceImpl();
+
+    @Mock
+    private Tangle tangle;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private SnapshotProvider snapshotProvider;
+
+    @Mock
+    private SnapshotService snapshotService;
+
+    @Mock
+    MilestoneService milestoneService;
+
+    @Mock
+    SpentAddressesProvider spentAddressesProvider;
+
+    @Mock
+    BundleValidator bundleValidator;
+
+
+    public LedgerServiceImplTest() {
+
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider,
+                bundleValidator);
+
+    }
+
+    @Test
+    public void generateBalanceDiff_persistsSpentAddresses() throws Exception {
+        List<TransactionViewModel> bundle = TangleMockUtils.mockValidBundle(tangle, bundleValidator, 1,
+                "A", "Z");
+        TransactionViewModel tailTx = bundle.get(0);
+        int milestoneIndex = 1;
+        when(milestoneService.isTransactionConfirmed(tailTx, milestoneIndex)).thenReturn(false);
+        when(snapshotProvider.getInitialSnapshot().getSolidEntryPoints()).thenReturn(Collections.emptyMap());
+
+        ledgerService.generateBalanceDiff(new HashSet<>(), tailTx.getHash(), milestoneIndex);
+        verify(spentAddressesProvider, times(1)).saveAddressesBatch(
+                eq(Arrays.asList(bundle.get(1).getAddressHash())));
+    }
+}

--- a/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
@@ -2,31 +2,23 @@ package com.iota.iri.service.ledger.impl;
 
 import com.iota.iri.BundleValidator;
 import com.iota.iri.TangleMockUtils;
-import com.iota.iri.TransactionTestUtils;
 import com.iota.iri.controllers.TransactionViewModel;
-import com.iota.iri.model.Hash;
-import com.iota.iri.service.ledger.LedgerException;
 import com.iota.iri.service.milestone.MilestoneService;
-import com.iota.iri.service.snapshot.Snapshot;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.SnapshotService;
-import com.iota.iri.service.spentaddresses.SpentAddressesException;
-import com.iota.iri.service.spentaddresses.SpentAddressesProvider;
+import com.iota.iri.service.spentaddresses.SpentAddressesService;
 import com.iota.iri.storage.Tangle;
-import com.iota.iri.utils.Converter;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.internal.junit.JUnitRule;
-import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoJUnitRule;
 import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Matchers.eq;
@@ -52,13 +44,13 @@ public class LedgerServiceImplTest {
     private SnapshotService snapshotService;
 
     @Mock
-    MilestoneService milestoneService;
+    private MilestoneService milestoneService;
 
     @Mock
-    SpentAddressesProvider spentAddressesProvider;
+    private SpentAddressesService spentAddressesService;
 
     @Mock
-    BundleValidator bundleValidator;
+    private BundleValidator bundleValidator;
 
 
     public LedgerServiceImplTest() {
@@ -66,8 +58,8 @@ public class LedgerServiceImplTest {
     }
 
     @Before
-    public void setUp() throws Exception {
-        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesProvider,
+    public void setUp() {
+        ledgerService.init(tangle, snapshotProvider, snapshotService, milestoneService, spentAddressesService,
                 bundleValidator);
 
     }
@@ -80,9 +72,7 @@ public class LedgerServiceImplTest {
         int milestoneIndex = 1;
         when(milestoneService.isTransactionConfirmed(tailTx, milestoneIndex)).thenReturn(false);
         when(snapshotProvider.getInitialSnapshot().getSolidEntryPoints()).thenReturn(Collections.emptyMap());
-
         ledgerService.generateBalanceDiff(new HashSet<>(), tailTx.getHash(), milestoneIndex);
-        verify(spentAddressesProvider, times(1)).saveAddressesBatch(
-                eq(Arrays.asList(bundle.get(1).getAddressHash())));
+        verify(spentAddressesService, times(1)).persistValidatedSpentAddressesAsync(eq(bundle));
     }
 }

--- a/src/test/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImplTest.java
+++ b/src/test/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImplTest.java
@@ -1,0 +1,15 @@
+package com.iota.iri.service.spentaddresses.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class SpentAddressesProviderImplTest {
+
+    @Test
+    public void saveAddressBatch() {
+
+    }
+
+}

--- a/src/test/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculatorTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculatorTest.java
@@ -58,13 +58,13 @@ public class CumulativeWeightCalculatorTest {
     public void testCalculateCumulativeWeight() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction3.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -89,11 +89,11 @@ public class CumulativeWeightCalculatorTest {
     public void testCalculateCumulativeWeightDiamond() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction2.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -121,13 +121,13 @@ public class CumulativeWeightCalculatorTest {
     public void testCalculateCumulativeWeightLinear() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction1.getHash(), transaction1.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction2.getHash(), transaction2.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction3.getHash(), transaction3.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -158,17 +158,17 @@ public class CumulativeWeightCalculatorTest {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4, transaction5,
                 transaction6;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction5 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction5 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction3.getHash(), transaction2.getHash()), getRandomTransactionHash());
-        transaction6 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction6 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction4.getHash(), transaction5.getHash()), getRandomTransactionHash());
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -212,7 +212,7 @@ public class CumulativeWeightCalculatorTest {
         for (int i = 1; i < hashes.length; i++) {
             hashes[i] = getRandomTransactionHash();
             TransactionViewModel transactionViewModel = new TransactionViewModel(
-                    getRandomTransactionWithTrunkAndBranch(hashes[i - random.nextInt(i) - 1],
+                    getTransactionWithTrunkAndBranch(hashes[i - random.nextInt(i) - 1],
                             hashes[i - random.nextInt(i) - 1]), hashes[i]);
             transactionViewModel.store(tangle, snapshotProvider.getInitialSnapshot());
             log.debug(String.format("current transaction %.4s \n with trunk %.4s \n and branch %.4s", hashes[i],
@@ -237,7 +237,7 @@ public class CumulativeWeightCalculatorTest {
     public void testTangleWithCircle() throws Exception {
         TransactionViewModel transaction;
         Hash randomTransactionHash = getRandomTransactionHash();
-        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(randomTransactionHash, randomTransactionHash), randomTransactionHash);
+        transaction = new TransactionViewModel(getTransactionWithTrunkAndBranch(randomTransactionHash, randomTransactionHash), randomTransactionHash);
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
 
@@ -250,13 +250,13 @@ public class CumulativeWeightCalculatorTest {
     public void testTangleWithCircle2() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         Hash randomTransactionHash2 = getRandomTransactionHash();
-        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 randomTransactionHash2, randomTransactionHash2), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction1.getHash(), transaction1.getHash()), randomTransactionHash2);
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -272,12 +272,12 @@ public class CumulativeWeightCalculatorTest {
     public void testCollsionsInDiamondTangle() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
         Hash transactionHash2 = getHashWithSimilarPrefix(transaction1);
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), transactionHash2);
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction2.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -328,7 +328,7 @@ public class CumulativeWeightCalculatorTest {
         Random random = new Random();
         for (int i = 1; i < hashes.length; i++) {
             hashes[i] = getRandomTransactionHash();
-            new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hashes[i - random.nextInt(i) - 1],
+            new TransactionViewModel(getTransactionWithTrunkAndBranch(hashes[i - random.nextInt(i) - 1],
                     hashes[i - random.nextInt(i) - 1]), hashes[i]).store(tangle, snapshotProvider.getInitialSnapshot());
         }
         long start = System.currentTimeMillis();

--- a/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
@@ -17,7 +17,7 @@ import org.junit.rules.TemporaryFolder;
 
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionTrits;
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionHash;
-import static com.iota.iri.TransactionTestUtils.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.TransactionTestUtils.getTransactionWithTrunkAndBranch;
 
 public class RatingOneTest {
     private static final TemporaryFolder dbFolder = new TemporaryFolder();
@@ -52,13 +52,13 @@ public class RatingOneTest {
     public void testCalculate() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction3.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());

--- a/src/test/java/com/iota/iri/service/tipselection/impl/TailFinderImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TailFinderImplTest.java
@@ -4,7 +4,7 @@ import static com.iota.iri.TransactionTestUtils.getRandomTransactionTrits;
 import static com.iota.iri.TransactionTestUtils.createBundleHead;
 import static com.iota.iri.TransactionTestUtils.createTransactionWithTrunkBundleHash;
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionHash;
-import static com.iota.iri.TransactionTestUtils.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.TransactionTestUtils.getTransactionWithTrunkAndBranch;
 
 import com.iota.iri.conf.MainnetConfig;
 import com.iota.iri.controllers.TransactionViewModel;
@@ -91,7 +91,7 @@ public class TailFinderImplTest {
         TransactionViewModel tx1 = createTransactionWithTrunkBundleHash(tx2, txa.getHash());
         tx1.store(tangle, snapshotProvider.getInitialSnapshot());
 
-        TransactionViewModel tx0 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx1.getHash(), tx2.getHash()),
+        TransactionViewModel tx0 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx1.getHash(), tx2.getHash()),
                 getRandomTransactionHash());
         tx0.store(tangle, snapshotProvider.getInitialSnapshot());
 

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static com.iota.iri.TransactionTestUtils.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.TransactionTestUtils.getTransactionWithTrunkAndBranch;
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionHash;
 
 import java.util.HashMap;
@@ -146,7 +146,7 @@ public class WalkValidatorImplTest {
         tx.setSnapshot(tangle, snapshotProvider.getInitialSnapshot(), 92);
         Hash hash = tx.getHash();
         for (int i = 0; i < 4 ; i++) {
-            tx = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash, hash), getRandomTransactionHash());
+            tx = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash, hash), getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
             tx.updateSolid(true);
@@ -170,7 +170,7 @@ public class WalkValidatorImplTest {
         tx.setSnapshot(tangle, snapshotProvider.getInitialSnapshot(), 92);
         Hash hash = tx.getHash();
         for (int i = 0; i < maxAnalyzedTxs ; i++) {
-            tx = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash, hash),
+            tx = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash, hash),
                     getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
@@ -193,7 +193,7 @@ public class WalkValidatorImplTest {
         final int maxAnalyzedTxs = config.getBelowMaxDepthTransactionLimit();
         Hash hash = Hash.NULL_HASH;
         for (int i = 0; i < maxAnalyzedTxs - 2 ; i++) {
-            tx = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash, hash), getRandomTransactionHash());
+            tx = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash, hash), getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
             tx.updateSolid(true);
@@ -216,7 +216,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = null;
         Hash hash = Hash.NULL_HASH;
         for (int i = 0; i < maxAnalyzedTxs; i++) {
-            tx = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hash, hash),
+            tx = new TransactionViewModel(getTransactionWithTrunkAndBranch(hash, hash),
                     getRandomTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
@@ -261,21 +261,21 @@ public class WalkValidatorImplTest {
         txBad.store(tangle, snapshotProvider.getInitialSnapshot());
         txBad.setSnapshot(tangle, snapshotProvider.getInitialSnapshot(), 10);
 
-        TransactionViewModel tx2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx1.getHash(), tx1.getHash()),
+        TransactionViewModel tx2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx1.getHash(), tx1.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx2,0);
         TransactionTestUtils.setCurrentIndex(tx2,0);
         tx2.updateSolid(true);
         tx2.store(tangle, snapshotProvider.getInitialSnapshot());
 
-        TransactionViewModel tx3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
+        TransactionViewModel tx3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx3,0);
         TransactionTestUtils.setCurrentIndex(tx3,0);
         tx3.updateSolid(true);
         tx3.store(tangle, snapshotProvider.getInitialSnapshot());
 
-        TransactionViewModel tx4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
+        TransactionViewModel tx4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx4,0);
         TransactionTestUtils.setCurrentIndex(tx4,0);
@@ -307,21 +307,21 @@ public class WalkValidatorImplTest {
         txBad.store(tangle, snapshotProvider.getInitialSnapshot());
         txBad.setSnapshot(tangle, snapshotProvider.getInitialSnapshot(), 10);
 
-        TransactionViewModel tx2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx1.getHash(), tx1.getHash()),
+        TransactionViewModel tx2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx1.getHash(), tx1.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx2,0);
         TransactionTestUtils.setCurrentIndex(tx2,0);
         tx2.updateSolid(true);
         tx2.store(tangle, snapshotProvider.getInitialSnapshot());
 
-        TransactionViewModel tx3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
+        TransactionViewModel tx3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx3,0);
         TransactionTestUtils.setCurrentIndex(tx3,0);
         tx3.updateSolid(true);
         tx3.store(tangle, snapshotProvider.getInitialSnapshot());
 
-        TransactionViewModel tx4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
+        TransactionViewModel tx4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
                 getRandomTransactionHash());
         TransactionTestUtils.setLastIndex(tx4,0);
         TransactionTestUtils.setCurrentIndex(tx4,0);

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionTrits;
 import static com.iota.iri.TransactionTestUtils.getRandomTransactionHash;
-import static com.iota.iri.TransactionTestUtils.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.TransactionTestUtils.getTransactionWithTrunkAndBranch;
 
 public class WalkerAlphaTest {
     private static final TemporaryFolder dbFolder = new TemporaryFolder();
@@ -71,11 +71,11 @@ public class WalkerAlphaTest {
         //build a small tangle - 1,2,3,4 point to  transaction
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -88,7 +88,7 @@ public class WalkerAlphaTest {
         UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
 
         //add 4 after the rating was calculated
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
         transaction4.store(tangle, snapshotProvider.getInitialSnapshot());
 
@@ -108,11 +108,11 @@ public class WalkerAlphaTest {
         //build a small tangle - 1,2,3,4 point to  transaction
         TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -151,11 +151,11 @@ public class WalkerAlphaTest {
         //build a small tangle - 1,2,3,4 point to  transaction
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
 
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -170,7 +170,7 @@ public class WalkerAlphaTest {
         rating.put(transaction2.getHash(), 10);
 
         //add 4 after the rating was calculated
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
         transaction4.store(tangle, snapshotProvider.getInitialSnapshot());
 
@@ -198,13 +198,13 @@ public class WalkerAlphaTest {
         //build a small tangle
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), Hash.NULL_HASH);
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction1.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction2.getHash(),
                 transaction3.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -228,11 +228,11 @@ public class WalkerAlphaTest {
         //build a small tangle
         TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(transaction1.getHash(),
                 transaction2.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());
@@ -255,13 +255,13 @@ public class WalkerAlphaTest {
         //build a small tangle
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
-        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction1 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction2 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction1.getHash(), transaction1.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction3 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction2.getHash(), transaction2.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+        transaction4 = new TransactionViewModel(getTransactionWithTrunkAndBranch(
                 transaction3.getHash(), transaction3.getHash()), getRandomTransactionHash());
         transaction.store(tangle, snapshotProvider.getInitialSnapshot());
         transaction1.store(tangle, snapshotProvider.getInitialSnapshot());


### PR DESCRIPTION
# Description

1. While we are applying a milestone, persist validated spent addresses in the db from confirmed transactions.
2. Stop persisting them while taking a local snapshot
3. Adds unit tests while doing neccessary refactoring to make the code more testable


Fixes #1321

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test added
Canary have been ran on the mainnet



# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
