### PR TITLE
Fix: Db exists() method optimization

### DIFF
--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -86,7 +86,7 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
     @Override
     public boolean containsAddress(Hash addressHash) throws SpentAddressesException {
         try {
-            return ((SpentAddress) rocksDBPersistenceProvider.get(SpentAddress.class, addressHash)).exists();
+            return rocksDBPersistenceProvider.exists(SpentAddress.class, addressHash);
         } catch (Exception e) {
             throw new SpentAddressesException(e);
         }

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -98,8 +98,12 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
 
     @Override
     public boolean exists(Class<?> model, Indexable key) throws Exception {
-        ColumnFamilyHandle handle = classTreeMap.get(model);
-        return handle != null && db.get(handle, key.bytes()) != null;
+        if (mayExist(model, key)) {
+            //ensure existence
+            ColumnFamilyHandle handle = classTreeMap.get(model);
+            return handle != null && db.get(handle, key.bytes()) != null;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
# Description
1. Ensures that in general RocksDb will go through its internal bloom filter when checking for existence
2. Make the `WereAddressesSpentFromProvider` use the rocksDB `exists`

Relates to #1291

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests will be written in #1091 and when we refactor the db


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
