### PR TITLE
Fix: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,9 @@ bin/
 *.jar
 src/main/ixi/
 dependency-reduced-pom.xml
-
+.checkstyle
+db-bench/
+db-log-bench/
 
 # Created by https://www.gitignore.io/api/osx,linux,windows
 


### PR DESCRIPTION
Updated gitignore to include eclipse checkstyle and benchmark folders

## Type of change
- Documentation Fix