### PR TITLE
Fix: Always set the domain field of a neighbor

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouter.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouter.java
@@ -289,6 +289,8 @@ public class NeighborRouter {
             String domain = ipToDomainMapping.get(remoteAddr.getAddress().getHostAddress());
             if (domain != null) {
                 newNeighbor.setDomain(domain);
+            }else{
+                newNeighbor.setDomain(remoteAddr.getAddress().getHostAddress());
             }
             newNeighbor.send(Handshake.createHandshakePacket((char) networkConfig.getNeighboringSocketPort(),
                     byteEncodedCooAddress, (byte) protocolConfig.getMwm()));
@@ -700,7 +702,7 @@ public class NeighborRouter {
         tcpChannel.connect(addr);
         Neighbor neighbor = new NeighborImpl<>(selector, tcpChannel, addr.getAddress().getHostAddress(), addr.getPort(),
                 txPipeline);
-        neighbor.setDomain(addr.getHostName());
+        neighbor.setDomain(addr.getHostString());
         tcpChannel.register(selector, SelectionKey.OP_CONNECT, neighbor);
     }
 
@@ -897,7 +899,17 @@ public class NeighborRouter {
     public List<Neighbor> getNeighbors() {
         List<Neighbor> neighbors = new ArrayList<>(connectedNeighbors.values());
         reconnectPool.forEach(uri -> {
-            neighbors.add(new NeighborImpl<>(null, null, uri.getHost(), uri.getPort(), null));
+            // try to resolve the address of the neighbor which is not connected
+            InetSocketAddress inetAddr = new InetSocketAddress(uri.getHost(), uri.getPort());
+            String hostAddress = "";
+            if(!inetAddr.isUnresolved()){
+                hostAddress = inetAddr.getAddress().getHostAddress();
+            }
+            Neighbor neighbor = new NeighborImpl<>(null, null, hostAddress, uri.getPort(), null);
+            // enforce the domain to be set, if the uri contains the IP address, the host address will not be empty
+            // hence using the getNeighbors() HTTP API call will return a meaningful answer.
+            neighbor.setDomain(uri.getHost());
+            neighbors.add(neighbor);
         });
         return neighbors;
     }

--- a/src/main/java/com/iota/iri/network/neighbor/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/neighbor/Neighbor.java
@@ -61,9 +61,9 @@ public interface Neighbor {
     void setDomain(String domain);
 
     /**
-     * Gets the domain name.
+     * Gets the domain name or if not available, the IP address.
      * 
-     * @return the domain name
+     * @return the domain name or IP address
      */
     String getDomain();
 

--- a/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
+++ b/src/main/java/com/iota/iri/service/dto/GetNeighborsResponse.java
@@ -118,7 +118,8 @@ public class GetNeighborsResponse extends AbstractResponse {
             Neighbor ne = new Neighbor();
             NeighborMetrics metrics = neighbor.getMetrics();
             int port = neighbor.getRemoteServerSocketPort();
-            ne.address = neighbor.getHostAddressAndPort();
+            String hostAddr = neighbor.getHostAddress();
+            ne.address = hostAddr == null || hostAddr.isEmpty() ? "" : neighbor.getHostAddressAndPort();
             ne.domain = neighbor.getDomain();
             ne.numberOfAllTransactions = metrics.getAllTransactionsCount();
             ne.numberOfInvalidTransactions = metrics.getInvalidTransactionsCount();


### PR DESCRIPTION
# Description
This PR alters the logic of neighbor properties and the `getNeighbors()` API call to fulfill following rules:
* if the neighbor is connected and there's no mapping to a domain, the IP address will be set in the `domain` field
* if the neighbor is connected and there's a mapping to a domain, the domain will be set in the `domain` field
* if the neighbor is not connected, the neighbor was added using an URI with a domain (tcp://example.com:15600) and during the call to `getNeighbors()` the domain can't be resolved to an IP address, the `domain` field will contain the domain name and the `address` field will be empty
* if the neighbor is not connected, the neighbor was added using an URI with an IP address (tcp://1.1.1.1:15600), the `domain` field will contain the IP address and the `address` field will contain the IP address + port combination
* if the neighbor is not connected, the neighbor was added using an URI with a domain (tcp://example.com:15600) and during the call to `getNeighbors()` the domain could be resolved to an IP address, the `domain` field will contain the domain name and the `address` field will contain the IP address + port combination.

The `domain` field of a neighbor always either contains the domain name of the initial URI or the IP address. It is never empty.

Additionally, this PR stops the node from doing reverse lookups of IP addresses to gather a domain name, as often a not desired domain will be set.

Fixes # (issue)
https://github.com/iotaledger/iri/issues/1536

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
