### PR TITLE
Fix: Don't resave the transaction itself

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -223,7 +223,8 @@ public class Iota {
                 log.info("Rescanned {} Transactions", counter);
             }
             List<Pair<Indexable, Persistable>> saveBatch = tx.getSaveBatch();
-            saveBatch.remove(5);
+            //don't re-save the tx itself
+            saveBatch.remove(saveBatch.size() - 1);
             tangle.saveBatch(saveBatch);
             tx = tx.next(tangle);
         }

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -350,13 +350,15 @@ public class TransactionViewModel {
      * The method then ensures that the {@link Transaction#bytes} are present before adding the {@link Transaction} and
      * {@link Hash} identifier to the already compiled list of {@link Transaction} components.
      *
-     * @return A complete list of all {@link Transaction} component objects paired with their {@link Hash} identifiers
+     * @return A complete list of all {@link Transaction} component objects paired with their {@link Hash} identifiers.
+     * The transaction object itself must be the last item in the list.
      * @throws Exception Thrown if the metadata fails to fetch, or if the bytes are not retrieved correctly
      */
     public List<Pair<Indexable, Persistable>> getSaveBatch() throws Exception {
         List<Pair<Indexable, Persistable>> hashesList = new ArrayList<>();
         hashesList.addAll(getMetadataSaveBatch());
         getBytes();
+        //must be last
         hashesList.add(new Pair<>(hash, transaction));
         return hashesList;
     }


### PR DESCRIPTION
# Description

While rescanning the DB we are not suppose to re-save the existing transactions themselves.
Unfortunately it seems like we were re-saving the transactions and dropping the `TAG` data itself.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Currently I am rescanning a node. I will validate that Tag information is present before merging.
Complete regression test should be done seperatly in #1466 


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
