### PR TITLE
Feature: Store pruned transaction hashes in a cuckoo filter

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -5,7 +5,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.iota.iri.IRI;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
@@ -109,7 +108,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected String localSnapshotsBasePath = Defaults.LOCAL_SNAPSHOTS_BASE_PATH;
     protected String spentAddressesDbPath = Defaults.SPENT_ADDRESSES_DB_PATH;
     protected String spentAddressesDbLogPath = Defaults.SPENT_ADDRESSES_DB_LOG_PATH;
-
+    protected String prunedTransactionsDbPath = Defaults.PRUNED_TRANSACTIONS_DB_PATH;
+    protected String prunedTransactionsDbLogPath = Defaults.PRUNED_TRANSACTIONS_DB_LOG_PATH;
+    
     public BaseIotaConfig() {
         //empty constructor
     }
@@ -650,13 +651,35 @@ public abstract class BaseIotaConfig implements IotaConfig {
     public String getSpentAddressesDbLogPath() {
         return spentAddressesDbLogPath;
     }
-
+    
     @JsonProperty
     @Parameter(names = {"--spent-addresses-db-log-path"}, description = SnapshotConfig.Descriptions.SPENT_ADDRESSES_DB_LOG_PATH)
-    protected void setSpentAddressesDbLogPath(String spentAddressesDbLogPath) {
+    protected void setPrunedTransactionDbLogPath(String spentAddressesDbLogPath) {
         this.spentAddressesDbLogPath = spentAddressesDbLogPath;
     }
-
+    
+    @Override
+    public String getPrunedTransactionsDbLogPath() {
+        return prunedTransactionsDbLogPath;
+    }
+    
+    @JsonProperty
+    @Parameter(names = {"--pruned-transactions-db-log-path"}, description = SnapshotConfig.Descriptions.PRUNED_TRANSACTIONS_DB_LOG_PATH)
+    protected void setSpentAddressesDbLogPath(String prunedTransactionsDbLogPath) {
+        this.prunedTransactionsDbLogPath = prunedTransactionsDbLogPath;
+    }
+    
+    @Override
+    public String getPrunedTransactionsDbPath() {
+        return prunedTransactionsDbPath;
+    }
+    
+    @JsonProperty
+    @Parameter(names = {"--pruned-transactions-db-path"}, description = SnapshotConfig.Descriptions.PRUNED_TRANSACTIONS_DB_PATH)
+    protected void setPrunedTransactionsDbPath(String prunedTransactionsDbPath) {
+        this.prunedTransactionsDbPath = prunedTransactionsDbPath;
+    }
+    
     /**
      * Checks if ZMQ is enabled.
      * @return true if zmqEnableTcp or zmqEnableIpc is set.
@@ -933,6 +956,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
         int LOCAL_SNAPSHOTS_DEPTH_MIN = 100;
         String SPENT_ADDRESSES_DB_PATH = "spent-addresses-db";
         String SPENT_ADDRESSES_DB_LOG_PATH = "spent-addresses-log";
+
+        String PRUNED_TRANSACTIONS_DB_LOG_PATH = "spent-addresses-db";
+        String PRUNED_TRANSACTIONS_DB_PATH = "spent-addresses-log";
         
         String LOCAL_SNAPSHOTS_BASE_PATH = "mainnet";
         String SNAPSHOT_FILE = "/snapshotMainnet.txt";

--- a/src/main/java/com/iota/iri/conf/SnapshotConfig.java
+++ b/src/main/java/com/iota/iri/conf/SnapshotConfig.java
@@ -76,6 +76,16 @@ public interface SnapshotConfig extends Config {
      */
     String getSpentAddressesDbLogPath();
 
+    /**
+     * @return {@value Descriptions#PRUNED_TRANSACTIONS_DB_PATH}
+     */
+    String getPrunedTransactionsDbPath();
+    
+    /**
+     * @return {@value Descriptions#PRUNED_TRANSACTIONS_DB_LOG_PATH}
+     */
+    String getPrunedTransactionsDbLogPath();
+    
     interface Descriptions {
 
         String LOCAL_SNAPSHOTS_ENABLED = "Flag that determines if local snapshots are enabled.";
@@ -94,5 +104,8 @@ public interface SnapshotConfig extends Config {
                 "from previous epochs";
         String SPENT_ADDRESSES_DB_PATH = "The folder where the spent addresses DB saves its data.";
         String SPENT_ADDRESSES_DB_LOG_PATH = "The folder where the spent addresses DB saves its logs.";
+        String PRUNED_TRANSACTIONS_DB_PATH = "The folder where the pruned transactions DB saves its data.";
+        String PRUNED_TRANSACTIONS_DB_LOG_PATH = "The folder where the pruned transactions DB saves its logs.";
     }
+
 }

--- a/src/main/java/com/iota/iri/model/persistables/Cuckoo.java
+++ b/src/main/java/com/iota/iri/model/persistables/Cuckoo.java
@@ -11,18 +11,17 @@ import com.iota.iri.utils.Serializer;
 /**
  * Persistable to manage the data we get as a result of pruning a milestone and its transactions
  */
-public class CuckooBucket implements Persistable {
+public class Cuckoo implements Persistable {
 
     /**
      * The filter number it belonged to in previous cycles
      */
-    public IntegerIndex bucketId;
+    public IntegerIndex filterId;
     
     /**
      * 
      */
-    public BitSet bucketBits;
-    public IntegerIndex bucketIndex;
+    public BitSet filterBits;
     
     /**
      * 
@@ -30,9 +29,8 @@ public class CuckooBucket implements Persistable {
      */
     @Override
     public byte[] bytes() {
-        byte[] index = bucketIndex.bytes();
-        byte[] num = bucketId.bytes();
-        return ArrayUtils.addAll(ArrayUtils.addAll(num, index), bucketBits.toByteArray());
+        byte[] num = filterId.bytes();
+        return ArrayUtils.addAll(num, filterBits.toByteArray());
     }
 
     /**
@@ -45,13 +43,12 @@ public class CuckooBucket implements Persistable {
     @Override
     public void read(byte[] bytes) {
         if(bytes != null) {
-            bucketId = new IntegerIndex(Serializer.getInteger(bytes, 0));
-            bucketIndex = new IntegerIndex(Serializer.getInteger(bytes, 4));
+            filterId = new IntegerIndex(Serializer.getInteger(bytes, 0));
             
-            short start = 8;
-            bucketBits = new BitSet(bytes.length - start);
+            short start = 4;
+            filterBits = new BitSet(bytes.length - start);
             for (int i = start; i < bytes.length; i++) {
-                bucketBits.set(i-start, bytes[i]);
+                filterBits.set(i-start, bytes[i]);
             }
         }
     }

--- a/src/main/java/com/iota/iri/model/persistables/Cuckoo.java
+++ b/src/main/java/com/iota/iri/model/persistables/Cuckoo.java
@@ -19,7 +19,7 @@ public class Cuckoo implements Persistable {
     public IntegerIndex filterId;
     
     /**
-     * 
+     * The bits that make up the CF
      */
     public BitSet filterBits;
     

--- a/src/main/java/com/iota/iri/model/persistables/CuckooBucket.java
+++ b/src/main/java/com/iota/iri/model/persistables/CuckooBucket.java
@@ -8,37 +8,75 @@ import com.iota.iri.model.IntegerIndex;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.utils.Serializer;
 
+/**
+ * Persistable to manage the data we get as a result of pruning a milestone and its transactions
+ */
 public class CuckooBucket implements Persistable {
 
+    /**
+     * The filter number it belonged to in previous cycles
+     */
+    public IntegerIndex bucketId;
+    
+    /**
+     * 
+     */
     public BitSet bucketBits;
     public IntegerIndex bucketIndex;
     
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public byte[] bytes() {
-        return ArrayUtils.addAll(bucketIndex.bytes(), bucketBits.toByteArray());
+        byte[] index = bucketIndex.bytes();
+        byte[] num = bucketId.bytes();
+        return ArrayUtils.addAll(ArrayUtils.addAll(num, index), bucketBits.toByteArray());
     }
 
+    /**
+     * Reads a CuckooBucket from the provided bytes.
+     * First 4 bytes are the bucket id, second 4 are the index inside that bucket
+     * Rest of the bytes is the bucket data
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public void read(byte[] bytes) {
         if(bytes != null) {
-            bucketIndex = new IntegerIndex(Serializer.getInteger(bytes));
+            bucketId = new IntegerIndex(Serializer.getInteger(bytes, 0));
+            bucketIndex = new IntegerIndex(Serializer.getInteger(bytes, 4));
             
-            bucketBits = new BitSet(bytes.length - 2);
-            for (int i = 1; i < bytes.length; i++) {
-                bucketBits.set(i-1, bytes[i]);
+            short start = 8;
+            bucketBits = new BitSet(bytes.length - start);
+            for (int i = start; i < bytes.length; i++) {
+                bucketBits.set(i-start, bytes[i]);
             }
         }
     }
 
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public byte[] metadata() {
         return new byte[0];
     }
 
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public void readMetadata(byte[] bytes) {
     }
 
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public boolean merge() {
         return false;

--- a/src/main/java/com/iota/iri/model/persistables/CuckooBucket.java
+++ b/src/main/java/com/iota/iri/model/persistables/CuckooBucket.java
@@ -1,0 +1,47 @@
+package com.iota.iri.model.persistables;
+
+import java.util.BitSet;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.iota.iri.model.IntegerIndex;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.utils.Serializer;
+
+public class CuckooBucket implements Persistable {
+
+    public BitSet bucketBits;
+    public IntegerIndex bucketIndex;
+    
+    @Override
+    public byte[] bytes() {
+        return ArrayUtils.addAll(bucketIndex.bytes(), bucketBits.toByteArray());
+    }
+
+    @Override
+    public void read(byte[] bytes) {
+        if(bytes != null) {
+            bucketIndex = new IntegerIndex(Serializer.getInteger(bytes));
+            
+            bucketBits = new BitSet(bytes.length - 2);
+            for (int i = 1; i < bytes.length; i++) {
+                bucketBits.set(i-1, bytes[i]);
+            }
+        }
+    }
+
+    @Override
+    public byte[] metadata() {
+        return new byte[0];
+    }
+
+    @Override
+    public void readMetadata(byte[] bytes) {
+    }
+
+    @Override
+    public boolean merge() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -54,8 +54,7 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
                     {{put("spent-addresses", SpentAddress.class);}}, null);
             this.rocksDBPersistenceProvider.init();
             readPreviousEpochsSpentAddresses();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new SpentAddressesException("There is a problem with accessing stored spent addresses", e);
         }
         return this;

--- a/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionException.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionException.java
@@ -1,0 +1,38 @@
+package com.iota.iri.service.transactionpruning;
+
+/**
+ * This class is used to wrap exceptions that are specific to the pruned transaction persistance.
+ *
+ * It allows us to distinct between the different kinds of errors that can happen during the execution of the code.
+ */
+public class PrunedTransactionException extends Exception {
+    /**
+     * Constructor of the exception which allows us to provide a specific error message and the cause of the error.
+     *
+     * @param message reason why this error occurred
+     * @param cause wrapped exception that caused this error
+     */
+    public PrunedTransactionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor of the exception which allows us to provide a specific error message without having an underlying
+     * cause.
+     *
+     * @param message reason why this error occurred
+     */
+    public PrunedTransactionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor of the exception which allows us to wrap the underlying cause of the error without providing a
+     * specific reason.
+     *
+     * @param cause wrapped exception that caused this error
+     */
+    public PrunedTransactionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionProvider.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionProvider.java
@@ -1,0 +1,36 @@
+package com.iota.iri.service.transactionpruning;
+
+import java.util.Collection;
+
+import com.iota.iri.model.Hash;
+
+/**
+ * Find, mark and store pruned transactions
+ */
+public interface PrunedTransactionProvider {
+    
+    /**
+     * Checks if this transactions has been pruned
+     * 
+     * @param transactionHash The transaction to check for
+     * @return <code>true</code> if it is, else <code>false</code>
+     * @throws PrunedTransactionException If the provider fails to check the transaction
+     */
+    boolean containsTransaction(Hash transactionHash) throws PrunedTransactionException;
+
+    /**
+     * Mark a transaction as spent.
+     * 
+     * @param transactionHash the transaction which we want to mark.
+     * @throws PrunedTransactionException If the provider fails to add the transaction
+     */
+    void addTransaction(Hash transactionHash) throws PrunedTransactionException;
+    
+    /**
+     * Mark all transactions as pruned.
+     * 
+     * @param transactionHashes The transactions we want to mark
+     * @throws PrunedTransactionException If the provider fails to add a transaction
+     */
+    void AddTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException;
+}

--- a/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionProvider.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/PrunedTransactionProvider.java
@@ -32,5 +32,5 @@ public interface PrunedTransactionProvider {
      * @param transactionHashes The transactions we want to mark
      * @throws PrunedTransactionException If the provider fails to add a transaction
      */
-    void AddTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException;
+    void addTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException;
 }

--- a/src/main/java/com/iota/iri/service/transactionpruning/TransactionPrunerJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/TransactionPrunerJob.java
@@ -112,6 +112,20 @@ public interface TransactionPrunerJob {
      * @param transactionPrunerJobStatus new execution status of the job
      */
     void setStatus(TransactionPrunerJobStatus transactionPrunerJobStatus);
+    
+    /**
+     * Getter for the pruned transaction maintainer.
+     *
+     * @return pruned transaction maintainer of the job.
+     */
+    PrunedTransactionProvider getPrunedProvider();
+    
+    /**
+     * Setter for the pruned transaction maintainer.
+     *
+     * @param prunedTransactionProvider pruned transaction maintainer of the job
+     */
+    void setPrunedProvider(PrunedTransactionProvider prunedTransactionProvider);
 
     /**
      * This method processes the cleanup job and performs the actual pruning.

--- a/src/main/java/com/iota/iri/service/transactionpruning/async/AsyncTransactionPruner.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/async/AsyncTransactionPruner.java
@@ -4,6 +4,7 @@ import com.iota.iri.conf.SnapshotConfig;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.spentaddresses.SpentAddressesService;
+import com.iota.iri.service.transactionpruning.PrunedTransactionProvider;
 import com.iota.iri.service.transactionpruning.TransactionPruner;
 import com.iota.iri.service.transactionpruning.TransactionPrunerJob;
 import com.iota.iri.service.transactionpruning.TransactionPruningException;
@@ -105,6 +106,11 @@ public class AsyncTransactionPruner implements TransactionPruner {
     private final Map<Class<? extends TransactionPrunerJob>, JobQueue> jobQueues = new HashMap<>();
 
     /**
+     * 
+     */
+    private PrunedTransactionProvider prunedTransactionProvider;
+
+    /**
      * This method initializes the instance and registers its dependencies.<br />
      * <br />
      * It simply stores the passed in values in their corresponding private properties.<br />
@@ -149,6 +155,7 @@ public class AsyncTransactionPruner implements TransactionPruner {
     @Override
     public void addJob(TransactionPrunerJob job) throws TransactionPruningException {
         job.setTransactionPruner(this);
+        job.setPrunedProvider(prunedTransactionProvider);
         job.setSpentAddressesService(spentAddressesService);
         job.setTangle(tangle);
         job.setTipsViewModel(tipsViewModel);

--- a/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
@@ -1,37 +1,66 @@
 package com.iota.iri.service.transactionpruning.impl;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
 
+import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.iota.iri.conf.SnapshotConfig;
 import com.iota.iri.model.Hash;
-import com.iota.iri.model.HashFactory;
 import com.iota.iri.model.persistables.CuckooBucket;
-import com.iota.iri.model.persistables.SpentAddress;
 import com.iota.iri.service.spentaddresses.SpentAddressesException;
-import com.iota.iri.service.spentaddresses.impl.SpentAddressesProviderImpl;
 import com.iota.iri.service.transactionpruning.PrunedTransactionException;
 import com.iota.iri.service.transactionpruning.PrunedTransactionProvider;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import com.iota.iri.utils.datastructure.CuckooFilter;
+import com.iota.iri.utils.datastructure.impl.CuckooFilterImpl;
 
+/**
+ * 
+ */
 public class PrunedTransactionProviderImpl implements PrunedTransactionProvider {
     
     private static final Logger log = LoggerFactory.getLogger(PrunedTransactionProviderImpl.class);
-
+    
+    private static final int FILTER_SIZE = 200000;
+    
+    private static final int MAX_FILTERS = 10;
+    
     private RocksDBPersistenceProvider persistenceProvider;
-
-    private CuckooFilter filter;
-
+    
     private SnapshotConfig config;
+
+    private CircularFifoQueue<CuckooFilter> filters;
+    private CuckooFilter lastAddedFilter;
+
+    // Once this exceeds integer max range, this will give problems.
+    private Integer highestIndex = -1;
+
+    private int filterSize;
+    
+    /**
+     * 
+     */
+    public PrunedTransactionProviderImpl() {
+        this(FILTER_SIZE);
+    }
+    
+    /**
+     * 
+     * @param filterSize
+     */
+    public PrunedTransactionProviderImpl(int filterSize) {
+        this.filterSize = filterSize;
+    }
     
     /**
      * Starts the PrunedTransactionProvider by reading the current pruned transactions from a persistence provider
@@ -50,10 +79,14 @@ public class PrunedTransactionProviderImpl implements PrunedTransactionProvider 
                     new HashMap<String, Class<? extends Persistable>>(1)
                     {{put("pruned-transactions", CuckooBucket.class);}}, null);
             this.persistenceProvider.init();
+            
+            // 10 * 1.000.000 * 4 hashes we can hold, with a total of 80mb size when max filled.
+            // The database has overhead for the bucket index, and allows a maximum of 2^7 - 1 filters
+            filters = new CircularFifoQueue<CuckooFilter>(MAX_FILTERS);
+            
             readPreviousPrunedTransactions();
-        }
-        catch (Exception e) {
-            throw new PrunedTransactionException("There is a problem with accessing stored spent addresses", e);
+        } catch (Exception e) {
+            throw new PrunedTransactionException("There is a problem with accessing previously pruned transactions", e);
         }
         
         return this;
@@ -61,33 +94,111 @@ public class PrunedTransactionProviderImpl implements PrunedTransactionProvider 
 
     private void readPreviousPrunedTransactions() throws PrunedTransactionException {
         if (config.isTestnet()) {
+            newFilter();
             return;
         }
 
         try {
-            for (byte[] bucketData : persistenceProvider.loadAllKeysFromTable(CuckooBucket.class)) {
+            
+            TreeMap<Integer, CuckooFilter> filters = new TreeMap<>();
+            
+            // Load all data from all filters
+            List<byte[]> bytes = persistenceProvider.loadAllKeysFromTable(CuckooBucket.class);
+            for (byte[] bucketData : bytes) {
                 CuckooBucket bucket = new CuckooBucket();
                 bucket.read(bucketData);
-                filter.update(bucket);
+                
+                if (MAX_FILTERS < bucket.bucketId.getValue()) {
+                    throw new PrunedTransactionException("Database contains more filters then we can store");
+                }
+                
+                // Find its bucket, or create it if wasnt there
+                CuckooFilter filter = filters.get(bucket.bucketId.getValue());
+                if (null == filter) {
+                    filter = new CuckooFilterImpl(filterSize, 4, 16);
+                    filters.put(bucket.bucketId.getValue(), filter);
+                }
+                
+                // Don't update using the entire CuckooBucket so that packages are separate-able
+                filter.update(bucket.bucketIndex.getValue(), bucket.bucketBits);
             }
+            
+            //Then add all in order, treemap maintains order from lowest to highest key
+            for (CuckooFilter filter : filters.values()) {
+                if (null != filter) {
+                    this.filters.add(filter);
+                }
+            }
+            
+            Entry<Integer, CuckooFilter> entry = filters.lastEntry();
+            if (null != entry) {
+                lastAddedFilter = entry.getValue();
+                highestIndex = entry.getKey();
+            } else {
+                newFilter();
+            }
+            
         } catch (IllegalArgumentException e) {
             throw new PrunedTransactionException(e);
         }
     }
+    
+    private void persistFilter(CuckooFilter filter, Integer index) {
+        
+    }
 
     @Override
     public boolean containsTransaction(Hash transactionHash) throws PrunedTransactionException {
+        byte[] hashBytes = transactionHash.bytes();
+        
+        // last filter added is most recent, thus most likely to be requested
+        CuckooFilter[] filterArray = filters.toArray(new CuckooFilter[filters.size()]);
+        for (int i = filterArray.length - 1; i >=0; i--) {
+            if (filterArray[i].contains(hashBytes)) {
+                return true;
+            }
+        }
         return false;
     }
     
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public void addTransaction(Hash transactionHash) throws PrunedTransactionException {
+        if (null == lastAddedFilter) {
+            newFilter();
+        }
         
+        if (!lastAddedFilter.add(transactionHash.bytes())){
+            newFilter().add(transactionHash.bytes());
+        }
     }
 
+    /**
+     * 
+     * {@inheritDoc}
+     */
     @Override
-    public void AddTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException {
-        
+    public void addTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException {
+        // Should we create a new filter when we get this method call? 
+        // It probably implies a new pruned job completed, and these TX would be checked more often then the older ones.
+        for (Hash transactionHash : transactionHashes) {
+            addTransaction(transactionHash);
+        }
+        persistFilter(lastAddedFilter, highestIndex);
     }
 
+    private CuckooFilter newFilter() {
+        if (filters.isAtFullCapacity()) {
+            log.debug("Removing " + filters.peek());
+        }
+        
+        highestIndex++;
+        
+        // We keep a reference to the last filter to prevent looking it up every time
+        filters.offer(lastAddedFilter = new CuckooFilterImpl(filterSize, 4, 16));
+        return lastAddedFilter;
+    }
 }

--- a/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
@@ -23,18 +23,31 @@ import com.iota.iri.utils.datastructure.CuckooFilter;
 import com.iota.iri.utils.datastructure.impl.CuckooFilterImpl;
 
 /**
- * 
+ * Implementation of a pruned transaction provider which uses a cuckoo filter to store pruned hashes
  */
 public class PrunedTransactionProviderImpl implements PrunedTransactionProvider {
     
     private static final Logger log = LoggerFactory.getLogger(PrunedTransactionProviderImpl.class);
     
+    /**
+     * The amount of fingerprints each bucket keeps. 
+     * More than 4 
+     */
     private static final int BUCKET_SIZE = 4;
     
+    /**
+     * The amount of bits a hash gets transformed to (Higher is better, but uses more storage)
+     */
     private static final int FINGER_PRINT_SIZE = 16;
     
+    /**
+     * The estimated amount of fingerprints each filter should hold (Will be scaled by cuckoo impl.)
+     */
     private static final int FILTER_SIZE = 200000;
     
+    /**
+     * The maximum amount of filters we have in use at any given time
+     */
     private static final int MAX_FILTERS = 10;
     
     private RocksDBPersistenceProvider persistenceProvider;

--- a/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/impl/PrunedTransactionProviderImpl.java
@@ -1,0 +1,93 @@
+package com.iota.iri.service.transactionpruning.impl;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.iota.iri.conf.SnapshotConfig;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashFactory;
+import com.iota.iri.model.persistables.CuckooBucket;
+import com.iota.iri.model.persistables.SpentAddress;
+import com.iota.iri.service.spentaddresses.SpentAddressesException;
+import com.iota.iri.service.spentaddresses.impl.SpentAddressesProviderImpl;
+import com.iota.iri.service.transactionpruning.PrunedTransactionException;
+import com.iota.iri.service.transactionpruning.PrunedTransactionProvider;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import com.iota.iri.utils.datastructure.CuckooFilter;
+
+public class PrunedTransactionProviderImpl implements PrunedTransactionProvider {
+    
+    private static final Logger log = LoggerFactory.getLogger(PrunedTransactionProviderImpl.class);
+
+    private RocksDBPersistenceProvider persistenceProvider;
+
+    private CuckooFilter filter;
+
+    private SnapshotConfig config;
+    
+    /**
+     * Starts the PrunedTransactionProvider by reading the current pruned transactions from a persistence provider
+     *
+     * @param config The snapshot configuration used for file location
+     * @return the current instance
+     * @throws SpentAddressesException if we failed to create a file at the designated location
+     */
+    public PrunedTransactionProviderImpl init(SnapshotConfig config) throws PrunedTransactionException {
+        this.config = config;
+        try {
+            this.persistenceProvider = new RocksDBPersistenceProvider(
+                    config.getPrunedTransactionsDbPath(),
+                    config.getPrunedTransactionsDbLogPath(),
+                    1000,
+                    new HashMap<String, Class<? extends Persistable>>(1)
+                    {{put("pruned-transactions", CuckooBucket.class);}}, null);
+            this.persistenceProvider.init();
+            readPreviousPrunedTransactions();
+        }
+        catch (Exception e) {
+            throw new PrunedTransactionException("There is a problem with accessing stored spent addresses", e);
+        }
+        
+        return this;
+    }
+
+    private void readPreviousPrunedTransactions() throws PrunedTransactionException {
+        if (config.isTestnet()) {
+            return;
+        }
+
+        try {
+            for (byte[] bucketData : persistenceProvider.loadAllKeysFromTable(CuckooBucket.class)) {
+                CuckooBucket bucket = new CuckooBucket();
+                bucket.read(bucketData);
+                filter.update(bucket);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new PrunedTransactionException(e);
+        }
+    }
+
+    @Override
+    public boolean containsTransaction(Hash transactionHash) throws PrunedTransactionException {
+        return false;
+    }
+    
+    @Override
+    public void addTransaction(Hash transactionHash) throws PrunedTransactionException {
+        
+    }
+
+    @Override
+    public void AddTransactionBatch(Collection<Hash> transactionHashes) throws PrunedTransactionException {
+        
+    }
+
+}

--- a/src/main/java/com/iota/iri/service/transactionpruning/jobs/AbstractTransactionPrunerJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/jobs/AbstractTransactionPrunerJob.java
@@ -3,6 +3,7 @@ package com.iota.iri.service.transactionpruning.jobs;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.service.snapshot.Snapshot;
 import com.iota.iri.service.spentaddresses.SpentAddressesService;
+import com.iota.iri.service.transactionpruning.PrunedTransactionProvider;
 import com.iota.iri.service.transactionpruning.TransactionPruner;
 import com.iota.iri.service.transactionpruning.TransactionPrunerJob;
 import com.iota.iri.service.transactionpruning.TransactionPrunerJobStatus;
@@ -42,6 +43,11 @@ public abstract class AbstractTransactionPrunerJob implements TransactionPrunerJ
      * Holds a reference to the last local or global snapshot that acts as a starting point for the state of ledger.
      */
     private Snapshot snapshot;
+
+    /**
+     * Holds a reference to the provider of pruned transactions, which we will use for speeding up old references checks
+     */
+    private PrunedTransactionProvider prunedTransactionProvider;
 
     /**
      * {@inheritDoc}
@@ -127,7 +133,23 @@ public abstract class AbstractTransactionPrunerJob implements TransactionPrunerJ
     public void setStatus(TransactionPrunerJobStatus status) {
         this.status = status;
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PrunedTransactionProvider getPrunedProvider() {
+        return prunedTransactionProvider;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPrunedProvider(PrunedTransactionProvider prunedTransactionProvider) {
+        this.prunedTransactionProvider = prunedTransactionProvider;
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/iota/iri/service/transactionpruning/jobs/HashPruningJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/jobs/HashPruningJob.java
@@ -1,0 +1,19 @@
+package com.iota.iri.service.transactionpruning.jobs;
+
+import com.iota.iri.service.transactionpruning.TransactionPruningException;
+
+public class HashPruningJob extends AbstractTransactionPrunerJob {
+    
+    public HashPruningJob() {
+        
+    }
+
+    @Override
+    public void process() throws TransactionPruningException {
+    }
+
+    @Override
+    public String serialize() {
+        return null;
+    }
+}

--- a/src/main/java/com/iota/iri/service/transactionpruning/jobs/MilestonePrunerJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/jobs/MilestonePrunerJob.java
@@ -15,6 +15,7 @@ import com.iota.iri.utils.dag.DAGHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,6 +245,10 @@ public class MilestonePrunerJob extends AbstractTransactionPrunerJob {
             });
 
             getTangle().deleteBatch(elementsToDelete);
+            getPrunedProvider().addTransactionBatch(elementsToDelete
+                    .stream()
+                    .map(a -> (Hash) a.low)
+                    .collect(Collectors.toList()));
         } catch(Exception e) {
             throw new TransactionPruningException("failed to cleanup milestone #" + getCurrentIndex(), e);
         }

--- a/src/main/java/com/iota/iri/service/transactionpruning/jobs/MilestonePrunerJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/jobs/MilestonePrunerJob.java
@@ -233,6 +233,10 @@ public class MilestonePrunerJob extends AbstractTransactionPrunerJob {
                         } catch (TransactionPruningException e) {
                             throw new RuntimeException(e);
                         }
+                    } else {
+                        // Confirmed TX, add to data structure
+                        // either add to list, or add a new job to add to the cuckoofilter
+                        
                     }
                 } else if(Milestone.class.equals(element.hi)) {
                     MilestoneViewModel.clear(((IntegerIndex) element.low).getValue());

--- a/src/main/java/com/iota/iri/service/transactionpruning/jobs/UnconfirmedSubtanglePrunerJob.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/jobs/UnconfirmedSubtanglePrunerJob.java
@@ -4,7 +4,6 @@ import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
 import com.iota.iri.model.persistables.Transaction;
-import com.iota.iri.service.spentaddresses.SpentAddressesService;
 import com.iota.iri.service.transactionpruning.TransactionPrunerJobStatus;
 import com.iota.iri.service.transactionpruning.TransactionPruningException;
 import com.iota.iri.storage.Indexable;

--- a/src/main/java/com/iota/iri/utils/Serializer.java
+++ b/src/main/java/com/iota/iri/utils/Serializer.java
@@ -41,10 +41,13 @@ public class Serializer {
         return getInteger(bytes, 0);
     }
     public static int getInteger(byte[] bytes, int start) {
+        return getInteger(bytes, start, Integer.BYTES);
+    }
+    
+    public static int getInteger(byte[] bytes, int start, int length) {
         if(bytes == null) {
             return 0;
         }
-        int length = Integer.BYTES;
         int res = 0;
         for (int i=0; i< length;i++) {
             res |= (bytes[start + i] & 0xFFL) << ((length-i-1) * 8);

--- a/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
@@ -2,7 +2,7 @@ package com.iota.iri.utils.datastructure;
 
 import java.util.BitSet;
 
-import com.iota.iri.model.persistables.CuckooBucket;
+import com.iota.iri.model.persistables.Cuckoo;
 
 /**
  * The Cuckoo Filter is a probabilistic data structure that supports fast set membership testing.
@@ -89,12 +89,8 @@ public interface CuckooFilter {
     int size();
 
     /**
-     * Update a part of this filter with the bucket information supplied.
-     * Discards any previous data inside this bucket.
-     * 
-     * @param index The index of the bucket we are updating
-     * @param bits the bucket data we use to update the filter
-     * @throws IllegalArgumentException when the bucket does not contain data which is valid for this filter
+     * This method returns a copy of all the bits that make up this filter
+     * @return The ilter bits
      */
-    void update(int index, BitSet bits) throws IllegalArgumentException ;
+    BitSet getFilterData();
 }

--- a/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
@@ -1,5 +1,7 @@
 package com.iota.iri.utils.datastructure;
 
+import com.iota.iri.model.persistables.CuckooBucket;
+
 /**
  * The Cuckoo Filter is a probabilistic data structure that supports fast set membership testing.
  *
@@ -83,4 +85,13 @@ public interface CuckooFilter {
      * @return the amount of stored items
      */
     int size();
+
+    /**
+     * Update a part of this filter with the bucket information supplied.
+     * Discards any previous data inside this bucket.
+     * 
+     * @param bucket the bucket data we use to update the filter
+     * @throws IllegalArgumentException when the bucket does not contain data which is valid for this filter
+     */
+    void update(CuckooBucket bucket) throws IllegalArgumentException ;
 }

--- a/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
@@ -1,5 +1,7 @@
 package com.iota.iri.utils.datastructure;
 
+import java.util.BitSet;
+
 import com.iota.iri.model.persistables.CuckooBucket;
 
 /**
@@ -90,8 +92,9 @@ public interface CuckooFilter {
      * Update a part of this filter with the bucket information supplied.
      * Discards any previous data inside this bucket.
      * 
-     * @param bucket the bucket data we use to update the filter
+     * @param index The index of the bucket we are updating
+     * @param bits the bucket data we use to update the filter
      * @throws IllegalArgumentException when the bucket does not contain data which is valid for this filter
      */
-    void update(CuckooBucket bucket) throws IllegalArgumentException ;
+    void update(int index, BitSet bits) throws IllegalArgumentException ;
 }

--- a/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/CuckooFilter.java
@@ -2,8 +2,6 @@ package com.iota.iri.utils.datastructure;
 
 import java.util.BitSet;
 
-import com.iota.iri.model.persistables.Cuckoo;
-
 /**
  * The Cuckoo Filter is a probabilistic data structure that supports fast set membership testing.
  *

--- a/src/main/java/com/iota/iri/utils/datastructure/impl/CuckooFilterImpl.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/impl/CuckooFilterImpl.java
@@ -1,5 +1,6 @@
 package com.iota.iri.utils.datastructure.impl;
 
+import com.iota.iri.model.persistables.CuckooBucket;
 import com.iota.iri.utils.BitSetUtils;
 import com.iota.iri.utils.datastructure.CuckooFilter;
 
@@ -136,6 +137,25 @@ public class CuckooFilterImpl implements CuckooFilter {
     @Override
     public boolean add(byte[] item) throws IndexOutOfBoundsException {
         return add(new CuckooFilterItem(hashFunction.digest(item)));
+    }
+    /**
+     * {@inheritDoc}
+     *
+     */
+    @Override
+    public void update(CuckooBucket bucket) throws IllegalArgumentException {
+        int amountInBucket = bucketSize;
+        if (bucket.bucketBits.length()  / amountInBucket > 0) {
+            
+        }
+        
+        for (int i=0; i < amountInBucket; i++) {
+            cuckooFilterTable.set(bucket.bucketIndex.getValue(), i, bucket.bucketBits.get(
+                    fingerPrintSize * i, 
+                    fingerPrintSize * (i + 1)
+                ));
+            
+        }
     }
 
     /**

--- a/src/main/java/com/iota/iri/utils/datastructure/impl/CuckooFilterImpl.java
+++ b/src/main/java/com/iota/iri/utils/datastructure/impl/CuckooFilterImpl.java
@@ -12,6 +12,11 @@ import java.util.BitSet;
  * This class implements the basic contract of the {@link CuckooFilter}.
  */
 public class CuckooFilterImpl implements CuckooFilter {
+    
+    private static int CUR_INDEX = 0;
+
+    int index = CUR_INDEX ++;
+    
     /**
      * The amount of times we try to kick elements when inserting before we consider the index to be too full.
      */
@@ -143,14 +148,20 @@ public class CuckooFilterImpl implements CuckooFilter {
      *
      */
     @Override
-    public void update(CuckooBucket bucket) throws IllegalArgumentException {
+    public void update(int index, BitSet bits) throws IllegalArgumentException {
         int amountInBucket = bucketSize;
-        if (bucket.bucketBits.length()  / amountInBucket > 0) {
-            
+        if (bits.length() % fingerPrintSize != 0) {
+            throw new IllegalArgumentException("Provided bits do not match fingerprint scheme");
+        } else if (bits.length() % fingerPrintSize > amountInBucket) {
+            throw new IllegalArgumentException("Provided fingerprint data will overflow the bucket");
+        } else if (index > tableSize * 0.955) {
+            throw new IllegalArgumentException("Provided bucket exceeds filter size");
+        } else if (false) {
+            // Can we recover input in any case when expected input does not match given?
         }
         
         for (int i=0; i < amountInBucket; i++) {
-            cuckooFilterTable.set(bucket.bucketIndex.getValue(), i, bucket.bucketBits.get(
+            cuckooFilterTable.set(index, i, bits.get(
                     fingerPrintSize * i, 
                     fingerPrintSize * (i + 1)
                 ));
@@ -605,5 +616,10 @@ public class CuckooFilterImpl implements CuckooFilter {
         public CuckooFilterTable delete(int bucketIndex, int slotIndex) {
             return set(bucketIndex, slotIndex, null);
         }
+    }
+    
+    @Override
+    public String toString() {
+        return index +" ";
     }
 }

--- a/src/test/java/com/iota/iri/service/transactionpruning/PrunedTransactionProviderImplTest.java
+++ b/src/test/java/com/iota/iri/service/transactionpruning/PrunedTransactionProviderImplTest.java
@@ -1,0 +1,69 @@
+package com.iota.iri.service.transactionpruning;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.iota.iri.TransactionTestUtils;
+import com.iota.iri.conf.SnapshotConfig;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.transactionpruning.impl.PrunedTransactionProviderImpl;
+
+public class PrunedTransactionProviderImplTest {
+    
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    
+    @Mock
+    public SnapshotConfig config;
+    
+    @Rule
+    public final TemporaryFolder dbFolder = new TemporaryFolder();
+    
+    @Rule
+    public final TemporaryFolder logFolder = new TemporaryFolder();
+    
+    PrunedTransactionProviderImpl provider;
+    
+    @Before
+    public void setUp() throws PrunedTransactionException {
+        Mockito.when(config.getPrunedTransactionsDbPath()).thenReturn(dbFolder.getRoot().getAbsolutePath());
+        Mockito.when(config.getPrunedTransactionsDbLogPath()).thenReturn(logFolder.getRoot().getAbsolutePath());
+        
+        // Filter size of 10, for easier testing
+        provider = new PrunedTransactionProviderImpl(10);
+        provider.init(config);
+    }
+    
+    @After
+    public void tearDown() {
+        dbFolder.delete();
+    }
+    
+    @Test
+    public void test() throws PrunedTransactionException {
+        Hash randomHash = TransactionTestUtils.getRandomTransactionHash();
+        provider.addTransaction(randomHash);
+        for (int i=0; i<100; i++) {
+            provider.addTransaction(TransactionTestUtils.getRandomTransactionHash());
+        }
+        
+        int contains = 0;
+        for (int i=0; i<100; i++) {
+            if (provider.containsTransaction(randomHash)){
+                contains++;
+            }
+        }
+        
+        System.out.println(contains);
+        assertTrue("Provider should contain the hash", contains > 90);
+    }
+}

--- a/src/test/java/com/iota/iri/service/transactionpruning/PrunedTransactionProviderImplTest.java
+++ b/src/test/java/com/iota/iri/service/transactionpruning/PrunedTransactionProviderImplTest.java
@@ -86,8 +86,8 @@ public class PrunedTransactionProviderImplTest {
         for (int i=0; i<10000*10; i++) {
             provider.addTransaction(TransactionTestUtils.getRandomTransactionHash());
         }
-        
 
+        // by now, we have added 10 full filters, so the first 100 should not exist anymore (deleted)
         int notContains = 0;
         for (int i=0; i<size; i++) {
             if (!provider.containsTransaction(hashes[i])) {


### PR DESCRIPTION
# Description
We want to track pruned confirmed transaction hashes to a cuckoo filter before we delete them.
At the end of each pruning cycle we want to persist the cuckoo filter state in the db.

We will currently maintain 10 cuckoo filters maximum, once a new filter gets added (another pruning cycle)
the first gets deleted.
Each filter is maintained in the database by an index, and when restored from database, the lowest index will be first to get deleted.

Fixes # (issue)
#1370

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
- Unit tests added

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
