### PR TITLE
Fix: set arrival time in millis (not seconds) (#766)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,8 @@
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.27.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -120,7 +120,7 @@ public class IRI {
 
             iota = new Iota(config);
             ixi = new IXI(iota);
-            api = new API(iota.configuration, ixi, iota.transactionRequester,
+            api = new API(config, ixi, iota.transactionRequester,
                     iota.spentAddressesService, iota.tangle, iota.bundleValidator,
                     iota.snapshotProvider, iota.ledgerService, iota.node, iota.tipsSelector,
                     iota.tipsViewModel, iota.transactionValidator,
@@ -131,7 +131,7 @@ public class IRI {
                 iota.init();
                 //TODO redundant parameter but we will touch this when we refactor IXI
                 ixi.init(config.getIxiDir());
-                api.init(new RestEasy(iota.configuration));
+                api.init(new RestEasy(config));
                 log.info("IOTA Node initialised correctly.");
             } catch (Exception e) {
                 log.error("Exception during IOTA node initialisation: ", e);

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -104,7 +104,7 @@ public class Iota {
     public final Node node;
     public final UDPReceiver udpReceiver;
     public final Replicator replicator;
-    public final IotaConfig configuration;
+    private final IotaConfig configuration;
     public final TipsViewModel tipsViewModel;
     public final TipSelector tipsSelector;
 

--- a/src/main/java/com/iota/iri/model/persistables/Transaction.java
+++ b/src/main/java/com/iota/iri/model/persistables/Transaction.java
@@ -40,6 +40,10 @@ public class Transaction implements Persistable {
 
     public int validity = 0;
     public int type = TransactionViewModel.PREFILLED_SLOT;
+
+    /**
+     * The time when the transaction arrived. In milliseconds.
+     */
     public long arrivalTime = 0;
 
     //public boolean confirmed = false;

--- a/src/test/java/com/iota/iri/network/NodeTest.java
+++ b/src/test/java/com/iota/iri/network/NodeTest.java
@@ -10,13 +10,14 @@ import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -24,12 +25,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class NodeTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     @Mock
     private NodeConfig nodeConfig;
     @Mock

--- a/src/test/java/com/iota/iri/network/NodeTest.java
+++ b/src/test/java/com/iota/iri/network/NodeTest.java
@@ -21,7 +21,12 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.longThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NodeTest {
@@ -82,7 +87,7 @@ public class NodeTest {
 
     private boolean isCloseToCurrentMillis(Long arrival) {
         long now = System.currentTimeMillis();
-        return arrival > now - 1000 && arrival < now;
+        return arrival > now - 1000 && arrival <= now;
     }
 
 

--- a/src/test/java/com/iota/iri/network/NodeTest.java
+++ b/src/test/java/com/iota/iri/network/NodeTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.core.Appender;
 import com.iota.iri.TransactionValidator;
 import com.iota.iri.conf.NodeConfig;
 import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import org.junit.After;
 import org.junit.Before;
@@ -81,7 +82,12 @@ public class NodeTest {
     @Test
     public void whenProcessReceivedDataSetArrivalTimeToCurrentMillis() throws Exception {
         Node node = new Node(null, mock(SnapshotProvider.class), mock(TransactionValidator.class), null, null, null, mock(NodeConfig.class));
+
         TransactionViewModel transaction = mock(TransactionViewModel.class);
+        // It is important to stub the getHash method here because processReceivedData will broadcast the transaction.
+        // This might sometimes (concurrency issue) lead to a NPE in the process receiver thread.
+        // See executor.submit(spawnProcessReceivedThread()) -> Node.weightQueue -> transaction.getHash().bytes()[i]
+        when(transaction.getHash()).thenReturn(Hash.NULL_HASH);
         when(transaction.store(any(), any())).thenReturn(true);
         Neighbor neighbor = mock(Neighbor.class, Answers.RETURNS_SMART_NULLS);
 

--- a/src/test/java/com/iota/iri/service/APIIntegrationTests.java
+++ b/src/test/java/com/iota/iri/service/APIIntegrationTests.java
@@ -91,7 +91,7 @@ public class APIIntegrationTests {
             //create node
             iota = new Iota(configuration);
             ixi = new IXI(iota);
-            api = new API(iota.configuration, ixi, iota.transactionRequester,
+            api = new API(configuration, ixi, iota.transactionRequester,
                     iota.spentAddressesService, iota.tangle, iota.bundleValidator,
                     iota.snapshotProvider, iota.ledgerService, iota.node, iota.tipsSelector,
                     iota.tipsViewModel, iota.transactionValidator,

--- a/src/test/java/com/iota/iri/service/APITest.java
+++ b/src/test/java/com/iota/iri/service/APITest.java
@@ -4,11 +4,12 @@ import com.iota.iri.TransactionValidator;
 import com.iota.iri.conf.IotaConfig;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.service.snapshot.SnapshotProvider;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 
@@ -16,11 +17,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class APITest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock(answer = Answers.RETURNS_SMART_NULLS)
     private TransactionValidator transactionValidator;

--- a/src/test/java/com/iota/iri/service/APITest.java
+++ b/src/test/java/com/iota/iri/service/APITest.java
@@ -12,7 +12,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.longThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class APITest {
@@ -40,11 +45,12 @@ public class APITest {
         api.storeTransactionsStatement(Collections.singletonList("FOO"));
 
         verify(transaction).setArrivalTime(longThat(this::isCloseToCurrentMillis));
+
     }
 
     private boolean isCloseToCurrentMillis(Long arrival) {
         long now = System.currentTimeMillis();
-        return arrival > now - 1000 && arrival < now;
+        return arrival > now - 1000 && arrival <= now;
     }
 
 }

--- a/src/test/java/com/iota/iri/service/APITest.java
+++ b/src/test/java/com/iota/iri/service/APITest.java
@@ -1,0 +1,50 @@
+package com.iota.iri.service;
+
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.conf.IotaConfig;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class APITest {
+
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
+    private TransactionValidator transactionValidator;
+
+    @Mock
+    private SnapshotProvider snapshotProvider;
+
+    @Mock
+    private IotaConfig config;
+
+    @Test
+    public void whenStoreTransactionsStatementThenSetArrivalTimeToCurrentMillis() throws Exception {
+        TransactionViewModel transaction = mock(TransactionViewModel.class);
+        when(transactionValidator.validateTrits(any(), anyInt())).thenReturn(transaction);
+        when(transaction.store(any(), any())).thenReturn(true);
+
+        API api = new API(config, null, null, null,
+                null, null,
+                snapshotProvider, null, null, null, null,
+                transactionValidator, null);
+
+        api.storeTransactionsStatement(Collections.singletonList("FOO"));
+
+        verify(transaction).setArrivalTime(longThat(this::isCloseToCurrentMillis));
+    }
+
+    private boolean isCloseToCurrentMillis(Long arrival) {
+        long now = System.currentTimeMillis();
+        return arrival > now - 1000 && arrival < now;
+    }
+
+}

--- a/src/test/java/com/iota/iri/service/NodeIntegrationTests.java
+++ b/src/test/java/com/iota/iri/service/NodeIntegrationTests.java
@@ -10,7 +10,6 @@ import com.iota.iri.crypto.Curl;
 import com.iota.iri.crypto.Sponge;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
-import com.iota.iri.model.HashFactory;
 import com.iota.iri.network.Node;
 import com.iota.iri.service.restserver.resteasy.RestEasy;
 import com.iota.iri.utils.Converter;
@@ -42,25 +41,26 @@ public class NodeIntegrationTests {
     public void testGetsSolid() throws Exception {
         int count = 1;
         long spacing = 5000;
-        Iota iotaNodes[] = new Iota[count];
-        API api[] = new API[count];
-        IXI ixi[] = new IXI[count];
+        Iota[] iotaNodes = new Iota[count];
+        API[] api = new API[count];
+        IXI[] ixi = new IXI[count];
         Thread cooThread, master;
         TemporaryFolder[] folders = new TemporaryFolder[count*2];
         for(int i = 0; i < count; i++) {
             folders[i*2] = new TemporaryFolder();
             folders[i*2 + 1] = new TemporaryFolder();
-            iotaNodes[i] = newNode(i, folders[i*2], folders[i*2+1]);
+            TestnetConfig conf = new TestnetConfig();
+            iotaNodes[i] = newNode(i, conf, folders[i*2], folders[i*2+1]);
             ixi[i] = new IXI(iotaNodes[i]);
             ixi[i].init(IXIConfig.IXI_DIR);
             
-            api[i] = new API(iotaNodes[i].configuration, ixi[i], iotaNodes[i].transactionRequester,
+            api[i] = new API(conf, ixi[i], iotaNodes[i].transactionRequester,
                     iotaNodes[i].spentAddressesService, iotaNodes[i].tangle, iotaNodes[i].bundleValidator,
                     iotaNodes[i].snapshotProvider, iotaNodes[i].ledgerService, iotaNodes[i].node, 
                     iotaNodes[i].tipsSelector, iotaNodes[i].tipsViewModel, iotaNodes[i].transactionValidator,
                     iotaNodes[i].latestMilestoneTracker);
             
-            api[i].init(new RestEasy(iotaNodes[i].configuration));
+            api[i].init(new RestEasy(conf));
         }
         Node.uri("udp://localhost:14701").ifPresent(uri -> iotaNodes[0].node.addNeighbor(iotaNodes[0].node.newNeighbor(uri, true)));
         //Node.uri("udp://localhost:14700").ifPresent(uri -> iotaNodes[1].node.addNeighbor(iotaNodes[1].node.newNeighbor(uri, true)));
@@ -86,10 +86,9 @@ public class NodeIntegrationTests {
         }
     }
 
-    private Iota newNode(int index, TemporaryFolder db, TemporaryFolder log) throws Exception {
+    private Iota newNode(int index, TestnetConfig conf, TemporaryFolder db, TemporaryFolder log) throws Exception {
         db.create();
         log.create();
-        TestnetConfig conf = new TestnetConfig();
         Iota iota;
         conf.setPort(14800 + index);
         conf.setUdpReceiverPort((14700 + index));

--- a/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/ledger/impl/LedgerServiceImplTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
@@ -58,8 +58,7 @@ public class WalkerAlphaTest {
         tangle.init();
 
         TailFinder tailFinder = Mockito.mock(TailFinder.class);
-        Mockito.when(tailFinder.findTail(Mockito.any(Hash.class)))
-                .then(args -> Optional.of(args.getArgumentAt(0, Hash.class)));
+        Mockito.when(tailFinder.findTail(Mockito.any(Hash.class))).then(args -> Optional.of(args.getArgument(0)));
         walker = new WalkerAlpha(tailFinder, tangle, new Random(1), new MainnetConfig());
     }
 
@@ -94,9 +93,9 @@ public class WalkerAlphaTest {
             //select
             Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
 
-            Assert.assertTrue(tip != null);
+            Assert.assertNotNull(tip);
             //log.info("selected tip: " + tip.toString());
-            Assert.assertTrue(!transaction4.getHash().equals(tip));
+            Assert.assertFalse(transaction4.getHash().equals(tip));
         }
     }
 

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
@@ -58,7 +58,8 @@ public class WalkerAlphaTest {
         tangle.init();
 
         TailFinder tailFinder = Mockito.mock(TailFinder.class);
-        Mockito.when(tailFinder.findTail(Mockito.any(Hash.class))).then(args -> Optional.of(args.getArgument(0)));
+        Mockito.when(tailFinder.findTail(Mockito.any(Hash.class)))
+                .then(args -> Optional.of(args.getArgument(0)));
         walker = new WalkerAlpha(tailFinder, tangle, new Random(1), new MainnetConfig());
     }
 


### PR DESCRIPTION
# Description

In API method storeTransactionStatement arrival date was set in seconds. Changed that to milliseconds. See cliri bug fix referenced in issue.

Fixes #766 
Replaces PR #1369

* Added tests
* Updated mockito (for new tests)
* Refactored incompatible mockito usage
* Made Iota.configuration private (instance access not needed and should be injected. Was easier to use this way in tests, too)
* Added documentation that arrival time is in millis

Attention: SnapshotServiceImpl#isOrphaned NOT changed. See comment in issue.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests that check that set arrival time is close to System.currentTimeMillis

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


