### PR TITLE
Fix: Made neighbors return ip if possible, otherwise host string

### DIFF
--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -132,7 +132,7 @@ public class GetNeighborsResponse extends AbstractResponse {
         public String getConnectionType() {
             return connectionType;
         }
-        
+
         /**
          * Creates a new Neighbor DTO from a Neighbor network instance
          * @param n the neighbor currently connected to this node

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -67,6 +67,31 @@ public class GetNeighborsResponse extends AbstractResponse {
         private long numberOfStaleTransactions;
         private long numberOfSentTransactions;
         private String connectionType;
+        
+        /**
+         * Creates a new Neighbor DTO from a Neighbor network instance
+         * @param n the neighbor currently connected to this node
+         * @return a new instance of {@link GetNeighborsResponse.Neighbor}
+         */
+        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
+            Neighbor ne = new Neighbor();
+            
+            String host = n.getHostAddress();
+            if (host == null) {
+                host = n.getAddress().getHostString();
+            }
+            
+            int port = n.getPort();
+            ne.address = host + ":" + port;
+            ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
+            ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
+            ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();
+            ne.numberOfNewTransactions = n.getNumberOfNewTransactions();
+            ne.numberOfRandomTransactionRequests = n.getNumberOfRandomTransactionRequests();
+            ne.numberOfSentTransactions = n.getNumberOfSentTransactions();
+            ne.connectionType = n.connectionType();
+            return ne;
+        }
 
         /**
          * The address of your neighbor
@@ -131,25 +156,6 @@ public class GetNeighborsResponse extends AbstractResponse {
          */
         public String getConnectionType() {
             return connectionType;
-        }
-
-        /**
-         * Creates a new Neighbor DTO from a Neighbor network instance
-         * @param n the neighbor currently connected to this node
-         * @return a new instance of {@link GetNeighborsResponse.Neighbor}
-         */
-        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
-            Neighbor ne = new Neighbor();
-            int port = n.getPort();
-            ne.address = n.getAddress().getAddress().getHostAddress() + ":" + port;
-            ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
-            ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
-            ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();
-            ne.numberOfNewTransactions = n.getNumberOfNewTransactions();
-            ne.numberOfRandomTransactionRequests = n.getNumberOfRandomTransactionRequests();
-            ne.numberOfSentTransactions = n.getNumberOfSentTransactions();
-            ne.connectionType = n.connectionType();
-            return ne;
         }
     }
 }

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -67,31 +67,6 @@ public class GetNeighborsResponse extends AbstractResponse {
         private long numberOfStaleTransactions;
         private long numberOfSentTransactions;
         private String connectionType;
-        
-        /**
-         * Creates a new Neighbor DTO from a Neighbor network instance
-         * @param n the neighbor currently connected to this node
-         * @return a new instance of {@link GetNeighborsResponse.Neighbor}
-         */
-        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
-            Neighbor ne = new Neighbor();
-            
-            String host = n.getHostAddress();
-            if (host == null) {
-                host = n.getAddress().getHostString();
-            }
-            
-            int port = n.getPort();
-            ne.address = host + ":" + port;
-            ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
-            ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
-            ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();
-            ne.numberOfNewTransactions = n.getNumberOfNewTransactions();
-            ne.numberOfRandomTransactionRequests = n.getNumberOfRandomTransactionRequests();
-            ne.numberOfSentTransactions = n.getNumberOfSentTransactions();
-            ne.connectionType = n.connectionType();
-            return ne;
-        }
 
         /**
          * The address of your neighbor
@@ -156,6 +131,31 @@ public class GetNeighborsResponse extends AbstractResponse {
          */
         public String getConnectionType() {
             return connectionType;
+        }
+        
+        /**
+         * Creates a new Neighbor DTO from a Neighbor network instance
+         * @param n the neighbor currently connected to this node
+         * @return a new instance of {@link GetNeighborsResponse.Neighbor}
+         */
+        public static Neighbor createFrom(com.iota.iri.network.Neighbor n) {
+            Neighbor ne = new Neighbor();
+            
+            String host = n.getHostAddress();
+            if (host == null) {
+                host = n.getAddress().getHostString();
+            }
+            
+            int port = n.getPort();
+            ne.address = host + ":" + port;
+            ne.numberOfAllTransactions = n.getNumberOfAllTransactions();
+            ne.numberOfInvalidTransactions = n.getNumberOfInvalidTransactions();
+            ne.numberOfStaleTransactions = n.getNumberOfStaleTransactions();
+            ne.numberOfNewTransactions = n.getNumberOfNewTransactions();
+            ne.numberOfRandomTransactionRequests = n.getNumberOfRandomTransactionRequests();
+            ne.numberOfSentTransactions = n.getNumberOfSentTransactions();
+            ne.connectionType = n.connectionType();
+            return ne;
         }
     }
 }


### PR DESCRIPTION
# Description

GetNeighborsResponseTest.getNeighbors was broken as it returned test.test:8888 instead of ip:port.
No. more!

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:
- [X] New and existing unit tests pass locally with my changes
