### PR TITLE
Lower error severity for faulty neighbor 

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
@@ -510,7 +510,7 @@ public class NeighborRouterImpl implements NeighborRouter {
                 return false;
             case FAILED:
                 // faulty handshaking
-                log.error("dropping connection to neighbor {} as handshaking was faulty", identity);
+                log.warn("dropping connection to neighbor {} as handshaking was faulty", identity);
                 closeNeighborConnection(channel, identity, selector);
                 return false;
             default:


### PR DESCRIPTION
# Description
While regression tests run, it is possible that the nodes will fail to connect to one another at some point if the kubernetes node has not been loaded all the way yet. During the fetch logs portion of the pipeline, it will scan the logs for errors, and if there is a faulty neighbor connection, it will fail the tests regardless of if they've passed prior to this point. By lowering the error message to a warning rather than an error, it will not fail passed tests on log fetching anymore. 

Fixes # The consistently failing regression tests in buildkite

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:
- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
