### PR TITLE
Allow IXI to manage more than POST HTTP requests

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.channels.StreamSinkChannel;
+import org.xnio.channels.StreamSourceChannel;
 import org.xnio.streams.ChannelInputStream;
 
 import java.io.IOException;
@@ -88,7 +89,7 @@ public class API {
 
     private Undertow server;
 
-    private final Gson gson = new GsonBuilder().create();
+    private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();    
     private volatile PearlDiver pearlDiver = new PearlDiver();
 
     private final AtomicInteger counter = new AtomicInteger(0);
@@ -220,7 +221,6 @@ public class API {
      */
     private void sendResponse(HttpServerExchange exchange, AbstractResponse res, long beginningTime) throws IOException {
         res.setDuration((int) (System.currentTimeMillis() - beginningTime));
-        final String response = gson.toJson(res);
 
         if (res instanceof ErrorResponse) {
             // bad request or invalid parameters
@@ -233,7 +233,10 @@ public class API {
             exchange.setStatusCode(500);
         }
 
-        setupResponseHeaders(exchange);
+
+        setupResponseHeaders(exchange, res);
+
+        final String response = convertResponseToClientFormat(res);
 
         ByteBuffer responseBuf = ByteBuffer.wrap(response.getBytes(StandardCharsets.UTF_8));
         exchange.setResponseContentLength(responseBuf.array().length);
@@ -258,6 +261,21 @@ public class API {
         sinkChannel.resumeWrites();
     }
 
+    private String convertResponseToClientFormat(AbstractResponse res) {
+        String response = null;
+        if(res instanceof IXIResponse){
+            final String content = ((IXIResponse)res).getContent();
+            if(content != null && StringUtils.isNotBlank(content)){
+                response = content;
+            }
+        }
+        if(response == null){
+            response = gson.toJson(res);
+        }
+
+         return response;
+    }
+    
     /**
      * <p>
      *     Processes an API HTTP request.
@@ -275,22 +293,47 @@ public class API {
      * @throws IOException If the body of this HTTP request cannot be read
      */
     private void processRequest(final HttpServerExchange exchange) throws IOException {
-        final ChannelInputStream cis = new ChannelInputStream(exchange.getRequestChannel());
-        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-
         final long beginningTime = System.currentTimeMillis();
-        final String body = IotaIOUtils.toString(cis, StandardCharsets.UTF_8);
-        AbstractResponse response;
 
-        if (!exchange.getRequestHeaders().contains("X-IOTA-API-Version")) {
-            response = ErrorResponse.create("Invalid API Version");
-        } else if (body.length() > maxBodyLength) {
-            response = ErrorResponse.create("Request too long");
-        } else {
-            response = process(body, exchange.getSourceAddress());
+        AbstractResponse response;
+        try {
+            final String body = getRequestBody(exchange);
+            if (body.length() > maxBodyLength) {
+                response = ErrorResponse.create("Request too long");
+            } else {
+                response = process(body, exchange);
+            }
+        } catch (IOException e) {
+            log.error("API Exception: {}", e.getLocalizedMessage(), e);
+            response =  ErrorResponse.create(e.getLocalizedMessage());
         }
         sendResponse(exchange, response, beginningTime);
     }
+
+    private String getRequestBody(final HttpServerExchange exchange) throws IOException {
+        StreamSourceChannel requestChannel = exchange.getRequestChannel();
+        final ChannelInputStream cis = new ChannelInputStream(requestChannel);
+        String body = IotaIOUtils.toString(cis, StandardCharsets.UTF_8);
+        
+        if(body.length() == 0){
+            body = getQueryParamsBody(exchange.getQueryParameters());
+        } else if (!exchange.getRequestHeaders().contains("X-IOTA-API-Version")) {
+            throw new IOException ("Invalid API Version");
+        }
+        return body;
+    }
+
+     private String getQueryParamsBody(Map<String, Deque<String>> queryParameters) {
+        Map<String, String> parametersMapper = new HashMap<String, String>();
+
+         for (String key : queryParameters.keySet()) {
+            Deque<String> dequeuedParameter = queryParameters.get(key);
+            String parameterValue = dequeuedParameter.getFirst();
+            parametersMapper.put(key, parameterValue);
+        }
+
+         return gson.toJson(parametersMapper);
+	}
 
     /**
      * Handles an API request body.
@@ -324,8 +367,7 @@ public class API {
      * @throws UnsupportedEncodingException If the requestString cannot be parsed into a Map.
                                             Currently caught and turned into a {@link ExceptionResponse}.
      */
-    private AbstractResponse process(final String requestString, InetSocketAddress sourceAddress)
-            throws UnsupportedEncodingException {
+    private AbstractResponse process(final String requestString, final HttpServerExchange exchange) throws UnsupportedEncodingException {
 
         try {
             // Request JSON data into map
@@ -346,6 +388,7 @@ public class API {
                 return ErrorResponse.create("COMMAND parameter has not been specified in the request.");
             }
 
+            InetSocketAddress sourceAddress = exchange.getSourceAddress();
             // Is this command allowed to be run from this request address?
             // We check the remote limit API configuration.
             if (instance.configuration.getRemoteLimitApi().contains(command) &&
@@ -1624,11 +1667,22 @@ public class API {
      * Updates the {@link HttpServerExchange} {@link HeaderMap} with the proper response settings.
      * @param exchange Contains information about what the client has send to us
      */
-    private static void setupResponseHeaders(HttpServerExchange exchange) {
+    private static void setupResponseHeaders(final HttpServerExchange exchange, final AbstractResponse res) {        
         final HeaderMap headerMap = exchange.getResponseHeaders();
         headerMap.add(new HttpString("Access-Control-Allow-Origin"),"*");
         headerMap.add(new HttpString("Keep-Alive"), "timeout=500, max=100");
+        headerMap.put(Headers.CONTENT_TYPE, getResponseContentType(res));
+
     }
+
+    private static String getResponseContentType(AbstractResponse response) {
+        if(response instanceof IXIResponse){
+            return ((IXIResponse)response).getResponseContentType();
+        }
+        else {
+            return "application/json";
+        }
+	}
 
     /**
      * Sets up the {@link HttpHandler} to have correct security settings.

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -261,6 +261,17 @@ public class API {
         sinkChannel.resumeWrites();
     }
 
+    /**
+     * <p>
+     *     Converts the abstract response to String based on type of response.
+     *     Extracts the content the res if it is an instance of IXIResponse in order
+     *     to serve it otherwise returnes the response as JSON string. 
+     * </p>
+     *
+     * @param res The response of the API.
+     *            See {@link #processRequest(HttpServerExchange)}
+     *            and {@link #process(String, InetSocketAddress)} for the different responses in each case.
+     */
     private String convertResponseToClientFormat(AbstractResponse res) {
         String response = null;
         if(res instanceof IXIResponse){
@@ -289,8 +300,8 @@ public class API {
      *     The result is sent back to the requester.
      * </p>
      *
-     * @param exchange Contains the data the client sent to us
-     * @throws IOException If the body of this HTTP request cannot be read
+     * @param exchange Contains the data the client sent to us.
+     * @throws IOException If the body of this HTTP request cannot be read.
      */
     private void processRequest(final HttpServerExchange exchange) throws IOException {
         final long beginningTime = System.currentTimeMillis();
@@ -310,6 +321,18 @@ public class API {
         sendResponse(exchange, response, beginningTime);
     }
 
+    /**
+     * <p>
+     *     Extracts a json body based on type of HTTP request.
+     *     In case of POST request the body is taken from the request body and the request
+     *     should contain of X-IOTA-API-Version header, otherwise, an exception is raised.
+     *     In another case, the body is extracted with getQueryParamsBody to build up a json
+     *     based on query parameters.
+     * </p>
+     *
+     * @param exchange Contains the data the client sent to us.
+     * @throws IOException If the body of this HTTP request cannot be read.
+     */
     private String getRequestBody(final HttpServerExchange exchange) throws IOException {
         StreamSourceChannel requestChannel = exchange.getRequestChannel();
         final ChannelInputStream cis = new ChannelInputStream(requestChannel);
@@ -323,16 +346,24 @@ public class API {
         return body;
     }
 
-     private String getQueryParamsBody(Map<String, Deque<String>> queryParameters) {
+    /**
+     * <p>
+     *     Extracts query parameters and builds up a json object using them
+     *     as key value.
+     * </p>
+     *
+     * @param queryParameters Contains a mutable map of query parameters.
+     */
+    private String getQueryParamsBody(Map<String, Deque<String>> queryParameters) {
         Map<String, String> parametersMapper = new HashMap<String, String>();
 
-         for (String key : queryParameters.keySet()) {
+        for (String key : queryParameters.keySet()) {
             Deque<String> dequeuedParameter = queryParameters.get(key);
             String parameterValue = dequeuedParameter.getFirst();
             parametersMapper.put(key, parameterValue);
         }
 
-         return gson.toJson(parametersMapper);
+        return gson.toJson(parametersMapper);
 	}
 
     /**
@@ -362,7 +393,7 @@ public class API {
      *
      * @param requestString The JSON encoded data of the request.
      *                      This String is attempted to be converted into a {@code Map<String, Object>}.
-     * @param sourceAddress The address from the sender of this API request.
+     * @param exchange Contains the data the client sent to us.
      * @return The result of this request.
      * @throws UnsupportedEncodingException If the requestString cannot be parsed into a Map.
                                             Currently caught and turned into a {@link ExceptionResponse}.
@@ -1666,7 +1697,9 @@ public class API {
     /**
      * Updates the {@link HttpServerExchange} {@link HeaderMap} with the proper response settings.
      * @param exchange Contains information about what the client has send to us
-     */
+     * @param res The response of the API.
+     *            See {@link #processRequest(HttpServerExchange)}
+     *            and {@link #process(String, InetSocketAddress)} for the different responses in each case.     */
     private static void setupResponseHeaders(final HttpServerExchange exchange, final AbstractResponse res) {        
         final HeaderMap headerMap = exchange.getResponseHeaders();
         headerMap.add(new HttpString("Access-Control-Allow-Origin"),"*");

--- a/src/main/java/com/iota/iri/service/dto/IXIResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/IXIResponse.java
@@ -1,6 +1,8 @@
 package com.iota.iri.service.dto;
 
 import com.iota.iri.IXI;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * <p>
@@ -27,4 +29,26 @@ public class IXIResponse extends AbstractResponse {
     public Object getResponse() {
         return ixi;
     }
+
+    private String getdefaultContentType() {
+        return "application/json";
+    }
+
+     public String getResponseContentType() {
+        Map<String, Object> responseMapper = getResponseMapper();
+        String fieldObj = (String)responseMapper.get("contentType");
+        String fieldValue = StringUtils.isBlank(fieldObj) ? getdefaultContentType() : fieldObj;
+        return fieldValue;
+    }
+
+     private Map<String, Object> getResponseMapper(){
+        return (Map<String, Object>)ixi;
+    }
+
+     public String getContent() {
+        Map<String, Object> responseMapper = getResponseMapper();
+        String fieldObj = (String)responseMapper.get("content");
+        String fieldValue = StringUtils.isBlank(fieldObj) ? null : fieldObj;
+        return fieldValue;
+	}
 }

--- a/src/main/java/com/iota/iri/service/dto/IXIResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/IXIResponse.java
@@ -34,18 +34,18 @@ public class IXIResponse extends AbstractResponse {
         return "application/json";
     }
 
-     public String getResponseContentType() {
+    public String getResponseContentType() {
         Map<String, Object> responseMapper = getResponseMapper();
         String fieldObj = (String)responseMapper.get("contentType");
         String fieldValue = StringUtils.isBlank(fieldObj) ? getdefaultContentType() : fieldObj;
         return fieldValue;
     }
 
-     private Map<String, Object> getResponseMapper(){
+    private Map<String, Object> getResponseMapper(){
         return (Map<String, Object>)ixi;
     }
 
-     public String getContent() {
+    public String getContent() {
         Map<String, Object> responseMapper = getResponseMapper();
         String fieldObj = (String)responseMapper.get("content");
         String fieldValue = StringUtils.isBlank(fieldObj) ? null : fieldObj;


### PR DESCRIPTION
# Description

_The previous PR was born to allow IXI Modules to decide the content-type they wish to send to the client. The idea is that clients might want to, for example, load web content directly on their browser, get data in XML format, images, or whatever the IXI module serves._

_My interest in this topic started from the same goal, precisely to be able to serve web content directly from the node. This functionality is currently not available due to missing handling or HTTP requests different than POST._

Previous PR #743    
Previous PR was created for issue #615

## Type of change

- Enhancement (a non-breaking change which adds functionality)

The previous PR provided changes to enable the node to make HTTP requests different from POST to be managed as fallback by IXI modules.
The changes didn't modify previous POST handling, that's why I would classify the change as enhancement.

I created this new PR because the previous one was developed on iri version 1.4.1.

To improve the previous work I implemented a different handling of X-IOTA-API-Version check management, that is now executed during body parsing, instead of repeating the check in each branch of the switch case (in process function).  
I added comments to new functions.

I would like to reopen the discussion about this feature that could be a good enhancement to the iri functionalities.

# How Has This Been Tested?

First of all I tried old ixi modules to check if updates are backcompatible (as https://github.com/iotaledger/iri/pull/743#issuecomment-389479482 asked), even if most of them are deprecated. Moreover I used an easy IXI module to check if the html content was correctly provided.

I launched unit tests and there is a problem I would like to discuss about. The result state: 

> [INFO] Results:  
[INFO]  
[ERROR] Errors:  
[ERROR]com.iota.iri.service.APIIntegrationTests.com.iota.iri.service.APIIntegrationTests  
[ERROR]   Run 1: APIIntegrationTests.setUp:91 » SpentAddresses There is a problem with accessin...  
[ERROR]   Run 2: APIIntegrationTests.tearDown:118 Exception occurred shutting down IOTA node
[INFO]  
[INFO]  
[ERROR] Tests run: 233, Failures: 0, Errors: 1, Skipped: 1  

I'm not really sure this is due to changes.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas