### PR TITLE
check for null key and value before cache.put

### DIFF
--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -102,9 +102,9 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     @Override
     public void put(K key, V value) {
-        if (key == null || value == null) {
-            return;
-        }
+        Objects.requireNonNull(key, "Cache key cannot be null");
+        Objects.requireNonNull(value, "Cache value cannot be null");
+
         if (getSize() >= cacheConfiguration.getMaxSize()) {
             release();
         }

--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -100,6 +100,9 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     @Override
     public void put(K key, V value) {
+        if (key == null || value == null) {
+            return;
+        }
         if (getSize() >= cacheConfiguration.getMaxSize()) {
             release();
         }

--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -73,10 +73,12 @@ public class CacheImpl<K, V> implements Cache<K, V> {
         }
         V value = strongStore.get(key);
 
-        if (value == null && weakStore.containsKey(key)) {
+        if (value == null) {
             value = weakStore.get(key);
-            put(key, value);
-            weakStore.remove(key);
+            if (value != null) {
+                put(key, value);
+                weakStore.remove(key);
+            }
         }
         if (value != null) {
             cacheHit();

--- a/src/test/java/com/iota/iri/cache/CacheTest.java
+++ b/src/test/java/com/iota/iri/cache/CacheTest.java
@@ -147,6 +147,16 @@ public class CacheTest {
         Assert.assertTrue("Cache Misses should be 1", cache.getCacheMisses() == 1);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullExceptionOnNullKey() {
+        cache.put(null, new TransactionViewModel(getTransaction(TEST_TRANSACTION_HASH), hash));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullExceptionOnNullValue() {
+        cache.put(hash, null);
+    }
+
     private Transaction getTransaction(String hash) {
         Transaction tx = new Transaction();
         tx.address = HashFactory.TRANSACTION.create(hash);


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Added null check before cache put. Fixes 
```
01/26 20:54:46.064 [Milestone Solidifier] ERROR MilestoneSolidifier:465 - Error while solidifying milestone #1071451
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011) ~[na:1.8.0_181]
	at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006) ~[na:1.8.0_181]
	at com.iota.iri.cache.impl.CacheImpl.put(CacheImpl.java:107) ~[iri-PR-e1526d2-e8e23c4c.jar:PR-e1526d2-e8e23c4c]
	at com.iota.iri.cache.impl.CacheImpl.get(CacheImpl.java:78) ~[iri-PR-e1526d2-e8e23c4c.jar:PR-e1526d2-e8e23c4c]
	at com.iota.iri.controllers.TransactionViewModel.fromHash(TransactionViewModel.java:158) ~[iri-PR-e1526d2-e8e23c4c.jar:PR-e1526d2-e8e23c4c]
	at com.iota.iri.TransactionValidator.checkSolidity(TransactionValidator.java:264) ~[iri-PR-e1526d2-e8e23c4c.jar:PR-e1526d2-e8e23c4c]
	at com.iota.iri.service.milestone.impl.MilestoneSolidifierImpl.isSolid(MilestoneSolidifierImpl.java:344) [iri-PR-e1526d2-e8e23c4c.jar:PR-e1526d2-e8e23c4c]
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- existing unit tests pass

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
