### PR TITLE
Fix: fetch correct arrival time while traversing dags for orphaned transactions.

### DIFF
--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
@@ -527,11 +527,6 @@ public class SnapshotServiceImpl implements SnapshotService {
     private boolean isOrphaned(Tangle tangle, TransactionViewModel transaction,
             TransactionViewModel referenceTransaction, Set<Hash> processedTransactions) throws SnapshotException {
 
-        long arrivalTime = transaction.getArrivalTime() / 1000L;
-        if (arrivalTime > referenceTransaction.getTimestamp()) {
-            return false;
-        }
-
         AtomicBoolean nonOrphanedTransactionFound = new AtomicBoolean(false);
         try {
             DAGHelper.get(tangle).traverseApprovers(

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImpl.java
@@ -538,7 +538,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                     transaction.getHash(),
                     currentTransaction -> !nonOrphanedTransactionFound.get(),
                     currentTransaction -> {
-                        if (arrivalTime > referenceTransaction.getTimestamp()) {
+                        if (currentTransaction.getArrivalTime() / 1000L > referenceTransaction.getTimestamp()) {
                             nonOrphanedTransactionFound.set(true);
                         }
                     },


### PR DESCRIPTION
# Description
While traversing the transactions approvers we use the arrival time of the original root transaction instead of the `currentTransaction`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

A unit test needs to be added

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
