### PR TITLE
RatingOne filter for alpha == 0

### DIFF
--- a/python-regression/tests/features/machine3/config.yml
+++ b/python-regression/tests/features/machine3/config.yml
@@ -1,6 +1,6 @@
 defaults: &blowball_tests_config_files
   db: https://s3.eu-central-1.amazonaws.com/iotaledger-dbfiles/dev/Blowball_Tests_db.tar
-  db_checksum: 0e9017ee8e6bef601dd68f08200d4ff2290701d0e903da518097620fa8adb092
+  db_checksum: cf4da9fef58f74d8721eee7e2726f3321ecc2257ef111e6b8b2f4c348b40c980
   iri_args: ['--testnet-coordinator',
   'EFPNKGPCBXXXLIBYFGIGYBYTFFPIOQVNNVVWTTIYZO9NFREQGVGDQQHUUQ9CLWAEMXVDFSSMOTGAHVIBH',
   '--milestone-keys',

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -5,7 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Collections;
 
 import com.iota.iri.conf.TipSelConfig;
 import com.iota.iri.model.Hash;
@@ -13,6 +12,7 @@ import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.tipselection.EntryPointSelector;
 import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.service.tipselection.impl.RatingOne;
 import com.iota.iri.service.tipselection.TipSelector;
 import com.iota.iri.service.tipselection.WalkValidator;
 import com.iota.iri.service.tipselection.Walker;
@@ -95,7 +95,7 @@ public class TipSelectorImpl implements TipSelector {
             Hash entryPoint = entryPointSelector.getEntryPoint(depth);
             Map<Hash, Integer> rating;
             if(config.getAlpha() == 0) {
-                rating = Collections.EMPTY_MAP;
+                rating = new RatingOne(tangle).calculate(entryPoint);
             } else {
                 rating = ratingCalculator.calculate(entryPoint);
             }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -157,7 +157,7 @@ public class WalkerAlpha implements Walker {
                 }
             }
         } else {
-            approvers = approversSet.stream().collect(Collectors.toList());
+            approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
             if (approvers.size() == 0) {
                 return Optional.empty();
             }


### PR DESCRIPTION
# Description
Under the right spam conditions nodes have a tendency to spit out chains of transactions rather than a dag. The reason for this is that the alpha == 0 implementation does not filter out transactions added after the walk has started, and so, in higher tps environments, the spam will begin creating a chain of transactions due to the synchronised nature of the calls. This rating filter allows the DAG to spread out more evenly.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
-Tested on ICC network as well as in private networks set up locally. 4 nodes with GTTA spammers on each, and the spaghettification is mitigated significantly in higher TPS environments. 

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
