### PR TITLE
Add broadcast queue

### DIFF
--- a/src/main/java/com/iota/iri/IRI.java
+++ b/src/main/java/com/iota/iri/IRI.java
@@ -7,6 +7,7 @@ import com.iota.iri.conf.Config;
 import com.iota.iri.conf.ConfigFactory;
 import com.iota.iri.conf.IotaConfig;
 import com.iota.iri.network.NetworkInjectionConfiguration;
+import com.iota.iri.network.pipeline.BroadcastQueue;
 import com.iota.iri.service.API;
 import com.iota.iri.utils.IotaUtils;
 import com.iota.iri.service.restserver.resteasy.RestEasy;
@@ -119,6 +120,7 @@ public class IRI {
         public static void main(String [] args) throws Exception {
             IotaConfig config = createConfiguration(args);
             String version = IotaUtils.getIriVersion();
+            BroadcastQueue broadcastQueue = config.getBroadcastQueue();
             log.info("Welcome to {} {}", config.isTestnet() ? TESTNET_NAME : MAINNET_NAME, version);
 
             Injector injector = Guice.createInjector(
@@ -132,6 +134,7 @@ public class IRI {
             shutdownHook();
 
             try {
+                iota.configureBroadcastQueue(broadcastQueue);
                 iota.init();
                 //TODO redundant parameter but we will touch this when we refactor IXI
                 ixi.init(config.getIxiDir());

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -6,6 +6,7 @@ import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.network.NeighborRouter;
 import com.iota.iri.network.TipsRequester;
 import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.network.pipeline.BroadcastQueue;
 import com.iota.iri.network.pipeline.TransactionProcessingPipeline;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.milestone.*;
@@ -106,6 +107,8 @@ public class Iota {
     public final TipsViewModel tipsViewModel;
     public final TipSelector tipsSelector;
 
+    private BroadcastQueue broadcastQueue;
+
     /**
      * Initializes the latest snapshot and then creates all services needed to run an IOTA node.
      *
@@ -181,7 +184,7 @@ public class Iota {
             tangle.clearMetadata(com.iota.iri.model.persistables.Transaction.class);
         }
 
-        transactionValidator.init();
+        transactionValidator.init(this.broadcastQueue);
 
         txPipeline.start();
         neighborRouter.start();
@@ -272,6 +275,14 @@ public class Iota {
         if (configuration.isZmqEnabled()) {
             tangle.addMessageQueueProvider(new ZmqMessageQueueProvider(configuration));
         }
+    }
+
+    /**
+     * Sets the {@link BroadcastQueue} for this IRI instance
+     * @param broadcastQueue Baseline IRI {@link BroadcastQueue}
+     */
+    public void configureBroadcastQueue(BroadcastQueue broadcastQueue){
+        this.broadcastQueue = broadcastQueue;
     }
 
     /**

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -10,6 +10,7 @@ import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.TransactionHash;
 import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.network.pipeline.BroadcastQueue;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.storage.Tangle;
 import org.slf4j.Logger;
@@ -33,7 +34,7 @@ public class TransactionValidator {
     private static final long MAX_TIMESTAMP_FUTURE = 2L * 60L * 60L;
     private static final long MAX_TIMESTAMP_FUTURE_MS = MAX_TIMESTAMP_FUTURE * 1_000L;
 
-
+    private BroadcastQueue broadcastQueue;
     /////////////////////////////////fields for solidification thread//////////////////////////////////////
 
     private Thread newSolidThread;
@@ -85,7 +86,8 @@ public class TransactionValidator {
      *
      * @see #spawnSolidTransactionsPropagation()
      */
-    public void init() {
+    public void init(BroadcastQueue broadcastQueue) {
+        this.broadcastQueue = broadcastQueue;
         newSolidThread.start();
     }
 
@@ -277,7 +279,7 @@ public class TransactionValidator {
             }
         }
         if (solid) {
-            updateSolidTransactions(tangle, snapshotProvider.getInitialSnapshot(), analyzedHashes);
+            updateSolidTransactions(tangle, snapshotProvider.getInitialSnapshot(), analyzedHashes, broadcastQueue);
         }
         analyzedHashes.clear();
         return solid;

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -4,12 +4,14 @@ import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
 import com.iota.iri.utils.IotaUtils;
+import com.iota.iri.network.pipeline.BroadcastQueue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.concurrent.BlockingQueue;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
@@ -56,6 +58,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected boolean dnsRefresherEnabled = Defaults.DNS_REFRESHER_ENABLED;
     protected boolean dnsResolutionEnabled = Defaults.DNS_RESOLUTION_ENABLED;
     protected List<String> neighbors = Collections.EMPTY_LIST;
+    protected BroadcastQueue broadcastQueue = new BroadcastQueue();
 
     //IXI
     protected String ixiDir = Defaults.IXI_DIR;
@@ -167,6 +170,11 @@ public abstract class BaseIotaConfig implements IotaConfig {
         }
         
         return apiHost;
+    }
+
+    @Override
+    public BroadcastQueue getBroadcastQueue() {
+        return broadcastQueue;
     }
 
     @JsonProperty

--- a/src/main/java/com/iota/iri/conf/NetworkConfig.java
+++ b/src/main/java/com/iota/iri/conf/NetworkConfig.java
@@ -1,5 +1,7 @@
 package com.iota.iri.conf;
 
+import com.iota.iri.network.pipeline.BroadcastQueue;
+
 import java.util.List;
 
 /**
@@ -88,6 +90,11 @@ public interface NetworkConfig extends Config {
      * @return {@value NetworkConfig.Descriptions#CACHE_SIZE_BYTES}
      */
     int getCacheSizeBytes();
+
+    /**
+     * @return The current {@link BroadcastQueue}
+     */
+    BroadcastQueue getBroadcastQueue();
 
     interface Descriptions {
         String NEIGHBORING_SOCKET_ADDRESS = "The address to bind the TCP server socket to.";

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -2,6 +2,9 @@ package com.iota.iri.controllers;
 
 import com.iota.iri.model.*;
 import com.iota.iri.model.persistables.*;
+import com.iota.iri.network.pipeline.BroadcastQueue;
+import com.iota.iri.network.pipeline.ProcessingContext;
+import com.iota.iri.network.pipeline.BroadcastPayload;
 import com.iota.iri.service.snapshot.Snapshot;
 import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
@@ -712,7 +715,8 @@ public class TransactionViewModel {
                 : TransactionViewModel.FILLED_SLOT;
     }
 
-    public static void updateSolidTransactions(Tangle tangle, Snapshot initialSnapshot, final LinkedHashSet<Hash> analyzedHashes)
+    public static void updateSolidTransactions(Tangle tangle, Snapshot initialSnapshot,
+                                               final LinkedHashSet<Hash> analyzedHashes, BroadcastQueue broadcastQueue)
             throws Exception {
         Object[] hashes = analyzedHashes.toArray();
         TransactionViewModel transactionViewModel;
@@ -724,6 +728,8 @@ public class TransactionViewModel {
             if (!transactionViewModel.isSolid()) {
                 transactionViewModel.updateSolid(true);
                 transactionViewModel.update(tangle, initialSnapshot, "solid|height");
+                BroadcastPayload payload = new BroadcastPayload(null,transactionViewModel);
+                broadcastQueue.add(new ProcessingContext(payload));
             }
         }
     }

--- a/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
+++ b/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
@@ -48,7 +48,8 @@ public class NetworkInjectionConfiguration extends AbstractModule {
             TipsViewModel tipsViewModel, LatestMilestoneTracker latestMilestoneTracker,
             TransactionRequester transactionRequester) {
         return new TransactionProcessingPipelineImpl(neighborRouter, configuration, txValidator, tangle,
-                snapshotProvider, tipsViewModel, latestMilestoneTracker, transactionRequester);
+                snapshotProvider, tipsViewModel, latestMilestoneTracker, transactionRequester,
+                configuration.getBroadcastQueue());
     }
 
     @Singleton

--- a/src/main/java/com/iota/iri/network/pipeline/BroadcastQueue.java
+++ b/src/main/java/com/iota/iri/network/pipeline/BroadcastQueue.java
@@ -1,0 +1,46 @@
+package com.iota.iri.network.pipeline;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * A queue for transactions intended to be submitted to the {@link BroadcastStage}
+ * for processing
+ */
+public class BroadcastQueue {
+
+    /** A blocking queue to store transactions for broadcasting */
+    private BlockingQueue<ProcessingContext> broadcastStageQueue = new ArrayBlockingQueue<>(100);
+
+    /** An object to be used for synchronizing calls */
+    private final Object broadcastSync = new Object();
+
+
+    /**
+     * Add transactions to the Broadcast Queue
+     * @param context Transaction context to be passed to the {@link BroadcastStage}
+     * @return True if added properly, False if not
+     */
+    public boolean add(ProcessingContext context) {
+        synchronized (broadcastSync) {
+            try {
+                this.broadcastStageQueue.put(context);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+    }
+
+    /**
+     * Getter for the current Broadcast Queue
+     * @return BlockingQueue of all transactions left to be broadcasted
+     */
+    public BlockingQueue<ProcessingContext> get(){
+        /** Call is synchronized to ensure all pending additions have completed before sending the state */
+        synchronized (broadcastSync) {
+            return this.broadcastStageQueue;
+        }
+    }
+}

--- a/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
+++ b/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
@@ -121,7 +121,6 @@ public class TransactionProcessingPipelineImpl implements TransactionProcessingP
                 while (!Thread.currentThread().isInterrupted()) {
                     ProcessingContext queueTake;
                     if(name.equals("broadcast")) {
-                        log.info("Broadcasting");
                         queueTake = broadcastStageQueue.get().take();
                     } else{
                         queueTake = queue.take();

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -7,6 +7,7 @@ import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.TransactionHash;
 import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.network.pipeline.BroadcastQueue;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.impl.SnapshotMockUtils;
 import com.iota.iri.storage.Tangle;
@@ -42,6 +43,9 @@ public class TransactionValidatorTest {
   @Mock
   private static SnapshotProvider snapshotProvider;
 
+  @Mock
+  private static BroadcastQueue broadcastQueue;
+
   @BeforeClass
   public static void setUp() throws Exception {
     dbFolder.create();
@@ -67,6 +71,7 @@ public class TransactionValidatorTest {
     TransactionRequester txRequester = new TransactionRequester(tangle, snapshotProvider);
     txValidator = new TransactionValidator(tangle, snapshotProvider, tipsViewModel, txRequester, new MainnetConfig());
     txValidator.setMwm(false, MAINNET_MWM);
+    txValidator.init(broadcastQueue);
   }
 
   @Test


### PR DESCRIPTION
# Description
Abstract the broadcast queue to allow solidification and networking operations to place transactions in the `BroadcastStage`. This improves the speed that transactions are broadcast to neighbours to improve synchronisation as well as allow neighbour nodes to receive newly added transactions faster. Improves state of the tangle in higher concentrated TPS environments. 

Fixes #1512 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
-High throughput spam mixing correctly with lower throughput spam from neighbouring node 

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
