### PR TITLE
Regression tests to python3

### DIFF
--- a/python-regression/tests/features/steps/api_test_steps.py
+++ b/python-regression/tests/features/steps/api_test_steps.py
@@ -120,11 +120,11 @@ def compare_thread_return(step, api_call):
             del response_list['duration']
         if 'info' in response_list:
             del response_list['info']
-        response_keys = response_list.keys()
+        response_keys = list(response_list.keys())
 
         expected_values = {}
         api_utils.prepare_options(step.hashes,expected_values)
-        keys = expected_values.keys()
+        keys = list(expected_values.keys())
 
         # Confirm that the lists are of equal length before comparing
         assert len(keys) == len(response_keys), \

--- a/python-regression/util/neighbor_logic/neighbor_logic.py
+++ b/python-regression/util/neighbor_logic/neighbor_logic.py
@@ -26,5 +26,5 @@ def check_if_neighbors(api, neighbors, expected_neighbor):
 
     if is_neighbor is False:
         tcp_address = "tcp://" + expected_neighbor
-        api.add_neighbors([tcp_address.decode()])
+        api.add_neighbors([tcp_address])
         logger.info('{} added as neighbor'.format(tcp_address))

--- a/python-regression/util/test_logic/value_fetch_logic.py
+++ b/python-regression/util/test_logic/value_fetch_logic.py
@@ -76,7 +76,7 @@ def fetch_node_address(value):
     host = world.machine['nodes'][value]['host']
     port = world.machine['nodes'][value]['ports']['gossip-tcp']
     address = "tcp://" + host + ":" + str(port)
-    return [address.decode()]
+    return [address]
 
 
 def fetch_static_value(value):


### PR DESCRIPTION
# Description

Fix regression tests that are now running on Python3.

# How Has This Been Tested?

By running our BuildKite pipelines.

https://buildkite.com/iota-foundation/iri-regression-tests/builds/1323
