### PR TITLE
ciglue.sh IXIs path relative to python-regression base folder

### DIFF
--- a/python-regression/ciglue.sh
+++ b/python-regression/ciglue.sh
@@ -28,7 +28,7 @@ cd ..
 pip install -e .
 
 for machine_dir in tests/features/machine?; do
-  python tiab/create_cluster.py -i $IMAGE -t $UUID -n $K8S_NAMESPACE -c $machine_dir/config.yml -o $machine_dir/output.yml -d
+  python tiab/create_cluster.py -i $IMAGE -t $UUID -n $K8S_NAMESPACE -c $machine_dir/config.yml -o $machine_dir/output.yml -x .. -d
   if [ $? -ne 0 ]; then
     ERROR=1
     python <<EOF


### PR DESCRIPTION
# Description

Enable support for local IXI modules uploading in regression tests by passing `create_cluster.py` the path to base `python-regression` folder.

## Type of change

- Enhancement (a non-breaking change which adds functionality)
