### PR TITLE
Feature: Added spent-address db folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /.idea
 /bin
 /mainnetdb
+/spent-addresses-db
+/spent-addresses-log
 /mainnet.log
 /*.iml
 .classpath


### PR DESCRIPTION
# Description
The spent-address-db and log are now added to `.gitignore`, so that we wont commit them accidentally

Fixes #1440

# Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
Git doesnt add folders to changes in current dir anymore

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
