### PR TITLE
Update regression node names, m6 times

### DIFF
--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -14,7 +14,7 @@ Feature: Test API calls on Machine 1
 		#See tests/features/steps/api_test_steps.py for further details
 		#
 
-		Given "getNodeInfo" is called on "nodeA" with:
+		Given "getNodeInfo" is called on "nodeA-m1" with:
 		|keys       |values				|type   	|
 
 		Then a response with the following is returned:
@@ -44,11 +44,11 @@ Feature: Test API calls on Machine 1
 
 	Scenario: GetNeighbors is called
 
-	    Given "addNeighbors" is called on "nodeA" with:
+	    Given "addNeighbors" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
-		|uris       |nodeB				|nodeAddress    |
+		|uris       |nodeB-m1				|nodeAddress    |
 
-		And "getNeighbors" is called on "nodeA" with:
+		And "getNeighbors" is called on "nodeA-m1" with:
 		|keys       |values				|type   	|
 
 		Then a response with the following is returned:
@@ -66,11 +66,11 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: Add and Remove Neighbors
-		Adds nodeB as a neighbor to nodeA, and then removes it.
+		Adds nodeB-m1 as a neighbor to nodeA-m1, and then removes it.
 
-		Given "addNeighbors" is called on "nodeA" with:
+		Given "addNeighbors" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
-		|uris       |nodeB				|nodeAddress    |
+		|uris       |nodeB-m1				|nodeAddress    |
 
 		Then a response with the following is returned:
 		|keys						|
@@ -78,9 +78,9 @@ Feature: Test API calls on Machine 1
 		|duration					|
 
 
-		When "removeNeighbors" is called on "nodeA" with:
+		When "removeNeighbors" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
-		|uris       |nodeB				|nodeAddress    |
+		|uris       |nodeB-m1				|nodeAddress    |
 
 
 		Then a response with the following is returned:
@@ -90,7 +90,7 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: GetTips is called
-		Given "getTips" is called on "nodeA" with:
+		Given "getTips" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
 
 		Then a response with the following is returned:
@@ -102,7 +102,7 @@ Feature: Test API calls on Machine 1
 
     #Values can be found in util/static_vals.py
 	Scenario: GetTrytes is called
-		Given "getTrytes" is called on "nodeA" with:
+		Given "getTrytes" is called on "nodeA-m1" with:
 		|keys       |values             |type               |
 		|hashes     |TEST_HASH          |staticList         |
 
@@ -113,7 +113,7 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: GetTransactionsToApprove is called
-		Given "getTransactionsToApprove" is called on "nodeA" with:
+		Given "getTransactionsToApprove" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|depth      |3					|int            |
 
@@ -125,7 +125,7 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: CheckConsistency is called
-		Given "checkConsistency" is called on "nodeA" with:
+		Given "checkConsistency" is called on "nodeA-m1" with:
 		|keys           |values				|type           |
 		|tails          |TEST_HASH			|staticList     |
 
@@ -133,9 +133,9 @@ Feature: Test API calls on Machine 1
 		|keys           |values         |type           |
 		|state		|True           |bool           |
 
-		When an inconsistent transaction is generated on "nodeA"
+		When an inconsistent transaction is generated on "nodeA-m1"
 
-		And "checkConsistency" is called on "nodeA" with:
+		And "checkConsistency" is called on "nodeA-m1" with:
 		|keys           |values				|type           |
 		|tails          |inconsistentTransactions       |responseList   |
 
@@ -147,7 +147,7 @@ Feature: Test API calls on Machine 1
 
 	#Values can be found in util/static_vals.py
 	Scenario: GetInclusionStates is called
-		Given "getInclusionStates" is called on "nodeA" with:
+		Given "getInclusionStates" is called on "nodeA-m1" with:
 		|keys           |values				|type               |
 		|transactions   |TEST_HASH			|staticList         |
 		|tips           |TEST_TIP_LIST			|staticValue        |
@@ -159,7 +159,7 @@ Feature: Test API calls on Machine 1
 	
 	#Address can be found in util/static_vals.py
 	Scenario: GetBalances is called
-		Given "getBalances" is called on "nodeA" with:
+		Given "getBalances" is called on "nodeA-m1" with:
 		|keys           |values			        |type               |
 		|addresses      |TEST_EMPTY_ADDRESS	        |staticList         |
 		|threshold      |100			        |int                |
@@ -173,7 +173,7 @@ Feature: Test API calls on Machine 1
 	    Begins attaching a transaction to the tangle with a high MWM, then issues an interrupt to the node
 	    If the interrupt is successful, the attachToTangle response will return a null tryte list
 
-		Given "attachToTangle" is called in parallel on "nodeA" with:
+		Given "attachToTangle" is called in parallel on "nodeA-m1" with:
 		|keys                   |values			|type           |
 		|trytes                 |EMPTY_TRANSACTION_TRYTES|staticList     |
 		|trunk_transaction      |TEST_HASH		|staticValue    |
@@ -181,7 +181,7 @@ Feature: Test API calls on Machine 1
 		|min_weight_magnitude   |50			|int            |
 
 		And we wait "1" second/seconds
-		Then "interruptAttachingToTangle" is called in parallel on "nodeA" with:
+		Then "interruptAttachingToTangle" is called in parallel on "nodeA-m1" with:
 		|keys                   |values				|type           |
 
         # Do not include duration in the return expectations as it will always return a variable amount
@@ -192,7 +192,7 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: WereAddressesSpentFrom is called
-		Given "wereAddressesSpentFrom" is called on "nodeA" with:
+		Given "wereAddressesSpentFrom" is called on "nodeA-m1" with:
 		|keys       |values				|type               |
 		|addresses  |TEST_EMPTY_ADDRESS			|staticList         |
 
@@ -207,7 +207,7 @@ Feature: Test API calls on Machine 1
 		Generate a transaction, attach it to the tangle, and store it locally. Then find
 		that transaction via its address.
 
-		Given a transaction is generated and attached on "nodeA" with:
+		Given a transaction is generated and attached on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|address    |TEST_STORE_ADDRESS			|staticValue    |
 		|value      |0					|int            |
@@ -216,11 +216,11 @@ Feature: Test API calls on Machine 1
 		|keys						|
 		|trytes						|
 
-		When "storeTransactions" is called on "nodeA" with:
+		When "storeTransactions" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|trytes     |TEST_STORE_TRANSACTION		|staticValue    |
 
-		And "findTransactions" is called on "nodeA" with:
+		And "findTransactions" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|addresses  |TEST_STORE_ADDRESS			|staticList     |
 
@@ -230,12 +230,12 @@ Feature: Test API calls on Machine 1
 
 
 
-	Scenario: Broadcast a test transacion
+	Scenario: Broadcast a test transaction
 		Send a test transaction from one node in a machine with a unique tag, and find that transaction
 		through a different node in the same machine
 		
-		Given "nodeA" and "nodeB" are neighbors
-		When a transaction is generated and attached on "nodeA" with:
+		Given "nodeA-m1" and "nodeB-m1" are neighbors
+		When a transaction is generated and attached on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|address    |TEST_ADDRESS			|staticValue    |
 		|tag        |TEST9TAG9ONE			|string         |
@@ -244,7 +244,7 @@ Feature: Test API calls on Machine 1
         #Give the transaction time to propagate
 		And we wait "3" second/seconds
 
-		And "findTransactions" is called on "nodeB" with:
+		And "findTransactions" is called on "nodeB-m1" with:
 		|keys       |values             |type           |
 		|tags       |TEST9TAG9ONE       |list           |
 

--- a/python-regression/tests/features/machine1/config.yml
+++ b/python-regression/tests/features/machine1/config.yml
@@ -19,8 +19,8 @@ seeds: # For internal use by the regression system.
     - SIID
 
 nodes:
-  nodeA: #name
+  nodeA-m1: #name
     <<: *api_tests_config_files
   
-  nodeB:
+  nodeB-m1:
     <<: *api_tests_config_files

--- a/python-regression/tests/features/machine2/2_transaction_tests.feature
+++ b/python-regression/tests/features/machine2/2_transaction_tests.feature
@@ -5,7 +5,7 @@ Feature: Test transaction confirmation
         A milestone will be issued that references these transactions, and this should
         confirm the transations.
 
-        Given "10" transactions are issued on "nodeA" with:
+        Given "10" transactions are issued on "nodeA-m2" with:
         |keys                   |values                     |type           |
         |address                |TEST_ADDRESS               |staticValue    |
         |value                  |0                          |int            |
@@ -19,7 +19,7 @@ Feature: Test transaction confirmation
         #Give the node 10 seconds to solidify the milestone
         And we wait "10" second/seconds
 
-        Then "getInclusionStates" is called on "nodeA" with:
+        Then "getInclusionStates" is called on "nodeA-m2" with:
         |keys                   |values                     |type           |
         |transactions           |evaluate_and_send          |responseValue  |
         |tips                   |latestMilestone            |configValue    |
@@ -35,7 +35,7 @@ Feature: Test transaction confirmation
         A milestone will be issued that references these transactions, and this should
         confirm the transations.
 
-        Given "10" transactions are issued on "nodeA" with:
+        Given "10" transactions are issued on "nodeA-m2" with:
         |keys                   |values                     |type           |
         |seed                   |THE_BANK                   |staticList     |
         |address                |TEST_ADDRESS               |staticValue    |
@@ -50,7 +50,7 @@ Feature: Test transaction confirmation
         #Give the node time to solidify the milestone
         And we wait "10" second/seconds
 
-        Then "getInclusionStates" is called on "nodeA" with:
+        Then "getInclusionStates" is called on "nodeA-m2" with:
         |keys                   |values                     |type           |
         |transactions           |evaluate_and_send          |responseValue  |
         |tips                   |latestMilestone            |configValue    |

--- a/python-regression/tests/features/machine2/config.yml
+++ b/python-regression/tests/features/machine2/config.yml
@@ -15,8 +15,5 @@ defaults: &transaction_tests_config_files
   java_options: -agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n -javaagent:/opt/jacoco/lib/jacocoagent.jar=destfile=/iri/jacoco.exec,output=file,append=true,dumponexit=true
 
 nodes:
-  nodeA: #name
-    <<: *transaction_tests_config_files
-
-  nodeB:
+  nodeA-m2: #name
     <<: *transaction_tests_config_files

--- a/python-regression/tests/features/machine3/3_blowball_tests.feature
+++ b/python-regression/tests/features/machine3/3_blowball_tests.feature
@@ -10,11 +10,11 @@ Feature: Test GTTA for blowballs
 		|keys           |values                 |type           |
 		|depth          |3                      |int            |
 
-		And "findTransactions" is called on "nodeA" with:
+		And "findTransactions" is called on "nodeA-m3" with:
 		|keys           |values                 |type           |
 		|addresses      |TEST_BLOWBALL_COO      |staticList     |
 
 		#Insert your testnet coordinator address above
 		Then the returned GTTA transactions will be compared with the milestones
-		And less than 5 percent of the returned transactions should reference milestones
+		And less than 5 percent of the returned transactions should be milestones
 	

--- a/python-regression/tests/features/machine3/config.yml
+++ b/python-regression/tests/features/machine3/config.yml
@@ -19,21 +19,21 @@ seeds: # For internal use by the regression system.
     - SIID
 
 nodes:
-  nodeA: #name
+  nodeA-m3: #name
     <<: *blowball_tests_config_files
   
-  nodeB:
+  nodeB-m3:
     <<: *blowball_tests_config_files
 
-  nodeC:
+  nodeC-m3:
     <<: *blowball_tests_config_files
 
-  nodeD:
+  nodeD-m3:
     <<: *blowball_tests_config_files
 
-  nodeE:
+  nodeE-m3:
     <<: *blowball_tests_config_files
 
-  nodeF:
+  nodeF-m3:
     <<: *blowball_tests_config_files
 

--- a/python-regression/tests/features/machine4/4_stitching.feature
+++ b/python-regression/tests/features/machine4/4_stitching.feature
@@ -8,8 +8,8 @@ Feature: Ensure node reliability while stitching a side tangle
 	
 	Scenario: Check consistency on a stitching transaction responds
 		
-		Given a stitching transaction is issued on "nodeA" with the tag "STITCHING"
-		And "checkConsistency" is called in parallel on "nodeA" with:
+		Given a stitching transaction is issued on "nodeA-m4" with the tag "STITCHING"
+		And "checkConsistency" is called in parallel on "nodeA-m4" with:
 		|keys                   |values                 |type           |
 		|tails                  |previousTransaction    |responseList   |
 
@@ -19,7 +19,7 @@ Feature: Ensure node reliability while stitching a side tangle
 
 		When a transaction is issued referencing the previous transaction
 
-		And "getTransactionsToApprove" is called on "nodeA" with:
+		And "getTransactionsToApprove" is called on "nodeA-m4" with:
 		|keys                   |values                 |type           |
 		|depth                  |3                      |int            |
 

--- a/python-regression/tests/features/machine4/config.yml
+++ b/python-regression/tests/features/machine4/config.yml
@@ -19,8 +19,5 @@ seeds: # For internal use by the regression system.
     - SIID
 
 nodes:
-  nodeA: #name
-    <<: *stitching_tests_config_files
-  
-  nodeB:
+  nodeA-m4: #name
     <<: *stitching_tests_config_files

--- a/python-regression/tests/features/machine5/5_milestone_validation.feature
+++ b/python-regression/tests/features/machine5/5_milestone_validation.feature
@@ -5,14 +5,14 @@ Feature: Test milestone validation
 
     Scenario: Verify current milestone index
 
-        Given "getNodeInfo" is called on "nodeA" with:
+        Given "getNodeInfo" is called on "nodeA-m5" with:
         |keys                   |values     |type       |
 
         Then the response for "getNodeInfo" should return with:
         |keys                   |values     |type       |
         |latestMilestoneIndex   |45         |int        |
 
-        And "getNodeInfo" is called on "nodeB" with:
+        And "getNodeInfo" is called on "nodeB-m5" with:
         |keys                   |values     |type       |
 
         Then the response for "getNodeInfo" should return with:

--- a/python-regression/tests/features/machine5/config.yml
+++ b/python-regression/tests/features/machine5/config.yml
@@ -34,8 +34,8 @@ seeds: # For internal use by the regression system.
     - SIID
 
 nodes:
-  nodeA: #name
+  nodeA-m5: #name
     <<: *no_validation_tests_config_files
   
-  nodeB:
+  nodeB-m5:
     <<: *validation_tests_config_files

--- a/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
+++ b/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
@@ -4,19 +4,19 @@ Feature: Test Bootstrapping With LS
   be started, connected to this node and one another: One will have only a DB and snapshot file, while the other will
   have only the snapshot meta and state file, along with the spent addresses DB and the snapshot file. All three nodes
   should sync with one another. And a snapshot should be taken on the node started with just a DB.
-  [NodeA: Permanode, NodeB: Just DB, NodeC: Just LS Files]
+  [NodeA-m6: Permanode, NodeB-m6: Just DB, NodeC-m6: Just LS Files]
 
   Scenario: PermaNode is synced
     Check that the permanode has been started correctly and is synced.
 
     #First make sure nodes are neighbored
-    Given "nodeA" and "nodeB" are neighbors
-    And "nodeA" and "nodeC" are neighbors
+    Given "nodeA-m6" and "nodeB-m6" are neighbors
+    And "nodeA-m6" and "nodeC-m6" are neighbors
 
     #Default for test is to issue 10322
-    When milestone 10322 is issued on "nodeA"
-    And we wait "60" second/seconds
-    Then "nodeA" is synced up to milestone 10322
+    When milestone 10322 is issued on "nodeA-m6"
+    And we wait "30" second/seconds
+    Then "nodeA-m6" is synced up to milestone 10322
 
 
   Scenario: DB node is synced, and files contain expected values
@@ -24,21 +24,21 @@ Feature: Test Bootstrapping With LS
     stored correctly.
 
     #First make sure nodes are neighbored
-    Given "nodeB" and "nodeA" are neighbors
-    And "nodeB" and "nodeC" are neighbors
+    Given "nodeB-m6" and "nodeA-m6" are neighbors
+    And "nodeB-m6" and "nodeC-m6" are neighbors
 
     # Default for test is to issue 10323
-    When milestone 10323 is issued on "nodeA"
+    When milestone 10323 is issued on "nodeA-m6"
     #Give the node time to finish syncing properly, then make sure that the node is synced to the latest milestone.
-    And we wait "60" second/seconds
-    Then "nodeB" is synced up to milestone 10323
-    And A local snapshot was taken on "nodeB" at index 10220
+    And we wait "30" second/seconds
+    Then "nodeB-m6" is synced up to milestone 10323
+    And A local snapshot was taken on "nodeB-m6" at index 10220
 
-    When reading the local snapshot state on "nodeB" returns with:
+    When reading the local snapshot state on "nodeB-m6" returns with:
       |keys                       |values                   |type             |
       |address                    |LS_TEST_STATE_ADDRESSES  |staticValue      |
 
-    And reading the local snapshot metadata on "nodeB" returns with:
+    And reading the local snapshot metadata on "nodeB-m6" returns with:
       |keys                       |values                   |type             |
       |hashes                     |LS_TEST_MILESTONE_HASHES |staticValue      |
 
@@ -47,14 +47,14 @@ Feature: Test Bootstrapping With LS
     Check that the node started with just LS Files is synced correctly.
 
     #First make sure nodes are neighbored
-    Given "nodeC" and "nodeA" are neighbors
-    And "nodeC" and "nodeB" are neighbors
+    Given "nodeC-m6" and "nodeA-m6" are neighbors
+    And "nodeC-m6" and "nodeB-m6" are neighbors
 
     #Default for test is to issue 10324
-    When milestone 10324 is issued on "nodeA"
+    When milestone 10324 is issued on "nodeA-m6"
     #Give the node time to finish syncing properly, then make sure that the node is synced to the latest milestone.
-    And we wait "180" second/seconds
-    Then "nodeC" is synced up to milestone 10324
+    And we wait "120" second/seconds
+    Then "nodeC-m6" is synced up to milestone 10324
 
 
   Scenario: Check DB for milestone hashes
@@ -62,12 +62,12 @@ Feature: Test Bootstrapping With LS
     are present in the new node.
 
     #First make sure nodes are neighbored
-    Given "nodeC" and "nodeA" are neighbors
+    Given "nodeC-m6" and "nodeA-m6" are neighbors
      #Default for test is to issue 10325
-    When milestone 10325 is issued on "nodeA"
-    And we wait "60" second/seconds
+    When milestone 10325 is issued on "nodeA-m6"
+    And we wait "30" second/seconds
 
-    Then "checkConsistency" is called on "nodeC" with:
+    Then "checkConsistency" is called on "nodeC-m6" with:
       |keys                       |values                   |type             |
       |tails                      |LS_TEST_MILESTONE_HASHES |staticValue      |
 
@@ -80,7 +80,7 @@ Feature: Test Bootstrapping With LS
     Takes a node with a large db and transaction pruning enabled, and checks to make sure that the transactions below
     the pruning depth are no longer present.
 
-    Given "checkConsistency" is called on "nodeD" with:
+    Given "checkConsistency" is called on "nodeD-m6" with:
       |keys                       |values                   |type             |
       |tails                      |LS_PRUNED_TRANSACTIONS   |staticValue      |
 

--- a/python-regression/tests/features/machine6/config.yml
+++ b/python-regression/tests/features/machine6/config.yml
@@ -47,14 +47,14 @@ db_for_pruning: &db_for_pruning
 
 
 nodes:
-  nodeA: #name
+  nodeA-m6: #name
     <<: *db_full
 
-  nodeB:
+  nodeB-m6:
     <<: *db_with_snapshot
 
-  nodeC:
+  nodeC-m6:
     <<: *db_with_LS_files
 
-  nodeD:
+  nodeD-m6:
     <<: *db_for_pruning

--- a/python-regression/tests/features/steps/response_handling_steps.py
+++ b/python-regression/tests/features/steps/response_handling_steps.py
@@ -166,7 +166,7 @@ def compare_gtta_with_milestones(step):
     logger.info('Transactions logged in /tests/features/machine3/blowball_logs.txt')
 
 
-@step(r'less than (\d+) percent of the returned transactions should reference milestones')
+@step(r'less than (\d+) percent of the returned transactions should be milestones')
 def less_than_max_percent(step, max_percent):
     """
     Checks the number of returned milestones and ensures that the total number of milestones returned is below a


### PR DESCRIPTION
# Description
Simple update to node labels in regression tests for log artefact creation during buildkite testing. This will allow for easier debugging of tests in the future. This also includes a reduction in the machine6 wait times. 

## Type of change
-Update to regression files 

# How Has This Been Tested?
Purely syntax changes

