### PR TITLE
Fix: recent seen transactions digest

### DIFF
--- a/src/main/java/com/iota/iri/network/Node.java
+++ b/src/main/java/com/iota/iri/network/Node.java
@@ -765,7 +765,7 @@ public class Node {
     }
 
     private long getBytesDigest(byte[] receivedData) {
-        return recentSeenBytesHashFunction.hashBytes(receivedData);
+        return recentSeenBytesHashFunction.hashBytes(receivedData, 0, TransactionViewModel.SIZE);
     }
 
     // helpers methods


### PR DESCRIPTION
# Description

Recent seen transactions cache must only hash transaction trytes instead of the whole network packet.

Fixes #1452

## Type of change

Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
