### PR TITLE
Feature: Restore ledger state from State Diffs

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -20,10 +20,7 @@ import com.iota.iri.service.milestone.LatestSolidMilestoneTracker;
 import com.iota.iri.service.milestone.MilestoneService;
 import com.iota.iri.service.milestone.MilestoneSolidifier;
 import com.iota.iri.service.milestone.SeenMilestonesRetriever;
-import com.iota.iri.service.snapshot.LocalSnapshotManager;
-import com.iota.iri.service.snapshot.SnapshotException;
-import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.snapshot.SnapshotService;
+import com.iota.iri.service.snapshot.*;
 import com.iota.iri.service.spentaddresses.SpentAddressesException;
 import com.iota.iri.service.spentaddresses.SpentAddressesProvider;
 import com.iota.iri.service.spentaddresses.SpentAddressesService;
@@ -183,6 +180,10 @@ public class Iota {
             tangle.clearColumn(com.iota.iri.model.persistables.Milestone.class);
             tangle.clearColumn(com.iota.iri.model.StateDiff.class);
             tangle.clearMetadata(com.iota.iri.model.persistables.Transaction.class);
+        }
+
+        if (configuration.isRestoreFromStateDiffs()) {
+            Snapshot snapshot = snapshotService.generateFromStateDiffs();
         }
 
         transactionValidator.init();

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -34,6 +34,8 @@ import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import com.iota.iri.utils.Pair;
 import com.iota.iri.zmq.ZmqMessageQueueProvider;
 
+import com.beust.jcommander.ParameterException;
+
 /**
  *
  * The main class of IRI. This will propagate transactions into and throughout the network. This data is stored as a
@@ -183,7 +185,10 @@ public class Iota {
         }
 
         if (configuration.isRestoreFromStateDiffs()) {
-            Snapshot snapshot = snapshotService.generateFromStateDiffs();
+            if (!configuration.getLocalSnapshotsEnabled()) {
+                throw new ParameterException("Local Snapshots must be enabled for restore to work");
+            }
+            snapshotService.updateLatestFromStateDiffs();
         }
 
         transactionValidator.init();

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -67,6 +67,8 @@ public abstract class BaseIotaConfig implements IotaConfig {
     protected String mainDb = Defaults.MAIN_DB;
     protected boolean revalidate = Defaults.REVALIDATE;
     protected boolean rescanDb = Defaults.RESCAN_DB;
+    protected boolean restoreFromStateDiffs = Defaults.RESTORE_FROM_STATE_DIFFS;
+
 
     //Protocol
     protected double pSendMilestone = Defaults.P_SEND_MILESTONE;
@@ -459,6 +461,17 @@ public abstract class BaseIotaConfig implements IotaConfig {
     @Parameter(names = {"--rescan"}, description = DbConfig.Descriptions.RESCAN_DB, arity = 1)
     protected void setRescanDb(boolean rescanDb) {
         this.rescanDb = rescanDb;
+    }
+
+    @Override
+    public boolean isRestoreFromStateDiffs() {
+        return restoreFromStateDiffs;
+    }
+
+    @JsonProperty("RESTORE")
+    @Parameter(names = {"--restore"}, description= DbConfig.Descriptions.RESTORE_FROM_STATE_DIFF, arity = 1)
+    public void setRestoreFromStateDiffs(boolean restoreFromStateDiffs) {
+        this.restoreFromStateDiffs = restoreFromStateDiffs;
     }
 
     @Override
@@ -880,6 +893,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
         String MAIN_DB = "rocksdb";
         boolean REVALIDATE = false;
         boolean RESCAN_DB = false;
+        boolean RESTORE_FROM_STATE_DIFFS = false;
 
         //Protocol
         double P_SEND_MILESTONE = 0.02d;

--- a/src/main/java/com/iota/iri/conf/DbConfig.java
+++ b/src/main/java/com/iota/iri/conf/DbConfig.java
@@ -54,7 +54,15 @@ public interface DbConfig extends Config {
      */
     boolean isRescanDb();
 
-    interface Descriptions {
+    /**
+     * Default Value: {@value BaseIotaConfig.Defaults#RESTORE_FROM_STATE_DIFFS}
+     *
+     * @return {@value DbConfig.Descriptions#RESTORE_FROM_STATE_DIFF}
+     */
+     boolean isRestoreFromStateDiffs();
+
+
+        interface Descriptions {
 
         String DB_PATH = "The folder where the DB saves its data.";
         String DB_LOG_PATH = "The folder where the DB logs info";
@@ -63,6 +71,8 @@ public interface DbConfig extends Config {
         String REVALIDATE = "Reload from the db data about confirmed transaction (milestones), state of the ledger, " +
                 "and transaction metadata.";
         String RESCAN_DB = "Rescan all transaction metadata (Approvees, Bundles, and Tags)";
+        String RESTORE_FROM_STATE_DIFF = "Recalculate the ledger balances from the last global snapshot using only " +
+                "diffs in the DB.";
         String DB_CONFIG_FILE = "The location of the RocksDB configuration file";
     }
 }

--- a/src/main/java/com/iota/iri/service/snapshot/SnapshotProvider.java
+++ b/src/main/java/com/iota/iri/service/snapshot/SnapshotProvider.java
@@ -40,6 +40,23 @@ public interface SnapshotProvider {
     void writeSnapshotToDisk(Snapshot snapshot, String basePath) throws SnapshotException;
 
     /**
+     * <p>
+     * Loads the builtin snapshot (last global snapshot) that is embedded in the jar (if a different path is provided it
+     * can also load from the disk).
+     * </p>
+     * <p>
+     * We first verify the integrity of the snapshot files by checking the signature of the files and then construct
+     * a {@link Snapshot} from the retrieved information.
+     * </p>
+     * <p>
+     * We add the NULL_HASH as the only solid entry point and an empty list of seen milestones.
+     * </p>
+     * @return the builtin snapshot (last global snapshot) that is embedded in the jar
+     * @throws SnapshotException if anything goes wrong while loading the builtin {@link Snapshot}
+     */
+    Snapshot loadBuiltInSnapshot() throws SnapshotException;
+
+    /**
      * Frees the resources of the {@link SnapshotProvider}.
      *
      * Snapshots require quite a bit of memory and should be cleaned up when they are not required anymore. This is

--- a/src/main/java/com/iota/iri/service/snapshot/SnapshotService.java
+++ b/src/main/java/com/iota/iri/service/snapshot/SnapshotService.java
@@ -133,11 +133,14 @@ public interface SnapshotService {
     /**
      * Generate the most up to date snapshot by applying {@link com.iota.iri.model.StateDiff}s on the built in
      * global snapshot. It should copy the metadata from the current latest snapshot if it indeed exists.
+     * After the invocation of this method the node's own ledger state (what is returned by
+     * {@link SnapshotProvider#getLatestSnapshot()} is updated.
      *
-     * @return Snapshot that contains the ledger
+     *
+     * @return Snapshot that contains the updated ledger
      * @throws IllegalStateException if {@link com.iota.iri.model.StateDiff}s are missing in the DB
      * @throws SnapshotException if snapshot validation fails
      * @throws Exception for any general DB error
      */
-    Snapshot generateFromStateDiffs() throws Exception;
+    Snapshot updateLatestFromStateDiffs() throws Exception;
 }

--- a/src/main/java/com/iota/iri/service/snapshot/SnapshotService.java
+++ b/src/main/java/com/iota/iri/service/snapshot/SnapshotService.java
@@ -129,4 +129,15 @@ public interface SnapshotService {
      */
     Map<Hash, Integer> generateSeenMilestones(LatestMilestoneTracker latestMilestoneTracker,
             MilestoneViewModel targetMilestone) throws SnapshotException;
+
+    /**
+     * Generate the most up to date snapshot by applying {@link com.iota.iri.model.StateDiff}s on the built in
+     * global snapshot. It should copy the metadata from the current latest snapshot if it indeed exists.
+     *
+     * @return Snapshot that contains the ledger
+     * @throws IllegalStateException if {@link com.iota.iri.model.StateDiff}s are missing in the DB
+     * @throws SnapshotException if snapshot validation fails
+     * @throws Exception for any general DB error
+     */
+    Snapshot generateFromStateDiffs() throws Exception;
 }

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -233,22 +233,8 @@ public class SnapshotProviderImpl implements SnapshotProvider {
         return null;
     }
 
-    /**
-     * <p>
-     * Loads the builtin snapshot (last global snapshot) that is embedded in the jar (if a different path is provided it
-     * can also load from the disk).
-     * </p>
-     * <p>
-     * We first verify the integrity of the snapshot files by checking the signature of the files and then construct
-     * a {@link Snapshot} from the retrieved information.
-     * </p>
-     * <p>
-     * We add the NULL_HASH as the only solid entry point and an empty list of seen milestones.
-     * </p>
-     * @return the builtin snapshot (last global snapshot) that is embedded in the jar
-     * @throws SnapshotException if anything goes wrong while loading the builtin {@link Snapshot}
-     */
-    private Snapshot loadBuiltInSnapshot() throws SnapshotException {
+    @Override
+    public Snapshot loadBuiltInSnapshot() throws SnapshotException {
         if (builtinSnapshot == null) {
             try {
                 if (!config.isTestnet() && !SignedFiles.isFileSignatureValid(

--- a/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/SnapshotProviderImpl.java
@@ -110,15 +110,7 @@ public class SnapshotProviderImpl implements SnapshotProvider {
 
     /**
      * {@inheritDoc}
-     */
-    @Override
-    public Snapshot getLatestSnapshot() {
-        return latestSnapshot;
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
+     *
      * <p>
      * It first writes two temporary files, then renames the current files by appending them with a ".bkp" extension and
      * finally renames the temporary files. This mechanism reduces the chances of the files getting corrupted if IRI
@@ -157,6 +149,14 @@ public class SnapshotProviderImpl implements SnapshotProvider {
         } finally {
             snapshot.unlockRead();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Snapshot getLatestSnapshot() {
+        return latestSnapshot;
     }
 
     /**


### PR DESCRIPTION
# Description
Allows to recalculate the ledger state by adding state diffs to the last global snapshot.

Fixes #1664 

## Type of change

- Enhancement (a non-breaking change which adds functionality)


# How Has This Been Tested?

This had been run locally on a db and seemed successful.

# Checklist:
- [ ] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
