### PR TITLE
Fix: Updated db config loading to account for sections

### DIFF
--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -569,7 +569,7 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
                 try (InputStream stream = new FileInputStream(config)){
                     // Map will contain DBOptions, TableOptions/BlockBasedTable, CFOptions
                     // Currently we only use DBOptions
-                    Map<String, Properties> map = parseINI(stream);
+                    Map<String, Properties> map = IotaIOUtils.parseINI(stream);
                     if (map.containsKey("DBOptions")) {
                         options = DBOptions.getDBOptionsFromProps(map.get("DBOptions"));
                     } else if (map.containsKey("default")) {
@@ -606,32 +606,5 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         }
 
         return options;
-    }
-    
-    // https://stackoverflow.com/a/41084504/4512850 -ish
-    private static Map<String, Properties> parseINI(InputStream stream) throws IOException {
-        Map<String, Properties> result = new HashMap<>();
-        
-        @SuppressWarnings("serial")
-        Properties p = new Properties() {
-
-            private Properties section;
-
-            public synchronized Object put(Object key, Object value) {
-                String header = (((String) key) + " " + value).trim();
-                if (header.startsWith("[") && header.endsWith("]")) {
-                    return result.put(header.substring(1, header.length() - 1), 
-                            section = new Properties());
-                } else if (section != null){
-                    return section.put(key, value);
-                } else {
-                    return super.put(key, value);
-                }
-            };
-
-        };
-        p.load(stream);
-        result.put("default", p);
-        return result;
     }
 }

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -577,10 +577,10 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
                     }
                     
                     if (options == null) {
-                        System.out.println("Options failed to parse, check the OPTIONS-00X in the db folder");
+                        log.warn("Options failed to parse, check the OPTIONS-00X in the db folder");
                     }
                 } catch (IllegalArgumentException e) {
-                    e.printStackTrace();
+                    log.warn("Options failed to parse, check the OPTIONS-00X in the db folder", e);
                 }
             }
         }

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -566,16 +566,25 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         if (configFile != null) {
             File config = Paths.get(configFile).toFile();
             if (config.exists() && config.isFile() && config.canRead()) {
-                Properties configProperties = new Properties();
-                
                 try (InputStream stream = new FileInputStream(config)){
-                    configProperties.load(stream);
-                    options = DBOptions.getDBOptionsFromProps(configProperties);
+                    // Map will contain DBOptions, TableOptions/BlockBasedTable, CFOptions
+                    // Currently we only use DBOptions
+                    Map<String, Properties> map = parseINI(stream);
+                    if (map.containsKey("DBOptions")) {
+                        options = DBOptions.getDBOptionsFromProps(map.get("DBOptions"));
+                    } else if (map.containsKey("default")) {
+                        options = DBOptions.getDBOptionsFromProps(map.get("default"));
+                    }
+                    
+                    if (options == null) {
+                        System.out.println("Options failed to parse, check the OPTIONS-00X in the db folder");
+                    }
                 } catch (IllegalArgumentException e) {
-                    log.warn("RocksDB configuration file is empty, falling back to default values");
+                    e.printStackTrace();
                 }
             }
         }
+        
         if (options == null) {
             options = new DBOptions()
                 .setCreateIfMissing(true)
@@ -597,5 +606,32 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         }
 
         return options;
+    }
+    
+    // https://stackoverflow.com/a/41084504/4512850 -ish
+    private static Map<String, Properties> parseINI(InputStream stream) throws IOException {
+        Map<String, Properties> result = new HashMap<>();
+        
+        @SuppressWarnings("serial")
+        Properties p = new Properties() {
+
+            private Properties section;
+
+            public synchronized Object put(Object key, Object value) {
+                String header = (((String) key) + " " + value).trim();
+                if (header.startsWith("[") && header.endsWith("]")) {
+                    return result.put(header.substring(1, header.length() - 1), 
+                            section = new Properties());
+                } else if (section != null){
+                    return section.put(key, value);
+                } else {
+                    return super.put(key, value);
+                }
+            };
+
+        };
+        p.load(stream);
+        result.put("default", p);
+        return result;
     }
 }

--- a/src/main/java/com/iota/iri/utils/IotaIOUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaIOUtils.java
@@ -1,6 +1,12 @@
 package com.iota.iri.utils;
 
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,5 +25,41 @@ public class IotaIOUtils extends IOUtils {
                 log.debug("Silent exception occured", ignored);
             }
         }
+    }
+    
+    /**
+     * Parses a java INI file with respect to sections, without relying on an external library.
+     * 
+     * From: https://stackoverflow.com/a/41084504/4512850 -ish
+     * @param stream The input stream we will be reading the INI from
+     * @return A map of sections with their properties. 
+     *         If there was a section-less start, these will be put in "default".
+     * @throws IOException
+     */
+    public static Map<String, Properties> parseINI(InputStream stream) throws IOException {
+        Map<String, Properties> result = new HashMap<>();
+        
+        @SuppressWarnings("serial")
+        Properties p = new Properties() {
+
+            private Properties section;
+
+            @Override
+            public synchronized Object put(Object key, Object value) {
+                String header = (((String) key) + " " + value).trim();
+                if (header.startsWith("[") && header.endsWith("]")) {
+                    return result.put(header.substring(1, header.length() - 1), 
+                            section = new Properties());
+                } else if (section != null){
+                    return section.put(key, value);
+                } else {
+                    return super.put(key, value);
+                }
+            };
+
+        };
+        p.load(stream);
+        result.put("default", p);
+        return result;
     }
 }


### PR DESCRIPTION
# Description
Copy/pasting the OPTIONS file in rocksdb in place of the config file we use should work.
However previously, sections were not supported, resulting in `null` and default options beeing loaded.

This adds the ability to load from both a partial or a full OPTIONS file

Fixes #1624

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
Loaded both a OPTIONS file from another location, and a small config file

# Checklist:
- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
