### PR TITLE
Fix: prevent self initialized connection being removed from reconnect pool too early

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouter.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouter.java
@@ -334,7 +334,6 @@ public class NeighborRouter {
             }
             if (channel.finishConnect()) {
                 log.info("established connection to neighbor {}, now performing handshake...", identity);
-                removeFromReconnectPool(neighbor);
                 // remove connect interest
                 key.interestOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
                 // add handshaking packet as the initial packet to send


### PR DESCRIPTION
# Description
If we initialize a connection to a neighbor ourselves, we should not remove that URI from the reconnect
pool up on the initialized (but not handshaked) connection, because it will lead to the node
not retrying a reconnect attempt in case the handshaking/read op. was faulty.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
