### PR TITLE
Fix: Update solidity of transactions from past to present in TransactionValidator

### DIFF
--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -247,7 +247,7 @@ public class TransactionValidator {
         if(fromHash(tangle, hash).isSolid()) {
             return true;
         }
-        Set<Hash> analyzedHashes = new HashSet<>(snapshotProvider.getInitialSnapshot().getSolidEntryPoints().keySet());
+        LinkedHashSet<Hash> analyzedHashes = new LinkedHashSet<>(snapshotProvider.getInitialSnapshot().getSolidEntryPoints().keySet());
         if(maxProcessedTransactions != Integer.MAX_VALUE) {
             maxProcessedTransactions += analyzedHashes.size();
         }
@@ -255,24 +255,26 @@ public class TransactionValidator {
         final Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(hash));
         Hash hashPointer;
         while ((hashPointer = nonAnalyzedTransactions.poll()) != null) {
-            if (analyzedHashes.add(hashPointer)) {
-                if(analyzedHashes.size() >= maxProcessedTransactions) {
-                    return false;
-                }
+            if (!analyzedHashes.add(hashPointer)) {
+                continue;
+            }
 
-                final TransactionViewModel transaction = fromHash(tangle, hashPointer);
-                if(!transaction.isSolid() && !snapshotProvider.getInitialSnapshot().hasSolidEntryPoint(hashPointer)) {
-                    if (transaction.getType() == PREFILLED_SLOT) {
-                        solid = false;
+            if (analyzedHashes.size() >= maxProcessedTransactions) {
+                return false;
+            }
 
-                        if (!transactionRequester.isTransactionRequested(hashPointer, milestone)) {
-                            transactionRequester.requestTransaction(hashPointer, milestone);
-                            continue;
-                        }
-                    } else {
-                        nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
-                        nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
+            TransactionViewModel transaction = fromHash(tangle, hashPointer);
+            if (!transaction.isSolid() && !snapshotProvider.getInitialSnapshot().hasSolidEntryPoint(hashPointer)) {
+                if (transaction.getType() == PREFILLED_SLOT) {
+                    solid = false;
+
+                    if (!transactionRequester.isTransactionRequested(hashPointer, milestone)) {
+                        transactionRequester.requestTransaction(hashPointer, milestone);
+                        continue;
                     }
+                } else {
+                    nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
+                    nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
                 }
             }
         }

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -712,12 +712,12 @@ public class TransactionViewModel {
                 : TransactionViewModel.FILLED_SLOT;
     }
 
-    public static void updateSolidTransactions(Tangle tangle, Snapshot initialSnapshot, final Set<Hash> analyzedHashes)
+    public static void updateSolidTransactions(Tangle tangle, Snapshot initialSnapshot, final LinkedHashSet<Hash> analyzedHashes)
             throws Exception {
-        Iterator<Hash> hashIterator = analyzedHashes.iterator();
+        Object[] hashes = analyzedHashes.toArray();
         TransactionViewModel transactionViewModel;
-        while (hashIterator.hasNext()) {
-            transactionViewModel = TransactionViewModel.fromHash(tangle, hashIterator.next());
+        for(int i = hashes.length -1; i >= 0; i--){
+            transactionViewModel = TransactionViewModel.fromHash(tangle, (Hash) hashes[i]);
 
             transactionViewModel.updateHeights(tangle, initialSnapshot);
 


### PR DESCRIPTION
# Description
Changes the `TransactionValidator`'s `checkSolidity()` method to use a `LinkedHashSet` in order to keep the order in which transactions got analyzed. The `TransactionViewModel`'s`updateSolidTransactions()`  method will then update the solid flag of the given txs in reverse order to guarantee that the flags are updated from past to present. 

refs: https://github.com/iotaledger/iri/pull/1491

Fixes # (issue)
#1187 (maybe)
#1292 (maybe)

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Private Net.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
