### PR TITLE
Bugfix: inconsistency in arrivalTime units

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -855,7 +855,7 @@ public class API {
         for (final TransactionViewModel transactionViewModel : elements) {
             //store transactions
             if(transactionViewModel.store(instance.tangle, instance.snapshotProvider.getInitialSnapshot())) {
-                transactionViewModel.setArrivalTime(System.currentTimeMillis() / 1000L);
+                transactionViewModel.setArrivalTime(System.currentTimeMillis());
                 instance.transactionValidator.updateStatus(transactionViewModel);
                 transactionViewModel.updateSender("local");
                 transactionViewModel.update(instance.tangle, instance.snapshotProvider.getInitialSnapshot(), "sender");


### PR DESCRIPTION
# Description
When storing a transaction via the API, the arrival timestamp is stored in Seconds, while when gossiped it's stored with an arrival timestamp in Milliseconds
Fixes #766 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)