### PR TITLE
Fix: Read from the db in order to find the existence of spent-addresses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <undertow.version>2.0.22.Final</undertow.version>
         <jackson-databind.version>2.9.9.1</jackson-databind.version>
         <zero-allocation-hashing.version>0.8</zero-allocation-hashing.version>
+        <system-rules.version>1.19.0</system-rules.version>
         <jacoco.version>0.7.9</jacoco.version>
         <!-- Setting the checkstyle.config.location here will make checkstyle use this file in every maven target.
              This variable will be load by checkstyle plugin automatically. It is more global than setting the
@@ -250,6 +251,13 @@
             <version>0.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>${system-rules.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -456,6 +464,9 @@
                                         <!-- A check for the rules themselves -->
                                         <urn>
                                             uk.co.froot.maven.enforcer:digest-enforcer-rules:0.0.1:jar:null:runtime:16a9e04f3fe4bb143c42782d07d5faf65b32106f
+                                        </urn>
+                                        <urn>
+                                            com.github.stefanbirkner:system-rules:${system-rules.version}:jar:null:test:16a9e04f3fe4bb143c42782d07d5faf65b32106f
                                         </urn>
                                     </urns>
 

--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
                                             uk.co.froot.maven.enforcer:digest-enforcer-rules:0.0.1:jar:null:runtime:16a9e04f3fe4bb143c42782d07d5faf65b32106f
                                         </urn>
                                         <urn>
-                                            com.github.stefanbirkner:system-rules:${system-rules.version}:jar:null:test:16a9e04f3fe4bb143c42782d07d5faf65b32106f
+                                            com.github.stefanbirkner:system-rules:${system-rules.version}:jar:null:test:d541c9a1cff0dda32e2436c74562e2e4aa6c88cd
                                         </urn>
                                     </urns>
 

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -226,8 +226,6 @@ public class SnapshotProviderImpl implements SnapshotProvider {
             if (localSnapshotFile.exists() && localSnapshotFile.isFile() && localSnapshotMetadDataFile.exists() &&
                     localSnapshotMetadDataFile.isFile()) {
 
-                assertSpentAddressesDbExist();
-
                 SnapshotState snapshotState = readSnapshotStatefromFile(localSnapshotFile.getAbsolutePath());
                 if (!snapshotState.hasCorrectSupply()) {
                     throw new SnapshotException("the snapshot state file has an invalid supply");
@@ -245,22 +243,6 @@ public class SnapshotProviderImpl implements SnapshotProvider {
         }
 
         return null;
-    }
-
-    private void assertSpentAddressesDbExist() throws SpentAddressesException {
-        String spentAddressesDbPath = config.getSpentAddressesDbPath();
-        try {
-            File spentAddressFolder = new File(spentAddressesDbPath);
-            //If there is at least one file in the db the check should pass
-            if (Files.newDirectoryStream(spentAddressFolder.toPath(), "*.sst").iterator().hasNext()) {
-                return;
-            }
-        }
-        catch (IOException e){
-            throw new SpentAddressesException("Can't load " + spentAddressesDbPath + " folder", e);
-        }
-
-        throw new SpentAddressesException(spentAddressesDbPath + " folder has no sst files");
     }
 
     /**


### PR DESCRIPTION
# Description

We now check the existence of spent-addresses by properly reading from the db rather then looking for sst files. We do it when we load from local snapshot and when we are not it testnet mode.

Fixes #1461

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested manually on a local node
- Unit test was added


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
