### PR TITLE
Fix regression tests for cached Transactions

### DIFF
--- a/python-regression/util/test_logic/api_test_logic.py
+++ b/python-regression/util/test_logic/api_test_logic.py
@@ -1,10 +1,11 @@
+import json
+import logging
+import urllib3
 from aloe import world
 from iota import Iota, Address, Tag, TryteString
-import json
-import urllib3
+
 from . import value_fetch_logic as value_fetch
 
-import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -133,7 +134,8 @@ def fetch_call(api_call, api, options):
 
     try:
         response = call_list[api_call](**options)
-    except ValueError:
+    except ValueError, e:
+        logger.info(str(e))
         response = None
 
     return response

--- a/python-regression/util/test_logic/api_test_logic.py
+++ b/python-regression/util/test_logic/api_test_logic.py
@@ -135,7 +135,7 @@ def fetch_call(api_call, api, options):
     try:
         response = call_list[api_call](**options)
     except ValueError, e:
-        logger.info(str(e))
+        logger.error(str(e))
         response = None
 
     return response

--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -91,9 +91,11 @@ public class CacheImpl<K, V> implements Cache<K, V> {
             return;
         }
         V value = strongStore.get(key);
-        weakStore.put(key, value);
         strongStore.remove(key);
         evictionQueue.remove(key);
+        if (value != null) {
+            weakStore.put(key, value);
+        }
     }
 
     @Override

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -2,19 +2,8 @@ package com.iota.iri.controllers;
 
 import com.iota.iri.cache.Cache;
 import com.iota.iri.cache.CacheConfiguration;
-import com.iota.iri.model.AddressHash;
-import com.iota.iri.model.BundleHash;
-import com.iota.iri.model.Hash;
-import com.iota.iri.model.HashFactory;
-import com.iota.iri.model.ObsoleteTagHash;
-import com.iota.iri.model.TagHash;
-import com.iota.iri.model.TransactionHash;
-import com.iota.iri.model.persistables.Address;
-import com.iota.iri.model.persistables.Approvee;
-import com.iota.iri.model.persistables.Bundle;
-import com.iota.iri.model.persistables.ObsoleteTag;
-import com.iota.iri.model.persistables.Tag;
-import com.iota.iri.model.persistables.Transaction;
+import com.iota.iri.model.*;
+import com.iota.iri.model.persistables.*;
 import com.iota.iri.service.snapshot.Snapshot;
 import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
@@ -22,12 +11,7 @@ import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Converter;
 import com.iota.iri.utils.Pair;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 
 /**
  * Controller class for {@link Transaction} sets. A {@link TransactionViewModel} stores a {@link HashesViewModel} for
@@ -461,13 +445,13 @@ public class TransactionViewModel {
         // We need to save approvees, tags, and other metadata that is used by
         // non-cached operations.
         List<Pair<Indexable, Persistable>> batch = getSaveBatch();
+        cachePut(tangle, this, hash);
+        cacheApprovees(tangle);
+
         if (exists(tangle, hash)) {
             return false;
         }
         tangle.saveBatch(batch);
-        cacheApprovees(tangle);
-
-        cachePut(tangle, this, hash);
         return true;
     }
 

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -331,9 +331,7 @@ public class TransactionViewModel {
      * @throws Exception Thrown if no branch is found when creating the branch {@link TransactionViewModel}
      */
     public TransactionViewModel getBranchTransaction(Tangle tangle) throws Exception {
-        if (branch == null) {
-            branch = TransactionViewModel.fromHash(tangle, getBranchTransactionHash());
-        }
+        branch = TransactionViewModel.fromHash(tangle, getBranchTransactionHash());
         return branch;
     }
 
@@ -347,9 +345,7 @@ public class TransactionViewModel {
      * @throws Exception Thrown if no trunk is found when creating the trunk {@link TransactionViewModel}
      */
     public TransactionViewModel getTrunkTransaction(Tangle tangle) throws Exception {
-        if (trunk == null) {
-            trunk = TransactionViewModel.fromHash(tangle, getTrunkTransactionHash());
-        }
+        trunk = TransactionViewModel.fromHash(tangle, getTrunkTransactionHash());
         return trunk;
     }
 
@@ -446,7 +442,9 @@ public class TransactionViewModel {
         // non-cached operations.
         List<Pair<Indexable, Persistable>> batch = getSaveBatch();
         cacheApprovees(tangle);
-        cachePut(tangle, this, hash);
+        if (tangle.getCache(TransactionViewModel.class).get(hash) == null) {
+            cachePut(tangle, this, hash);
+        }
 
         if (tangle.exists(Transaction.class, hash)) {
             return false;

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -445,10 +445,10 @@ public class TransactionViewModel {
         // We need to save approvees, tags, and other metadata that is used by
         // non-cached operations.
         List<Pair<Indexable, Persistable>> batch = getSaveBatch();
-        cachePut(tangle, this, hash);
         cacheApprovees(tangle);
+        cachePut(tangle, this, hash);
 
-        if (exists(tangle, hash)) {
+        if (tangle.exists(Transaction.class, hash)) {
             return false;
         }
         tangle.saveBatch(batch);


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Fix failed regression tests after caching `TransactionViewModels`.

I realized that when running `BundleValidator#loadTransactionsFromTangle` for a given tx, it could happen that the `tx.branch` or `tx.trunk` could be older than what's in the cache. So we read from cache always.

Secondly, fresh tx i.e `parsed=false` were being gossiped to the node and `tx.store` was overriding the already parsed tx in the cache. So some sort of `cache.putIfAbsent` was necessary for `tx.store`.
Only way cached tx update is by `tx.update`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Existing unit tests pass

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
