### PR TITLE
Fix: Fixes regression introduced through the bundle validator refactor

### DIFF
--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -205,17 +205,15 @@ public class LedgerServiceImpl implements LedgerService {
                                     break;
                                 }
 
-                                if (bundleTransactions.get(0).getHash().equals(transactionViewModel.getHash())) {
 
-                                    for (final TransactionViewModel bundleTransactionViewModel : bundleTransactions) {
+                                for (final TransactionViewModel bundleTransactionViewModel : bundleTransactions) {
 
-                                        if (bundleTransactionViewModel.value() != 0 && countedTx.add(bundleTransactionViewModel.getHash())) {
+                                    if (bundleTransactionViewModel.value() != 0 && countedTx.add(bundleTransactionViewModel.getHash())) {
 
-                                            final Hash address = bundleTransactionViewModel.getAddressHash();
-                                            final Long value = state.get(address);
-                                            state.put(address, value == null ? bundleTransactionViewModel.value()
-                                                    : Math.addExact(value, bundleTransactionViewModel.value()));
-                                        }
+                                        final Hash address = bundleTransactionViewModel.getAddressHash();
+                                        final Long value = state.get(address);
+                                        state.put(address, value == null ? bundleTransactionViewModel.value()
+                                                : Math.addExact(value, bundleTransactionViewModel.value()));
                                     }
                                 }
                             }

--- a/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/com/iota/iri/service/ledger/impl/LedgerServiceImpl.java
@@ -217,8 +217,6 @@ public class LedgerServiceImpl implements LedgerService {
                                                     : Math.addExact(value, bundleTransactionViewModel.value()));
                                         }
                                     }
-
-                                    break;
                                 }
                             }
 


### PR DESCRIPTION
# Description
Through a redundant break statement, the balance diff creating method did return before it actually computed any balance diff, leading to every applied milestone to not change any addresses.

Weird is that no unit or regression tests catched this. We should have a regression test which mutates addresses and then does a `getBalances()` call to check that the address really was mutated (I didn't check whether we already have such regression test).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Applied this patch to my localsnapshot/spent-addresses RocksDB PR and verified that the mutated balances were not zero anymore.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
