### PR TITLE
Fix: Ensure reference transaction is valid when alpha is 0

### DIFF
--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -123,6 +123,18 @@ Feature: Test API calls on Machine 1
 		|duration					|
 		|trunkTransaction				|
 
+	Scenario: GetTransactionsToApprove is called with a reference transaction
+    		Given "getTransactionsToApprove" is called on "nodeA" with:
+    		|keys       |values				|type           |
+    		|depth      |3					|int            |
+    		|reference  |
+
+    		Then a response with the following is returned:
+    		|keys						|
+    		|branchTransaction				|
+    		|duration					|
+    		|trunkTransaction				|
+
 
 	Scenario: CheckConsistency is called
 		Given "checkConsistency" is called on "nodeA" with:

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -123,6 +123,7 @@ Feature: Test API calls on Machine 1
 		|duration					|
 		|trunkTransaction				|
 
+
 	Scenario: CheckConsistency is called
 		Given "checkConsistency" is called on "nodeA" with:
 		|keys           |values				|type           |

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -127,7 +127,7 @@ Feature: Test API calls on Machine 1
     		Given "getTransactionsToApprove" is called on "nodeA" with:
     		|keys       |values				|type           |
     		|depth      |3					|int            |
-    		|reference  |
+    		|reference  |TEST_HASH          |staticList     |
 
     		Then a response with the following is returned:
     		|keys						|

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -123,20 +123,6 @@ Feature: Test API calls on Machine 1
 		|duration					|
 		|trunkTransaction				|
 
-	@Now
-	Scenario: GetTransactionsToApprove is called with a reference transaction
-    		Given "getTransactionsToApprove" is called on "nodeA" with:
-    		|keys       |values				|type           |
-    		|depth      |3					|int            |
-    		|reference  |TEST_HASH          |staticList     |
-
-    		Then a response with the following is returned:
-    		|keys						|
-    		|branchTransaction				|
-    		|duration					|
-    		|trunkTransaction				|
-
-
 	Scenario: CheckConsistency is called
 		Given "checkConsistency" is called on "nodeA" with:
 		|keys           |values				|type           |

--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -123,6 +123,7 @@ Feature: Test API calls on Machine 1
 		|duration					|
 		|trunkTransaction				|
 
+	@Now
 	Scenario: GetTransactionsToApprove is called with a reference transaction
     		Given "getTransactionsToApprove" is called on "nodeA" with:
     		|keys       |values				|type           |

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -18,6 +18,8 @@ import com.iota.iri.service.tipselection.WalkValidator;
 import com.iota.iri.service.tipselection.Walker;
 import com.iota.iri.storage.Tangle;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Implementation of <tt>TipSelector</tt> that selects 2 tips,
  * based on cumulative weights and transition function alpha.
@@ -127,7 +129,8 @@ public class TipSelectorImpl implements TipSelector {
         }
     }
 
-    private void checkReference(Hash reference, Map<Hash, Integer> rating, WalkValidator walkValidator)
+    @VisibleForTesting
+    void checkReference(Hash reference, Map<Hash, Integer> rating, WalkValidator walkValidator)
             throws Exception {
         if (config.getAlpha() != 0 && !rating.containsKey(reference)) {
             throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_TOO_OLD);

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -27,6 +27,7 @@ public class TipSelectorImpl implements TipSelector {
 
     private static final String REFERENCE_TRANSACTION_TOO_OLD = "reference transaction is too old";
     private static final String TIPS_NOT_CONSISTENT = "inconsistent tips pair selected";
+    private static final String REFERENCE_TRANSACTION_IS_INVALID = "reference transaction is invalid";
 
     private final EntryPointSelector entryPointSelector;
     private final RatingCalculator ratingCalculator;
@@ -107,7 +108,7 @@ public class TipSelectorImpl implements TipSelector {
             tips.add(tip);
 
             if (reference.isPresent()) {
-                checkReference(reference.get(), rating);
+                checkReference(reference.get(), rating, walkValidator);
                 entryPoint = reference.get();
             }
 
@@ -126,9 +127,12 @@ public class TipSelectorImpl implements TipSelector {
         }
     }
 
-    private void checkReference(Hash reference, Map<Hash, Integer> rating)
-            throws InvalidAlgorithmParameterException {
-        if (!rating.containsKey(reference)) {
+    private void checkReference(Hash reference, Map<Hash, Integer> rating, WalkValidator walkValidator)
+            throws Exception {
+        if (config.getAlpha() == 0 && !walkValidator.isValid(reference)) {
+            throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_IS_INVALID);
+        }
+        else if (!rating.containsKey(reference)) {
             throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_TOO_OLD);
         }
     }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -129,11 +129,11 @@ public class TipSelectorImpl implements TipSelector {
 
     private void checkReference(Hash reference, Map<Hash, Integer> rating, WalkValidator walkValidator)
             throws Exception {
-        if (config.getAlpha() == 0 && !walkValidator.isValid(reference)) {
-            throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_IS_INVALID);
-        }
-        else if (!rating.containsKey(reference)) {
+        if (config.getAlpha() != 0 && !rating.containsKey(reference)) {
             throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_TOO_OLD);
+        }
+        else if (config.getAlpha() == 0 && !walkValidator.isValid(reference)) {
+            throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_IS_INVALID);
         }
     }
 }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -105,6 +105,7 @@ public class TipSelectorImpl implements TipSelector {
 
             //random walk
             List<Hash> tips = new LinkedList<>();
+            //ISSUE #786: walkValidator should become a state less dependency
             WalkValidator walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService, config);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);
@@ -129,6 +130,7 @@ public class TipSelectorImpl implements TipSelector {
         }
     }
 
+    //Because walkValidator currently can't be mocked, it is easier to test this private method directly
     @VisibleForTesting
     void checkReference(Hash reference, Map<Hash, Integer> rating, WalkValidator walkValidator)
             throws Exception {

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -105,7 +105,7 @@ public class TipSelectorImpl implements TipSelector {
 
             //random walk
             List<Hash> tips = new LinkedList<>();
-            //ISSUE #786: walkValidator should become a state less dependency
+            //ISSUE #786: walkValidator should become a stateless dependency
             WalkValidator walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService, config);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);

--- a/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
@@ -1,13 +1,15 @@
 package com.iota.iri.service.tipselection.impl;
 
 import com.iota.iri.conf.BaseIotaConfig;
-import com.iota.iri.conf.MainnetConfig;
 import com.iota.iri.conf.TipSelConfig;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.tipselection.*;
+import com.iota.iri.service.tipselection.EntryPointSelector;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.service.tipselection.WalkValidator;
+import com.iota.iri.service.tipselection.Walker;
 import com.iota.iri.storage.Tangle;
 
 import java.security.InvalidAlgorithmParameterException;
@@ -15,16 +17,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.openjdk.jmh.annotations.TearDown;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,7 +62,7 @@ public class TipSelectorImplTest {
     }
 
     @Before
-    public void setUpEach() throws Exception {
+    public void setUpEach() {
         when(config.getAlpha()).thenReturn(BaseIotaConfig.Defaults.ALPHA);
         tipSelector = new TipSelectorImpl(tangle, snapshotProvider, ledgerService, entryPointSelector, ratingCalculator,
                 walker, config);

--- a/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
@@ -1,0 +1,102 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.conf.BaseIotaConfig;
+import com.iota.iri.conf.MainnetConfig;
+import com.iota.iri.conf.TipSelConfig;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashFactory;
+import com.iota.iri.service.ledger.LedgerService;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.tipselection.*;
+import com.iota.iri.storage.Tangle;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.*;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.openjdk.jmh.annotations.TearDown;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TipSelectorImplTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private EntryPointSelector entryPointSelector;
+
+    @Mock
+    private RatingCalculator ratingCalculator;
+
+    @Mock
+    private Walker walker;
+
+    @Mock
+    private LedgerService ledgerService;
+
+    @Mock
+    private Tangle tangle;
+
+    @Mock
+    private SnapshotProvider snapshotProvider;
+
+    @Mock
+    private TipSelConfig config;
+
+    private static final Hash REFERENCE = HashFactory.TRANSACTION.create("ENTRYPOINT");
+
+    private TipSelectorImpl tipSelector;
+
+    public TipSelectorImplTest() {
+        //Empty Constructor
+    }
+
+    @Before
+    public void setUpEach() throws Exception {
+        when(config.getAlpha()).thenReturn(BaseIotaConfig.Defaults.ALPHA);
+        tipSelector = new TipSelectorImpl(tangle, snapshotProvider, ledgerService, entryPointSelector, ratingCalculator,
+                walker, config);
+    }
+
+    @Test
+    public void checkReferenceTest() throws Exception {
+        Map<Hash, Integer> map = new HashMap<Hash, Integer>(){{put(REFERENCE, 0);}};
+        tipSelector.checkReference(REFERENCE, map, null);
+        //test passes if no exceptions are thrown
+    }
+
+    @Test(expected = InvalidAlgorithmParameterException.class)
+    public void checkReferenceExceptionTest() throws Exception {
+        tipSelector.checkReference(REFERENCE, Collections.emptyMap(), null);
+        //test passes if exceptions is thrown
+    }
+
+    @Test
+    public void checkReferenceAlpha0Test() throws Exception {
+        WalkValidator walkValidator = mock(WalkValidator.class);
+        when(config.getAlpha()).thenReturn(0d);
+        when(walkValidator.isValid(REFERENCE)).thenReturn(true);
+        tipSelector.checkReference(REFERENCE, null, walkValidator);
+        //test passes if no exceptions are thrown
+    }
+
+    @Test(expected = InvalidAlgorithmParameterException.class)
+    public void checkReferenceAlpha0ExceptionTest() throws Exception {
+        WalkValidator walkValidator = mock(WalkValidator.class);
+        when(config.getAlpha()).thenReturn(0d);
+        when(walkValidator.isValid(REFERENCE)).thenReturn(false);
+        tipSelector.checkReference(REFERENCE, null, walkValidator);
+        //test passes if an exceptions is thrown
+    }
+}


### PR DESCRIPTION

## Description

In #1596 we introduced a bug. If one calls GTTA with the reference parameter, and no CW map was created, then we get an `InvalidAlgorithmParaemterException` since IRI assumes that we chose to promote a transaction that is not in the cone of our entrypoint milestone.

To fix this bug we do full validation on the `reference` transaction:
- It exists
- It is solid
- It is a tail (I don't think it was a requirement before, but as far as I am aware we should only promote tails)
- It is not below max depth
- It is consistent with our first tip.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests will be added before the merge

# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
