### PR TITLE
Adds config option to disable sync progress printing

### DIFF
--- a/src/main/java/com/iota/iri/MainInjectionConfiguration.java
+++ b/src/main/java/com/iota/iri/MainInjectionConfiguration.java
@@ -124,7 +124,7 @@ public class MainInjectionConfiguration extends AbstractModule {
             MilestoneService milestoneService, LedgerService ledgerService,
             LatestMilestoneTracker latestMilestoneTracker, TransactionRequester transactionRequester) {
         return new LatestSolidMilestoneTrackerImpl(tangle, snapshotProvider, milestoneService, ledgerService,
-                latestMilestoneTracker, transactionRequester);
+                latestMilestoneTracker, transactionRequester, configuration);
     }
 
     @Singleton

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -106,6 +106,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected String spentAddressesDbPath = Defaults.SPENT_ADDRESSES_DB_PATH;
     protected String spentAddressesDbLogPath = Defaults.SPENT_ADDRESSES_DB_LOG_PATH;
 
+    //Solidification
+    protected boolean printSyncProgressEnabled = Defaults.PRINT_SYNC_PROGRESS_ENABLED;
+
     public BaseIotaConfig() {
         //empty constructor
     }
@@ -818,6 +821,17 @@ public abstract class BaseIotaConfig implements IotaConfig {
         this.powThreads = powThreads;
     }
 
+    @Override
+    public boolean isPrintSyncProgressEnabled() {
+        return printSyncProgressEnabled;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--print-sync-progress"}, description = SolidificationConfig.Descriptions.PRINT_SYNC_PROGRESS_ENABLED, arity = 1)
+    protected void setPrintSyncProgressEnabled(boolean printSyncProgressEnabled) {
+        this.printSyncProgressEnabled = printSyncProgressEnabled;
+    }
+
     /**
      * Represents the default values primarily used by the {@link BaseIotaConfig} field initialisation.
      */
@@ -909,6 +923,9 @@ public abstract class BaseIotaConfig implements IotaConfig {
         long SNAPSHOT_TIME = 1554904800;
         int MILESTONE_START_INDEX = 1050000;
         int BELOW_MAX_DEPTH_TRANSACTION_LIMIT = 20_000;
+
+        //Solidification
+        boolean PRINT_SYNC_PROGRESS_ENABLED = true;
 
     }
 }

--- a/src/main/java/com/iota/iri/conf/SolidificationConfig.java
+++ b/src/main/java/com/iota/iri/conf/SolidificationConfig.java
@@ -7,7 +7,16 @@ package com.iota.iri.conf;
 public interface SolidificationConfig extends Config {
 
     /**
+     * Default Value: {@value BaseIotaConfig.Defaults#PRINT_SYNC_PROGRESS_ENABLED}
+     *
+     * @return {@value SolidificationConfig.Descriptions#PRINT_SYNC_PROGRESS_ENABLED}
+     */
+    boolean isPrintSyncProgressEnabled();
+
+    /**
      * Field descriptions
      */
-    interface Descriptions { }
+    interface Descriptions {
+        String PRINT_SYNC_PROGRESS_ENABLED = "Whether the node should print out progress when synchronizing.";
+    }
 }

--- a/src/main/java/com/iota/iri/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
@@ -1,5 +1,6 @@
 package com.iota.iri.service.milestone.impl;
 
+import com.iota.iri.conf.SolidificationConfig;
 import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
@@ -102,6 +103,8 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
      */
     private SyncProgressInfo syncProgressInfo = new SyncProgressInfo();
 
+    private SolidificationConfig solidificationConfig;
+
     /**
      * <p>
      * This method initializes the instance and registers its dependencies.
@@ -126,8 +129,9 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
      * @return the initialized instance itself to allow chaining
      */
     public LatestSolidMilestoneTrackerImpl(Tangle tangle, SnapshotProvider snapshotProvider,
-            MilestoneService milestoneService, LedgerService ledgerService,
-            LatestMilestoneTracker latestMilestoneTracker, TransactionRequester transactionRequester) {
+                                           MilestoneService milestoneService, LedgerService ledgerService,
+                                           LatestMilestoneTracker latestMilestoneTracker, TransactionRequester transactionRequester,
+                                           SolidificationConfig solidificationConfig) {
 
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
@@ -135,6 +139,7 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
         this.ledgerService = ledgerService;
         this.latestMilestoneTracker = latestMilestoneTracker;
         this.transactionRequester = transactionRequester;
+        this.solidificationConfig = solidificationConfig;
     }
 
     @Override
@@ -322,6 +327,10 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
 
         tangle.publish("lmsi %d %d", prevSolidMilestoneIndex, latestSolidMilestoneIndex);
         tangle.publish("lmhs %s", latestMilestoneHash);
+
+        if (!solidificationConfig.isPrintSyncProgressEnabled()) {
+            return;
+        }
 
         int latestMilestoneIndex = latestMilestoneTracker.getLatestMilestoneIndex();
 


### PR DESCRIPTION
# Description
Adds an option to disable the printing of progress information to the console about synchronization. This is useful for Dyrell who's spamming milestones in a fast fashion, where however the printing of the progress bar slows down that process too much for generating DBs.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
