### PR TITLE
Build: attempt to fix oracle jdk build with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+
+dist: trusty
+
 jdk:
   - oraclejdk8
   - openjdk8


### PR DESCRIPTION
# Description

Travis fails to pass with oracleJDK 8. 
In this PR we will try to make it pass or stop using jdk8 all together.

Travis is still needed until we add a few more features to buildkite

Fixes # (issue)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

We see if Travis passes