### PR TITLE
Regression: Fix snapshot pruning config for machine6

### DIFF
--- a/python-regression/tests/features/machine6/config.yml
+++ b/python-regression/tests/features/machine6/config.yml
@@ -11,6 +11,8 @@ default_args: &args
    'true',
    '--snapshot',
    './snapshot.txt',
+   '--local-snapshots-pruning-enabled',
+   'true',
    '--local-snapshots-pruning-delay',
    '10000'
   ]


### PR DESCRIPTION
# Description
After the inclusion of https://github.com/iotaledger/iri/pull/1471 into `dev` the pruning logic defaults to `false`, this adds the `true`

Fixes #1289 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran test locally to see if the pruning was enabled on the nodes for `machine6` after pulling #1289 into my local branch. 
