### PR TITLE
Feature: Set alpha to zero

### DIFF
--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -873,7 +873,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
 
         //TipSel
         int MAX_DEPTH = 15;
-        double ALPHA = 0.001d;
+        double ALPHA = 0d;
         int TIP_SELECTION_TIMEOUT_SEC = 60;
 
         //PearlDiver


### PR DESCRIPTION
# Description
Changes the `α` value to zero and thus lets the node skip cumulative weight calculation during tip-selection.

Fixes # (issue)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Running existing unit tests.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
