### PR TITLE
Fix: Correct walker behaviour for alpha == 0

### DIFF
--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -128,7 +128,7 @@ public class WalkerAlpha implements Walker {
         int approverIndex;
 
         //Check if ratings map is empty. If so, alpha was set to 0 and a random approver will be selected.
-        if(!Collections.EMPTY_MAP.equals(ratings)) {
+        if(alpha != 0) {
             //filter based on tangle state when starting the walk            
             approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
             //After filtering, if no approvers are available, it's a tip.
@@ -161,7 +161,7 @@ public class WalkerAlpha implements Walker {
             if (approvers.size() == 0) {
                 return Optional.empty();
             }
-            approverIndex = random.nextInt(approversSet.size());
+            approverIndex = random.nextInt(approvers.size());
         }
         return Optional.of(approvers.get(approverIndex));
     }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -134,7 +134,7 @@ public class WalkerAlpha implements Walker {
             return Optional.empty();
         }
 
-        //Check if ratings map is empty. If so, alpha was set to 0 and a random approver will be selected.
+        //Check if alpha was set to 0. If so, weight calculations are skipped and a random approver will be selected.
         if(alpha != 0) {
             //calculate the probabilities
             List<Integer> walkRatings = approvers.stream().map(ratings::get).collect(Collectors.toList());

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -127,15 +127,15 @@ public class WalkerAlpha implements Walker {
         List<Hash> approvers;         
         int approverIndex;
 
+        //filter based on tangle state when starting the walk
+        approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
+        //After filtering, if no approvers are available, it's a tip.
+        if (approvers.size() == 0) {
+            return Optional.empty();
+        }
+
         //Check if ratings map is empty. If so, alpha was set to 0 and a random approver will be selected.
         if(alpha != 0) {
-            //filter based on tangle state when starting the walk            
-            approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
-            //After filtering, if no approvers are available, it's a tip.
-            if (approvers.size() == 0) {
-                return Optional.empty();
-            }
-
             //calculate the probabilities
             List<Integer> walkRatings = approvers.stream().map(ratings::get).collect(Collectors.toList());
 
@@ -157,10 +157,6 @@ public class WalkerAlpha implements Walker {
                 }
             }
         } else {
-            approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
-            if (approvers.size() == 0) {
-                return Optional.empty();
-            }
             approverIndex = random.nextInt(approvers.size());
         }
         return Optional.of(approvers.get(approverIndex));


### PR DESCRIPTION
# Description

Currently the walker uses an `if(!Collections.EMPTY_MAP.equals(ratings))` check to determine if the alpha value is 0 in the walker. But since the ratings list is is provided by `ratingOne` this list is not empty. Therefore the node is still performing the walk as though the alpha is not 0. The improved behaviour from not doing the ratings calculation has been the result of the alpha 0 change, but having the walk skip the additional unnecessary calculations on the walk end should show another improvement to response time. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

-Set a break point in the walker to make sure that the walk is registering the correct alpha value and using the correct logic


# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
