### PR TITLE
Allow to configure benchmark from CLI

### DIFF
--- a/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
+++ b/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
@@ -21,7 +21,8 @@ public class BenchmarkRunner {
                 .mode(Mode.AverageTime)
                 .timeUnit(TimeUnit.MILLISECONDS)
                 .warmupIterations(getWarmUpIterations(5))
-                .forks(getForks())
+                .forks(getForks(1))
+                .threads(getThreads())
                 .measurementIterations(getMeasurementIterations(10))
                 .shouldFailOnError(true)
                 .shouldDoGC(false)
@@ -38,7 +39,8 @@ public class BenchmarkRunner {
                 .mode(Mode.Throughput)
                 .timeUnit(TimeUnit.SECONDS)
                 .warmupIterations(getWarmUpIterations(5))
-                .forks(getForks())
+                .forks(getForks(1))
+                .threads(getThreads())
                 .measurementIterations(getMeasurementIterations(10))
                 .shouldFailOnError(true)
                 .shouldDoGC(false)
@@ -46,8 +48,12 @@ public class BenchmarkRunner {
         new Runner(opts).run();
     }
 
-    private int getForks() {
-        return getProperty("forks", String.valueOf(Runtime.getRuntime().availableProcessors()));
+    private int getThreads() {
+        return getProperty("threads", Integer.toString(Runtime.getRuntime().availableProcessors()));
+    }
+
+    private int getForks(int defValue) {
+        return getProperty("forks", Integer.toString(defValue));
     }
 
     private int getWarmUpIterations(int defValue) {
@@ -59,7 +65,6 @@ public class BenchmarkRunner {
     }
 
     private int getProperty(String property, String defValue){
-        int prop = Integer.valueOf(Optional.ofNullable(System.getProperty(property)).orElse(defValue));
-        return prop;
+        return Integer.valueOf(Optional.ofNullable(System.getProperty(property)).orElse(defValue));
     }
 }

--- a/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
+++ b/src/test/java/com/iota/iri/benchmarks/BenchmarkRunner.java
@@ -8,19 +8,21 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class BenchmarkRunner {
 
     @Test
     public void launchDbBenchmarks() throws RunnerException {
+
         Options opts = new OptionsBuilder()
                 .include(RocksDbBenchmark.class.getName() + ".*")
                 .mode(Mode.AverageTime)
                 .timeUnit(TimeUnit.MILLISECONDS)
-                .warmupIterations(5)
-                .forks(1)
-                .measurementIterations(10)
+                .warmupIterations(getWarmUpIterations(5))
+                .forks(getForks())
+                .measurementIterations(getMeasurementIterations(10))
                 .shouldFailOnError(true)
                 .shouldDoGC(false)
                 .build();
@@ -32,15 +34,32 @@ public class BenchmarkRunner {
     @Test
     public void launchCryptoBenchmark() throws RunnerException {
         Options opts = new OptionsBuilder()
-          .include(this.getClass().getPackage().getName() + ".crypto")
-          .mode(Mode.Throughput)
-          .timeUnit(TimeUnit.SECONDS)
-          .warmupIterations(5)
-          .forks(1)
-          .measurementIterations(10)
-          .shouldFailOnError(true)
-          .shouldDoGC(false)
-          .build();
+                .include(this.getClass().getPackage().getName() + ".crypto")
+                .mode(Mode.Throughput)
+                .timeUnit(TimeUnit.SECONDS)
+                .warmupIterations(getWarmUpIterations(5))
+                .forks(getForks())
+                .measurementIterations(getMeasurementIterations(10))
+                .shouldFailOnError(true)
+                .shouldDoGC(false)
+                .build();
         new Runner(opts).run();
+    }
+
+    private int getForks() {
+        return getProperty("forks", String.valueOf(Runtime.getRuntime().availableProcessors()));
+    }
+
+    private int getWarmUpIterations(int defValue) {
+        return getProperty("warmUpIterations", Integer.toString(defValue));
+    }
+
+    private int getMeasurementIterations(int defValue) {
+        return getProperty("measurementIterations", Integer.toString(defValue));
+    }
+
+    private int getProperty(String property, String defValue){
+        int prop = Integer.valueOf(Optional.ofNullable(System.getProperty(property)).orElse(defValue));
+        return prop;
     }
 }


### PR DESCRIPTION
# Description
We have added the following flags to benchmark runner:
`-Dforks` - How may time should the jvm fork. Running more than one fork will cause more iterations but should reset JVM optimization profiles. May reduce variance. Default Value: 1.
`-DwarmUpIterations` - How many warm up iterations we should run before we stop measuring. Default value: 5
`-DmeasurementIterations` - How many measurement iterations we should have. Default value: 10
`-Dthreads` - How many threads will run the test (concurrency). Default value: # of cores.

Example of how to run from CLI:
`mvn -Dtest=BenchmarkRunner#launchDbBenchmarks -Dforks=2 -DmeasurementIterations=6 -DwarmUpIterations=2 -Dthreads=3 test`

Fixes #1651 

## Type of change

- Test Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Locally run the example line. The following was printed:
```
# Warmup: 2 iterations, 10 s each
# Measurement: 6 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 3 threads, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: com.iota.iri.benchmarks.dbbenchmark.RocksDbBenchmark.deleteBatch
# Parameters: (numTxsToTest = 10)
```



# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code

