### PR TITLE
Disable Tip Solidifier

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -939,7 +939,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
         int TIP_SELECTION_TIMEOUT_SEC = 60;
 
         //Tip solidification
-        boolean TIP_SOLIDIFIER_ENABLED = true;
+        boolean TIP_SOLIDIFIER_ENABLED = false;
 
         //PearlDiver
         int POW_THREADS = 0;


### PR DESCRIPTION
# Description

Disables the tip solidifier in order to reduce syncing overhead.
The suggestion is that the milestone solidifier is enough to have a healthy tangle

## Type of change


- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tests on the ICC network concluded that this is safe

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
