### PR TITLE
Fix #1276: Return ip address instead of hostname in getNeighbors

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -171,7 +171,7 @@ public class Node {
      * traffic - so a balance is sought between speed and resource utilization.
      *
      */
-    private Runnable spawnNeighborDNSRefresherThread() {
+    Runnable spawnNeighborDNSRefresherThread() {
         return () -> {
             if (configuration.isDnsResolutionEnabled()) {
                 log.info("Spawning Neighbor DNS Refresher Thread");

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -57,7 +57,7 @@ public class GetNeighborsResponse extends AbstractResponse {
      * 
      */
     @SuppressWarnings("unused")
-    private static class Neighbor {
+    public static class Neighbor {
 
         private String address;
         private long numberOfAllTransactions;
@@ -138,7 +138,7 @@ public class GetNeighborsResponse extends AbstractResponse {
          * @param n the neighbor currently connected to this node
          * @return a new instance of {@link GetNeighborsResponse.Neighbor}
          */
-        static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
+        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
             Neighbor ne = new Neighbor();
             int port = n.getPort();
             ne.address = n.getAddress().getAddress().getHostAddress() + ":" + port;

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -60,13 +60,13 @@ public class GetNeighborsResponse extends AbstractResponse {
     static class Neighbor {
 
         private String address;
-        long numberOfAllTransactions;
-        long numberOfRandomTransactionRequests;
-        long numberOfNewTransactions;
-        long numberOfInvalidTransactions;
-        long numberOfStaleTransactions;
-        long numberOfSentTransactions;
-        String connectionType;
+        private long numberOfAllTransactions;
+        private long numberOfRandomTransactionRequests;
+        private long numberOfNewTransactions;
+        private long numberOfInvalidTransactions;
+        private long numberOfStaleTransactions;
+        private long numberOfSentTransactions;
+        private String connectionType;
 
         /**
          * The address of your neighbor

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -57,7 +57,7 @@ public class GetNeighborsResponse extends AbstractResponse {
      * 
      */
     @SuppressWarnings("unused")
-    static class Neighbor {
+    private static class Neighbor {
 
         private String address;
         private long numberOfAllTransactions;

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -2,12 +2,10 @@ package com.iota.iri.service.dto;
 
 import java.util.List;
 
-import com.iota.iri.service.API;
-
 /**
  * 
  * Contains information about the result of a successful {@code getNeighbors} API call.
- * See {@link API#getNeighborsStatement} for how this response is created.
+ * See {@link GetNeighborsResponse#create(List)} for how this response is created.
  *
  */
 public class GetNeighborsResponse extends AbstractResponse {
@@ -25,7 +23,7 @@ public class GetNeighborsResponse extends AbstractResponse {
      *     <li>numberOfSentTransactions</li>
      *     <li>numberOfStaleTransactions</li>
      * </ol>
-     * @see {@link com.iota.iri.service.dto.GetNeighborsResponse.Neighbor}
+     * @see com.iota.iri.service.dto.GetNeighborsResponse.Neighbor
      */
     private Neighbor[] neighbors;
 
@@ -58,16 +56,17 @@ public class GetNeighborsResponse extends AbstractResponse {
      * A plain DTO of an iota neighbor.
      * 
      */
+    @SuppressWarnings("unused")
     static class Neighbor {
 
         private String address;
-        public long numberOfAllTransactions,
-                numberOfRandomTransactionRequests,
-                numberOfNewTransactions,
-                numberOfInvalidTransactions,
-                numberOfStaleTransactions,
-                numberOfSentTransactions;
-        public String connectionType;
+        long numberOfAllTransactions;
+        long numberOfRandomTransactionRequests;
+        long numberOfNewTransactions;
+        long numberOfInvalidTransactions;
+        long numberOfStaleTransactions;
+        long numberOfSentTransactions;
+        String connectionType;
 
         /**
          * The address of your neighbor
@@ -139,10 +138,10 @@ public class GetNeighborsResponse extends AbstractResponse {
          * @param n the neighbor currently connected to this node
          * @return a new instance of {@link GetNeighborsResponse.Neighbor}
          */
-        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
+        static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
             Neighbor ne = new Neighbor();
             int port = n.getPort();
-            ne.address = n.getAddress().getHostString() + ":" + port;
+            ne.address = n.getAddress().getAddress().getHostAddress() + ":" + port;
             ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
             ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
             ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();

--- a/src/test/java/com/iota/iri/network/NodeTest.java
+++ b/src/test/java/com/iota/iri/network/NodeTest.java
@@ -1,0 +1,70 @@
+package com.iota.iri.network;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.iota.iri.conf.NodeConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NodeTest {
+    @Mock
+    private NodeConfig nodeConfig;
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+    @Captor
+    private ArgumentCaptor<ILoggingEvent> captorLoggingEvent;
+
+    private Node classUnderTest;
+    private static final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+    @Before
+    public void setUp() {
+        // inject our mock appender
+        logger.addAppender(mockAppender);
+
+        // set up class under test
+        nodeConfig = Mockito.mock(NodeConfig.class);
+        classUnderTest = new Node(null, null, null, null, null, null, nodeConfig);
+
+        // verify config calls in Node constructor
+        verify(nodeConfig).getRequestHashSize();
+        verify(nodeConfig).getTransactionPacketSize();
+    }
+
+    @After
+    public void tearDown() {
+        logger.detachAppender(mockAppender);
+    }
+
+    @Test
+    public void spawnNeighborDNSRefresherThreadTest() {
+        when(nodeConfig.isDnsResolutionEnabled()).thenReturn(false);
+        Runnable runnable = classUnderTest.spawnNeighborDNSRefresherThread();
+        runnable.run();
+        verify(nodeConfig).isDnsResolutionEnabled();
+        verifyNoMoreInteractions(nodeConfig);
+
+        // verify logging
+        verify(mockAppender).doAppend(captorLoggingEvent.capture());
+        final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
+        assertThat("Loglevel must be info", loggingEvent.getLevel(), is(Level.INFO));
+        assertThat("Invalid log message", loggingEvent.getFormattedMessage(),is("Ignoring DNS Refresher Thread... DNS_RESOLUTION_ENABLED is false"));
+    }
+}

--- a/src/test/java/com/iota/iri/service/dto/GetNeighborsResponseTest.java
+++ b/src/test/java/com/iota/iri/service/dto/GetNeighborsResponseTest.java
@@ -1,0 +1,41 @@
+package com.iota.iri.service.dto;
+
+import com.iota.iri.network.Neighbor;
+import com.iota.iri.network.TCPNeighbor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class GetNeighborsResponseTest {
+
+    private List<Neighbor> neighbors;
+
+    @Before
+    public void setUp() throws Exception {
+        InetAddress inetAddress = InetAddress.getByAddress("test.test", new byte[]{10, 0, 0, 1});
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(inetAddress, 8888);
+        Neighbor neighbor = new TCPNeighbor(inetSocketAddress, true);
+        neighbors = Collections.singletonList(neighbor);
+    }
+
+    @Test
+    public void getNeighbors() {
+        GetNeighborsResponse response = (GetNeighborsResponse) GetNeighborsResponse.create(neighbors);
+        assertEquals("One neighbor must exist", 1, response.getNeighbors().length);
+        assertNotEquals("test.test", response.getNeighbors()[0].getAddress());
+        assertEquals("Must return IP address and port", "10.0.0.1:8888", response.getNeighbors()[0].getAddress());
+    }
+
+    @Test
+    public void create() {
+        GetNeighborsResponse response = (GetNeighborsResponse) GetNeighborsResponse.create(neighbors);
+        assertEquals("One neighbor must exist", 1, response.getNeighbors().length);
+    }
+}


### PR DESCRIPTION
# Description

Will return the ip address on api call to getNeighbors.

Fixes #1276 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Created unit tests in GetNeighborsResponseTest
- Start iri with <code>--testnet -n tcp://1.2.3.4:15600</code>
- <code>curl http://localhost:14265 -X POST -H 'Content-Type: application/json' -H 'X-IOTA-API-Version: 1' -d '{"command": "getNeighbors"}'</code>

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
