### PR TITLE
Fix: Adds recently requested txs set to TransactionRequester

### DIFF
--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -131,7 +131,8 @@ public class TransactionValidator {
      */
     private boolean hasInvalidTimestamp(TransactionViewModel transactionViewModel) {
         // ignore invalid timestamps for transactions that were requested by our node while solidifying a milestone
-        if(transactionRequester.isTransactionRequested(transactionViewModel.getHash())) {
+        if(transactionRequester.wasTransactionRecentlyRequested(transactionViewModel.getHash())) {
+            transactionRequester.removeRecentlyRequestedTransaction(transactionViewModel.getHash());
             return false;
         }
 


### PR DESCRIPTION
# Description
Fixes transactions to be deemed invalid by their timestamp because the bypass via the `transactionRequester.isTransactionRequested()` doesn't work with the new request queue logic via https://github.com/iotaledger/iri/pull/1530

Fixes # (issue)
https://github.com/iotaledger/iri/issues/1541

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
