### PR TITLE
Feature: Add getAllAddresses to the spentAdddresses provider

### DIFF
--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
@@ -32,5 +32,13 @@ public interface SpentAddressesProvider {
      * @throws SpentAddressesException If the provider fails to add an address
      */
     void saveAddressesBatch(Collection<Hash> addressHashes) throws SpentAddressesException;
+    
+    /**
+     * Loads all spent addresses we know of in a collection
+     * 
+     * @return The spent addresses
+     * @throws SpentAddressesException If the provider fails read
+     */
+    Collection<Hash> getAllAddresses() throws SpentAddressesException;
 
 }

--- a/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/SpentAddressesProvider.java
@@ -3,6 +3,7 @@ package com.iota.iri.service.spentaddresses;
 import com.iota.iri.model.Hash;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Find, mark and store spent addresses
@@ -39,6 +40,7 @@ public interface SpentAddressesProvider {
      * @return The spent addresses
      * @throws SpentAddressesException If the provider fails read
      */
-    Collection<Hash> getAllAddresses() throws SpentAddressesException;
+    //used by IXI
+    List<Hash> getAllAddresses();
 
 }

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -119,7 +119,7 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
     }
 
     @Override
-    public Collection<Hash> getAllAddresses() throws SpentAddressesException {
+    public List<Hash> getAllAddresses() {
         List<Hash> addresses = new ArrayList<>();
         for (byte[] bytes : rocksDBPersistenceProvider.loadAllKeysFromTable(SpentAddress.class)) {
             addresses.add(HashFactory.ADDRESS.create(bytes));

--- a/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/spentaddresses/impl/SpentAddressesProviderImpl.java
@@ -14,8 +14,10 @@ import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import com.iota.iri.utils.Pair;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -106,7 +108,6 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
         try {
             // Its bytes are always new byte[0], therefore identical in storage
             SpentAddress spentAddressModel = new SpentAddress();
-
             rocksDBPersistenceProvider.saveBatch(addressHash
                 .stream()
                 .map(address -> new Pair<Indexable, Persistable>(address, spentAddressModel))
@@ -115,5 +116,14 @@ public class SpentAddressesProviderImpl implements SpentAddressesProvider {
         } catch (Exception e) {
             throw new SpentAddressesException(e);
         }
+    }
+
+    @Override
+    public Collection<Hash> getAllAddresses() throws SpentAddressesException {
+        List<Hash> addresses = new ArrayList<>();
+        for (byte[] bytes : rocksDBPersistenceProvider.loadAllKeysFromTable(SpentAddress.class)) {
+            addresses.add(HashFactory.ADDRESS.create(bytes));
+        }
+        return addresses;
     }
 }


### PR DESCRIPTION
# Description

adds a getAll() method to get all spent addresses known to the node

Required for #1450

Replaces #1490

## Type of change
- Enhancement (a non-breaking change which adds functionality)


# How Has This Been Tested?

Tested by @kwek20 in the previous PR


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
