### PR TITLE
Feature: Truncate transaction bytes before persisting them to the database

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/PreProcessStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/PreProcessStage.java
@@ -6,7 +6,9 @@ import com.iota.iri.model.HashFactory;
 import com.iota.iri.network.FIFOCache;
 import com.iota.iri.network.TransactionCacheDigester;
 import com.iota.iri.network.protocol.Protocol;
+import com.iota.iri.network.protocol.ProtocolMessage;
 import com.iota.iri.utils.Converter;
+import com.iota.iri.utils.TransactionTruncator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +48,7 @@ public class PreProcessStage implements Stage {
         byte[] data = packetData.array();
 
         // expand received tx data
-        byte[] txDataBytes = Protocol.expandTx(data);
+        byte[] txDataBytes = TransactionTruncator.expandTransaction(data, ProtocolMessage.TRANSACTION_GOSSIP.getMaxLength());
         // copy requested tx hash
         byte[] reqHashBytes = Protocol.extractRequestedTxHash(data);
 

--- a/src/main/java/com/iota/iri/network/protocol/ProtocolMessage.java
+++ b/src/main/java/com/iota/iri/network/protocol/ProtocolMessage.java
@@ -1,5 +1,7 @@
 package com.iota.iri.network.protocol;
 
+import com.iota.iri.utils.TransactionTruncator;
+
 /**
  * Defines the different message types supported by the protocol and their characteristics.
  */
@@ -23,8 +25,8 @@ public enum ProtocolMessage {
      * The transaction payload + requested transaction hash gossipping packet. In reality most of this packets won't
      * take up their full 1604 bytes as the signature message fragment of the tx is truncated.
      */
-    TRANSACTION_GOSSIP((byte) 2, (short) (Protocol.GOSSIP_REQUESTED_TX_HASH_BYTES_LENGTH + Protocol.NON_SIG_TX_PART_BYTES_LENGTH
-            + Protocol.SIG_DATA_MAX_BYTES_LENGTH), true);
+    TRANSACTION_GOSSIP((byte) 2, (short) (Protocol.GOSSIP_REQUESTED_TX_HASH_BYTES_LENGTH + TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH
+            + TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH), true);
 
     private static final ProtocolMessage[] lookup = new ProtocolMessage[256];
 

--- a/src/main/java/com/iota/iri/utils/TransactionTruncator.java
+++ b/src/main/java/com/iota/iri/utils/TransactionTruncator.java
@@ -2,6 +2,9 @@ package com.iota.iri.utils;
 
 import com.iota.iri.model.persistables.Transaction;
 
+/**
+ * Provides utility methods to truncate and expand raw transaction data.
+ */
 public class TransactionTruncator {
 
     /**

--- a/src/main/java/com/iota/iri/utils/TransactionTruncator.java
+++ b/src/main/java/com/iota/iri/utils/TransactionTruncator.java
@@ -1,0 +1,71 @@
+package com.iota.iri.utils;
+
+import com.iota.iri.model.persistables.Transaction;
+
+public class TransactionTruncator {
+
+    /**
+     * The max amount of bytes a signature message fragment is made up from.
+     */
+    public final static int SIG_DATA_MAX_BYTES_LENGTH = 1312;
+    /**
+     * The amount of bytes making up the non signature message fragment part of a transaction.
+     */
+    public final static int NON_SIG_TX_PART_BYTES_LENGTH = 292;
+
+    /**
+     * Truncates the given byte encoded transaction by removing unneeded bytes from the signature message fragment.
+     *
+     * @param txBytes the transaction bytes to truncate
+     * @return an array containing the truncated transaction data
+     */
+    public static byte[] truncateTransaction(byte[] txBytes) {
+        // check how many bytes from the signature can be truncated
+        int bytesToTruncate = 0;
+        for (int i = SIG_DATA_MAX_BYTES_LENGTH - 1; i >= 0; i--) {
+            if (txBytes[i] != 0) {
+                break;
+            }
+            bytesToTruncate++;
+        }
+        // allocate space for truncated tx
+        byte[] truncatedTx = new byte[SIG_DATA_MAX_BYTES_LENGTH - bytesToTruncate + NON_SIG_TX_PART_BYTES_LENGTH];
+        System.arraycopy(txBytes, 0, truncatedTx, 0, SIG_DATA_MAX_BYTES_LENGTH - bytesToTruncate);
+        System.arraycopy(txBytes, SIG_DATA_MAX_BYTES_LENGTH, truncatedTx, SIG_DATA_MAX_BYTES_LENGTH - bytesToTruncate,
+                NON_SIG_TX_PART_BYTES_LENGTH);
+        return truncatedTx;
+    }
+
+    /**
+     * Expands an array containing a truncated transaction using a given reference size
+     * to determine the amount of bytes to pad.
+     *
+     * @param data          the truncated transaction data to be expanded
+     * @param referenceSize the max size to use as a reference to compute the bytes to be added
+     * @return an array containing the expanded transaction data
+     */
+    public static byte[] expandTransaction(byte[] data, int referenceSize) {
+        byte[] txDataBytes = new byte[Transaction.SIZE];
+        int numOfBytesOfSigMsgFragToExpand = referenceSize - data.length;
+        byte[] sigMsgFragPadding = new byte[numOfBytesOfSigMsgFragToExpand];
+        int sigMsgFragBytesToCopy = data.length - TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH;
+
+        // build up transaction payload. empty signature message fragment equals padding with 1312x 0 bytes
+        System.arraycopy(data, 0, txDataBytes, 0, sigMsgFragBytesToCopy);
+        System.arraycopy(sigMsgFragPadding, 0, txDataBytes, sigMsgFragBytesToCopy, sigMsgFragPadding.length);
+        System.arraycopy(data, sigMsgFragBytesToCopy, txDataBytes, TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH,
+                TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH);
+        return txDataBytes;
+    }
+
+    /**
+     * Expands an array containing a truncated transaction.
+     *
+     * @param data the truncated transaction data to be expanded
+     * @return an array containing the expanded transaction data
+     */
+    public static byte[] expandTransaction(byte[] data) {
+        return expandTransaction(data, Transaction.SIZE);
+    }
+
+}

--- a/src/main/java/com/iota/iri/utils/TransactionTruncator.java
+++ b/src/main/java/com/iota/iri/utils/TransactionTruncator.java
@@ -51,7 +51,10 @@ public class TransactionTruncator {
         byte[] txDataBytes = new byte[Transaction.SIZE];
         int numOfBytesOfSigMsgFragToExpand = referenceSize - data.length;
         byte[] sigMsgFragPadding = new byte[numOfBytesOfSigMsgFragToExpand];
-        int sigMsgFragBytesToCopy = data.length - TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH;
+        // we deduct the transaction bytes size from the reference to get the correct
+        // length of signature message bytes we need to copy from the source data
+        int sigMsgFragBytesToCopy = data.length - (referenceSize - Transaction.SIZE)
+                - TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH;
 
         // build up transaction payload. empty signature message fragment equals padding with 1312x 0 bytes
         System.arraycopy(data, 0, txDataBytes, 0, sigMsgFragBytesToCopy);

--- a/src/test/java/com/iota/iri/TransactionTestUtils.java
+++ b/src/test/java/com/iota/iri/TransactionTestUtils.java
@@ -10,12 +10,31 @@ import com.iota.iri.utils.Converter;
 
 import java.util.Random;
 
+import com.iota.iri.utils.TransactionTruncator;
 import org.apache.commons.lang3.StringUtils;
 
 public class TransactionTestUtils {
 
     private static Random seed = new Random(1);
-    
+
+    public final static int NON_EMPTY_SIG_PART_BYTES_COUNT = 1000;
+    public final static int TRUNCATION_BYTES_COUNT = TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH - NON_EMPTY_SIG_PART_BYTES_COUNT;
+    public final static int SIG_FILL = 3, REST_FILL = 4, EMPTY_FILL = 0;
+
+    public static byte[] constructTransactionBytes() {
+        byte[] originTxData = new byte[Transaction.SIZE];
+        for (int i = 0; i < NON_EMPTY_SIG_PART_BYTES_COUNT; i++) {
+            originTxData[i] = SIG_FILL;
+        }
+        for (int i = NON_EMPTY_SIG_PART_BYTES_COUNT; i < TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH; i++) {
+            originTxData[i] = EMPTY_FILL;
+        }
+        for (int i = TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH; i < Transaction.SIZE; i++) {
+            originTxData[i] = REST_FILL;
+        }
+        return originTxData;
+    }
+
     /**
      * Updates the transaction index in trits.
      * 

--- a/src/test/java/com/iota/iri/TransactionTestUtils.java
+++ b/src/test/java/com/iota/iri/TransactionTestUtils.java
@@ -21,6 +21,12 @@ public class TransactionTestUtils {
     public final static int TRUNCATION_BYTES_COUNT = TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH - NON_EMPTY_SIG_PART_BYTES_COUNT;
     public final static int SIG_FILL = 3, REST_FILL = 4, EMPTY_FILL = 0;
 
+    /**
+     * Constructs transaction bytes where the signature message fragment is filled with 1000
+     * {@link TransactionTestUtils#SIG_FILL} bytes, 312 {@link TransactionTestUtils#EMPTY_FILL} bytes and
+     * the non signature message fragment part with 292 {@link TransactionTestUtils#REST_FILL} bytes.
+     * @return byte data of the transaction
+     */
     public static byte[] constructTransactionBytes() {
         byte[] originTxData = new byte[Transaction.SIZE];
         for (int i = 0; i < NON_EMPTY_SIG_PART_BYTES_COUNT; i++) {

--- a/src/test/java/com/iota/iri/network/SampleTransaction.java
+++ b/src/test/java/com/iota/iri/network/SampleTransaction.java
@@ -8,6 +8,7 @@ import com.iota.iri.model.persistables.Transaction;
 import com.iota.iri.network.protocol.Protocol;
 import com.iota.iri.network.protocol.ProtocolMessage;
 import com.iota.iri.utils.Converter;
+import com.iota.iri.utils.TransactionTruncator;
 import net.openhft.hashing.LongHashFunction;
 
 import java.nio.ByteBuffer;
@@ -40,7 +41,7 @@ public class SampleTransaction {
         for (int i = 0; i < SIG_FILLED_COUNT; i++) {
             raw[i] = SIG_FILL;
         }
-        TRUNCATED_SAMPLE_TX_BYTES = Protocol.truncateTx(raw);
+        TRUNCATED_SAMPLE_TX_BYTES = TransactionTruncator.truncateTransaction(raw);
 
         SAMPLE_TRANSACTION = new Transaction();
         SAMPLE_TRANSACTION.bytes = BYTES_OF_SAMPLE_TX;

--- a/src/test/java/com/iota/iri/network/protocol/ProtocolTest.java
+++ b/src/test/java/com/iota/iri/network/protocol/ProtocolTest.java
@@ -1,5 +1,6 @@
 package com.iota.iri.network.protocol;
 
+import com.iota.iri.TransactionTestUtils;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.persistables.Transaction;
@@ -12,10 +13,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class ProtocolTest {
-
-    private int nonEmptySigPartBytesCount = 1000;
-    private int truncationBytesCount = Protocol.SIG_DATA_MAX_BYTES_LENGTH - nonEmptySigPartBytesCount;
-    final private int sigFill = 3, restFill = 4, emptyFill = 0;
 
     @Test
     public void parsingHeaderWithUnknownMessageTypeThrows() {
@@ -77,7 +74,7 @@ public class ProtocolTest {
         assertEquals("should have correct length",
                 (maxLength - (maxLength - 60) + Protocol.SUPPORTED_PROTOCOL_VERSIONS.length), buf.getShort());
         assertEquals("should resolve to the correct source port", ownSourcePort, buf.getChar());
-        assertTrue("timestamp in handshake packet should be same age or newer than timestamp",now <= buf.getLong());
+        assertTrue("timestamp in handshake packet should be same age or newer than timestamp", now <= buf.getLong());
         byte[] actualCooAddress = new byte[Handshake.BYTE_ENCODED_COO_ADDRESS_BYTES_LENGTH];
         buf.get(actualCooAddress);
         assertArrayEquals("should resolve to the correct coo address", byteEncodedCooAddress, actualCooAddress);
@@ -88,77 +85,17 @@ public class ProtocolTest {
                 supportedVersions);
     }
 
-    private byte[] constructTransactionBytes() {
-        byte[] originTxData = new byte[Transaction.SIZE];
-        for (int i = 0; i < nonEmptySigPartBytesCount; i++) {
-            originTxData[i] = sigFill;
-        }
-        for (int i = nonEmptySigPartBytesCount; i < Protocol.SIG_DATA_MAX_BYTES_LENGTH; i++) {
-            originTxData[i] = emptyFill;
-        }
-        for (int i = Protocol.SIG_DATA_MAX_BYTES_LENGTH; i < Transaction.SIZE; i++) {
-            originTxData[i] = restFill;
-        }
-        return originTxData;
-    }
-
     @Test
     public void createTransactionGossipPacket() {
         Transaction sourceTx = new Transaction();
-        sourceTx.bytes = constructTransactionBytes();
+        sourceTx.bytes = TransactionTestUtils.constructTransactionBytes();
         TransactionViewModel tvm = new TransactionViewModel(sourceTx, null);
         ByteBuffer buf = Protocol.createTransactionGossipPacket(tvm, Hash.NULL_HASH.bytes());
-        final int expectedMessageSize = Transaction.SIZE - truncationBytesCount
+        final int expectedMessageSize = Transaction.SIZE - TransactionTestUtils.TRUNCATION_BYTES_COUNT
                 + Protocol.GOSSIP_REQUESTED_TX_HASH_BYTES_LENGTH;
         assertEquals("buffer should have the right capacity",
                 Protocol.PROTOCOL_HEADER_BYTES_LENGTH + expectedMessageSize, buf.capacity());
         assertEquals("should be of type tx gossip message", ProtocolMessage.TRANSACTION_GOSSIP.getTypeID(), buf.get());
         assertEquals("should have correct message length", expectedMessageSize, buf.getShort());
-    }
-
-    @Test
-    public void expandTx() {
-        int truncatedSize = 1000;
-        byte[] truncatedTxData = new byte[truncatedSize];
-        for (int i = 0; i < truncatedSize; i++) {
-            truncatedTxData[i] = 3;
-        }
-        byte[] expandedTxData = Protocol.expandTx(truncatedTxData);
-
-        // stuff after signature message fragment should be intact
-        for (int i = expandedTxData.length - 1; i >= Protocol.SIG_DATA_MAX_BYTES_LENGTH; i--) {
-            assertEquals("non sig data should be intact", 3, expandedTxData[i]);
-        }
-
-        // bytes between truncated signature message fragment and rest should be 0s
-        int expandedBytesCount = truncatedSize - Protocol.NON_SIG_TX_PART_BYTES_LENGTH;
-        for (int i = Protocol.SIG_DATA_MAX_BYTES_LENGTH - 1; i > expandedBytesCount; i--) {
-            assertEquals("expanded sig frag should be filled with zero at the right positions", 0, expandedTxData[i]);
-        }
-
-        // origin signature message fragment should be intact
-        for (int i = 0; i < Protocol.SIG_DATA_MAX_BYTES_LENGTH - expandedBytesCount; i++) {
-            assertEquals("origin sig frag should be intact", 3, expandedTxData[i]);
-        }
-    }
-
-    @Test
-    public void truncateTx() {
-        byte[] originTxData = constructTransactionBytes();
-        byte[] truncatedTx = Protocol.truncateTx(originTxData);
-        assertEquals("should have the correct size after truncation", Transaction.SIZE - truncationBytesCount,
-                truncatedTx.length);
-
-        for (int i = 0; i < nonEmptySigPartBytesCount; i++) {
-            assertEquals("non empty sig frag part should be intact", sigFill, truncatedTx[i]);
-        }
-        for (int i = truncatedTx.length - 1; i > truncatedTx.length - Protocol.NON_SIG_TX_PART_BYTES_LENGTH; i--) {
-            assertEquals("non sig frag part should be intact", restFill, truncatedTx[i]);
-        }
-        for (int i = 0; i < truncatedTx.length; i++) {
-            assertNotEquals(
-                    "truncated tx should not have zero bytes (given the non sig frag part not containing zero bytes)",
-                    emptyFill, truncatedTx[i]);
-        }
     }
 }

--- a/src/test/java/com/iota/iri/utils/TransactionTruncatorTest.java
+++ b/src/test/java/com/iota/iri/utils/TransactionTruncatorTest.java
@@ -1,0 +1,57 @@
+package com.iota.iri.utils;
+
+import com.iota.iri.TransactionTestUtils;
+import com.iota.iri.model.persistables.Transaction;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TransactionTruncatorTest {
+
+    @Test
+    public void truncateByteEncodedTransaction() {
+        byte[] originTxData = TransactionTestUtils.constructTransactionBytes();
+        byte[] truncatedTx = TransactionTruncator.truncateTransaction(originTxData);
+        assertEquals("should have the correct size after truncation",
+                Transaction.SIZE - TransactionTestUtils.TRUNCATION_BYTES_COUNT,
+                truncatedTx.length);
+
+        for (int i = 0; i < TransactionTestUtils.NON_EMPTY_SIG_PART_BYTES_COUNT; i++) {
+            assertEquals("non empty sig frag part should be intact", TransactionTestUtils.SIG_FILL, truncatedTx[i]);
+        }
+        for (int i = truncatedTx.length - 1; i > truncatedTx.length - TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH; i--) {
+            assertEquals("non sig frag part should be intact", TransactionTestUtils.REST_FILL, truncatedTx[i]);
+        }
+        for (int i = 0; i < truncatedTx.length; i++) {
+            assertNotEquals(
+                    "truncated tx should not have zero bytes (given the non sig frag part not containing zero bytes)",
+                    TransactionTestUtils.EMPTY_FILL, truncatedTx[i]);
+        }
+    }
+
+    @Test
+    public void expandTruncatedByteEncodedTransaction() {
+        int truncatedSize = 1000;
+        byte[] truncatedTxData = new byte[truncatedSize];
+        for (int i = 0; i < truncatedSize; i++) {
+            truncatedTxData[i] = 3;
+        }
+        byte[] expandedTxData = TransactionTruncator.expandTransaction(truncatedTxData);
+
+        // stuff after signature message fragment should be intact
+        for (int i = expandedTxData.length - 1; i >= TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH; i--) {
+            assertEquals("non sig data should be intact", 3, expandedTxData[i]);
+        }
+
+        // bytes between truncated signature message fragment and rest should be 0s
+        int expandedBytesCount = truncatedSize - TransactionTruncator.NON_SIG_TX_PART_BYTES_LENGTH;
+        for (int i = TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH - 1; i > expandedBytesCount; i--) {
+            assertEquals("expanded sig frag should be filled with zero at the right positions", 0, expandedTxData[i]);
+        }
+
+        // origin signature message fragment should be intact
+        for (int i = 0; i < TransactionTruncator.SIG_DATA_MAX_BYTES_LENGTH - expandedBytesCount; i++) {
+            assertEquals("origin sig frag should be intact", 3, expandedTxData[i]);
+        }
+    }
+}

--- a/src/test/java/com/iota/iri/utils/dag/DAGHelperTest.java
+++ b/src/test/java/com/iota/iri/utils/dag/DAGHelperTest.java
@@ -1,5 +1,6 @@
 package com.iota.iri.utils.dag;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashSet;
@@ -78,7 +79,7 @@ public class DAGHelperTest {
         assertEquals("Last transaction hash should have been C", tx.getHash(), C);
         assertEquals("Last transaction should have TX3 its address", tx.getAddressHash(), TX3.address);
         assertEquals("Last transaction should have TX3 its timestamp", tx.getAttachmentTimestamp(), TX3.attachmentTimestamp);
-        assertEquals("Last transaction should have TX3 its bytes", tx.getBytes(), TX3.bytes());
+        assertArrayEquals("Last transaction should have TX3 its bytes", tx.getTransaction().bytes(), TX3.bytes());
     }
         
 
@@ -102,7 +103,7 @@ public class DAGHelperTest {
         assertEquals("Last transaction hash should have been the genisis hash", tx.getHash(), Hash.NULL_HASH);
         assertEquals("Last transaction should have TX1 its address", tx.getAddressHash(), TX1.address);
         assertEquals("Last transaction should have TX1 its timestamp", tx.getAttachmentTimestamp(), TX1.attachmentTimestamp);
-        assertEquals("Last transaction should have TX1 its bytes", tx.getBytes(), TX1.bytes());
+        assertArrayEquals("Last transaction should have TX1 its bytes", tx.getTransaction().bytes(), TX1.bytes());
     }
 
 }


### PR DESCRIPTION
# Description
Lets the `Transaction` `Persistable` truncate the transaction bytes up on saving it by removing zero bytes from the signature message fragment (from the right). Up on loading a transaction, the bytes are back expanded to their full capacity (1604 bytes). This reduces the stored size of a transaction up to 81% (given a complete empty signature message fragment).

Fixes # (issue)
https://github.com/iotaledger/iri/issues/1626

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Moved the expand/truncate methods from the `Protocol` class to a new separate class called `TransactionTruncator` and writing relevant unit tests for it.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
