### PR TITLE
Checkstyle: add inner type and constants rules

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,5 +27,10 @@ IOTA checkstyle draft
         <module name="PackageName"/>
         <module name="ParameterName"/>
         <module name="TypeName"/>
+        <module name="ConstantName">
+            <property name="format"
+                      value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+        </module>
+        <module name="InnerTypeLast"/>
     </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -28,6 +28,10 @@ IOTA checkstyle draft
         <module name="ParameterName"/>
         <module name="TypeName"/>
         <module name="ConstantName">
+            <!-- Sometimes private/protected are not really constant values -->
+            <property name="applyToPrivate" value="false"/>
+            <property name="applyToProtected" value="false"/>
+            <!-- log is always fine -->
             <property name="format"
                       value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
         </module>

--- a/src/main/java/com/iota/iri/service/dto/AbstractResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/AbstractResponse.java
@@ -14,12 +14,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
   **/
 public abstract class AbstractResponse {
 
-    /**
-     * An 'empty' Response class.
-     * Will only contain values which are included in {@link AbstractResponse} itself.
-     * This is used when an API command does not need to return data.
-     */
-	private static class Emptyness extends AbstractResponse {}
 
 	/**
 	 * Number of milliseconds it took to complete the request
@@ -73,4 +67,10 @@ public abstract class AbstractResponse {
     	return new Emptyness();
     }
 
+    /**
+     * An 'empty' Response class.
+     * Will only contain values which are included in {@link AbstractResponse} itself.
+     * This is used when an API command does not need to return data.
+     */
+    private static class Emptyness extends AbstractResponse {}
 }


### PR DESCRIPTION


# Description

adds checkstyle rules to enforce:
1. Inner classes are always in the end
2. public constants are always UPPER_SNAKE_CASE

```
<module name="ConstantName">
            <!-- Sometimes private/protected are not really constant values -->
            <property name="applyToPrivate" value="false"/>
            <property name="applyToProtected" value="false"/>
            <!-- log is always fine -->
            <property name="format"
                      value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
        </module>
        <module name="InnerTypeLast"/>
``` 

See #642 

## Type of change

- style fix

# How Has This Been Tested?

Only a style change. Automatic tests suffice.


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
