### PR TITLE
Added non-0 zero alpha to test configuration

### DIFF
--- a/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
@@ -1,16 +1,7 @@
 package com.iota.iri.service.tipselection.impl;
 
-import com.iota.iri.conf.BaseIotaConfig;
-import com.iota.iri.conf.TipSelConfig;
-import com.iota.iri.model.Hash;
-import com.iota.iri.model.HashFactory;
-import com.iota.iri.service.ledger.LedgerService;
-import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.tipselection.EntryPointSelector;
-import com.iota.iri.service.tipselection.RatingCalculator;
-import com.iota.iri.service.tipselection.WalkValidator;
-import com.iota.iri.service.tipselection.Walker;
-import com.iota.iri.storage.Tangle;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.util.Collections;
@@ -24,8 +15,17 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.iota.iri.conf.BaseIotaConfig;
+import com.iota.iri.conf.TipSelConfig;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashFactory;
+import com.iota.iri.service.ledger.LedgerService;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.tipselection.EntryPointSelector;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.service.tipselection.WalkValidator;
+import com.iota.iri.service.tipselection.Walker;
+import com.iota.iri.storage.Tangle;
 
 public class TipSelectorImplTest {
 
@@ -70,6 +70,7 @@ public class TipSelectorImplTest {
 
     @Test
     public void checkReferenceTest() throws Exception {
+        when(config.getAlpha()).thenReturn(0.001d);
         Map<Hash, Integer> map = new HashMap<Hash, Integer>(){{put(REFERENCE, 0);}};
         tipSelector.checkReference(REFERENCE, map, null);
         //test passes if no exceptions are thrown
@@ -77,6 +78,7 @@ public class TipSelectorImplTest {
 
     @Test(expected = InvalidAlgorithmParameterException.class)
     public void checkReferenceExceptionTest() throws Exception {
+        when(config.getAlpha()).thenReturn(0.001d);
         tipSelector.checkReference(REFERENCE, Collections.emptyMap(), null);
         //test passes if exceptions is thrown
     }


### PR DESCRIPTION
# Description

Since we changed default alpha to 0, the tipselImpltest behaves different.
Adding the value a>0 fixes this issue.

This was not seen before since the tests were made separate of the alpha change

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit tests pass, node runs tipsel properly under 10 TPS load

# Checklist:
- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
