### PR TITLE
fix issue where updated tx was not saved to DB

### DIFF
--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -105,9 +105,6 @@ public class CacheImpl<K, V> implements Cache<K, V> {
         Objects.requireNonNull(key, "Cache key cannot be null");
         Objects.requireNonNull(value, "Cache value cannot be null");
 
-        if (getSize() >= cacheConfiguration.getMaxSize()) {
-            release();
-        }
         // new entry
         if (strongStore.put(key, value) == null) {
             releaseQueue.offer(key);

--- a/src/main/java/com/iota/iri/controllers/ApproveeViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/ApproveeViewModel.java
@@ -151,8 +151,11 @@ public class ApproveeViewModel implements HashesViewModel {
      * @param approveeViewModel The approveeViewModel to cache
      * @param hash              The hash of this viewmodel
      */
-    public static void cachePut(Tangle tangle, ApproveeViewModel approveeViewModel, Indexable hash) {
+    public static void cachePut(Tangle tangle, ApproveeViewModel approveeViewModel, Indexable hash) throws Exception {
         Cache<Indexable, ApproveeViewModel> cache = tangle.getCache(ApproveeViewModel.class);
+        if (cache.getSize() >= cache.getConfiguration().getMaxSize()) {
+            cacheRelease(tangle);
+        }
         cache.put(hash, approveeViewModel);
     }
 

--- a/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
@@ -235,10 +235,14 @@ public class MilestoneViewModel {
      * @param milestoneViewModel milestoneViewModel to cache
      * @param index              index of milestone
      */
-    private static void cachePut(Tangle tangle, MilestoneViewModel milestoneViewModel, Indexable index) {
+    private static void cachePut(Tangle tangle, MilestoneViewModel milestoneViewModel, Indexable index)
+            throws Exception {
         Cache<Indexable, MilestoneViewModel> cache = getCache(tangle);
         if (cache == null) {
             return;
+        }
+        if (cache.getSize() >= cache.getConfiguration().getMaxSize()) {
+            cacheRelease(tangle);
         }
         cache.put(index, milestoneViewModel);
     }

--- a/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/MilestoneViewModel.java
@@ -10,8 +10,6 @@ import com.iota.iri.storage.Persistable;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Pair;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Queue;
 
 /**
@@ -268,32 +266,27 @@ public class MilestoneViewModel {
     }
 
     /**
-     * Release {@link CacheConfiguration#getReleaseCount()} items from the cache
+     * Release {@link CacheConfiguration#getReleaseCount()} items from the cache. Since this data is immutable, we only
+     * release from cache but not persist to DB again.
      * 
      * @param tangle Tangle
      * @throws Exception Exception
      */
-    public static void cacheRelease(Tangle tangle) throws Exception {
+    private static void cacheRelease(Tangle tangle) throws Exception {
         Cache<Indexable, MilestoneViewModel> cache = getCache(tangle);
         if (cache == null) {
             return;
         }
         Queue<Indexable> releaseQueueCopy = cache.getReleaseQueueCopy();
-        List<Pair<Indexable, Persistable>> batch = new ArrayList<>();
-        List<Indexable> indicesToRelease = new ArrayList<>();
 
         for (int i = 0; i < cache.getConfiguration().getReleaseCount(); i++) {
             Indexable index = releaseQueueCopy.poll();
             if (index != null) {
                 MilestoneViewModel milestoneViewModel = cache.get(index);
                 if (milestoneViewModel != null) {
-                    batch.add(new Pair<>(index, milestoneViewModel.milestone));
-                    indicesToRelease.add(index);
+                    cache.release(index);
                 }
             }
         }
-
-        tangle.saveBatch(batch);
-        cache.release(indicesToRelease);
     }
 }

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -455,14 +455,13 @@ public class TransactionViewModel {
     }
 
     private void cacheApprovees(Tangle tangle) throws Exception {
-        Cache<Indexable, ApproveeViewModel> approveeViewModelCache = tangle.getCache(ApproveeViewModel.class);
         ApproveeViewModel branchViewModel = ApproveeViewModel.load(tangle, getBranchTransactionHash());
         branchViewModel.addHash(hash);
-        approveeViewModelCache.put(getBranchTransactionHash(), branchViewModel);
+        ApproveeViewModel.cachePut(tangle, branchViewModel, getBranchTransactionHash());
 
         ApproveeViewModel trunkViewModel = ApproveeViewModel.load(tangle, getTrunkTransactionHash());
         trunkViewModel.addHash(hash);
-        approveeViewModelCache.put(getTrunkTransactionHash(), trunkViewModel);
+        ApproveeViewModel.cachePut(tangle, trunkViewModel, getTrunkTransactionHash());
 
         ApproveeViewModel.load(tangle, hash);
     }

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -85,8 +85,8 @@ public class TransactionViewModel {
     private byte[] trits;
     public int weightMagnitude;
 
-    // true if entry is fresh. False if dirty
-    private boolean cacheEntryFresh = true;
+    // True if should the tvm should be persisted to DB upon cache release. False otherwise.
+    private boolean shouldPersist = false;
 
     /**
      * Populates the meta data of the {@link TransactionViewModel}. If the controller {@link Hash} identifier is null,
@@ -314,7 +314,7 @@ public class TransactionViewModel {
 
         TransactionViewModel cachedTvm = tangle.getCache(TransactionViewModel.class).get(hash);
         if (cachedTvm != null) {
-            this.cacheEntryFresh = false;
+            this.shouldPersist = true;
         }
         cachePut(tangle, this, hash);
         tangle.updateMessageQueueProvider(transaction, hash, item);
@@ -998,8 +998,8 @@ public class TransactionViewModel {
             if (hash != null) {
                 TransactionViewModel tvm = cache.get(hash);
                 hashesToRelease.add(hash);
-                if (tvm != null && !tvm.isCacheEntryFresh()) {
-                    tvm.setCacheEntryFresh(true);
+                if (tvm != null && tvm.shouldPersist()) {
+                    tvm.setShouldPersist(false);
                     cache.put(hash, tvm);
                     batch.addAll(tvm.getSaveBatch());
                 }
@@ -1027,8 +1027,8 @@ public class TransactionViewModel {
             if (hash != null) {
                 TransactionViewModel tvm = cache.get(hash);
                 hashesToRelease.add(hash);
-                if (tvm != null && !tvm.isCacheEntryFresh()) {
-                    tvm.setCacheEntryFresh(true);
+                if (tvm != null && tvm.shouldPersist()) {
+                    tvm.setShouldPersist(false);
                     cache.put(hash, tvm);
                     batch.addAll(tvm.getSaveBatch());
                 }
@@ -1065,21 +1065,21 @@ public class TransactionViewModel {
     }
 
     /**
-     * The state of the cache entry. A fresh entry is one that has not been updated before.
+     * If the tvm should be persisted to DB upon cache release.
      *
-     * @return True if fresh. False otherwise
+     * @return True if should persist. False otherwise
      */
-    public boolean isCacheEntryFresh() {
-        return cacheEntryFresh;
+    private boolean shouldPersist() {
+        return shouldPersist;
     }
 
     /**
-     * Sets the state of the cache entry.
+     * Sets whether the tvm should be persisted to DB upon cache release or not.
      * 
-     * @param cacheEntryFresh cache entry
+     * @param shouldPersist If the tvm should be persisted
      */
-    public void setCacheEntryFresh(boolean cacheEntryFresh) {
-        this.cacheEntryFresh = cacheEntryFresh;
+    private void setShouldPersist(boolean shouldPersist) {
+        this.shouldPersist = shouldPersist;
     }
 
 }

--- a/src/main/java/com/iota/iri/storage/Tangle.java
+++ b/src/main/java/com/iota/iri/storage/Tangle.java
@@ -4,8 +4,6 @@ import com.iota.iri.cache.Cache;
 import com.iota.iri.cache.CacheManager;
 import com.iota.iri.cache.impl.CacheManagerImpl;
 import com.iota.iri.conf.MainnetConfig;
-import com.iota.iri.controllers.ApproveeViewModel;
-import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.StateDiff;
@@ -79,8 +77,6 @@ public class Tangle {
     public void shutdown() throws Exception {
         log.info("Releasing all caches...");
         TransactionViewModel.cacheReleaseAll(this);
-        ApproveeViewModel.cacheRelease(this);
-        MilestoneViewModel.cacheRelease(this);
         cacheManager.clearAllCaches();
         log.info("Shutting down Tangle Persistence Providers... ");
         this.persistenceProviders.forEach(PersistenceProvider::shutdown);

--- a/src/main/java/com/iota/iri/storage/Tangle.java
+++ b/src/main/java/com/iota/iri/storage/Tangle.java
@@ -78,7 +78,7 @@ public class Tangle {
      */
     public void shutdown() throws Exception {
         log.info("Releasing all caches...");
-        TransactionViewModel.cacheRelease(this);
+        TransactionViewModel.cacheReleaseAll(this);
         ApproveeViewModel.cacheRelease(this);
         MilestoneViewModel.cacheRelease(this);
         cacheManager.clearAllCaches();

--- a/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
@@ -441,7 +441,7 @@ public class TransactionViewModelTest {
 
         Hash hash = tvms[0].getHash();
         TransactionViewModel tvm = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash), hash);
-        Assert.assertTrue(tvm.isMilestone());
+        Assert.assertTrue("TVM should be a milestone", tvm.isMilestone());
     }
 
     @Test
@@ -478,7 +478,7 @@ public class TransactionViewModelTest {
             Hash hash = tvms[i].getHash();
             TransactionViewModel tvm = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash),
                     hash);
-            Assert.assertTrue(tvm.isMilestone());
+            Assert.assertTrue("TVM should be a milestone", tvm.isMilestone());
         }
     }
 }

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneServiceImplTest.java
@@ -66,12 +66,10 @@ public class MilestoneServiceImplTest {
     public void setUp() throws Exception {
         SnapshotMockUtils.mockSnapshotProvider(snapshotProvider);
 
-        MilestoneViewModel.cacheRelease(tangle);
     }
 
     @After
     public void tearDown() throws Exception {
-        MilestoneViewModel.cacheRelease(tangle);
     }
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImplTest.java
+++ b/src/test/java/com/iota/iri/service/snapshot/impl/SnapshotServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.iota.iri.service.snapshot.impl;
 
 import com.iota.iri.TangleMockUtils;
-import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
@@ -78,7 +77,6 @@ public class SnapshotServiceImplTest {
     public void setUp() throws Exception {
         SnapshotMockUtils.mockSnapshotProvider(snapshotProvider);
 
-        MilestoneViewModel.cacheRelease(tangle);
     }
 
     //endregion ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImplTest.java
@@ -1,6 +1,5 @@
 package com.iota.iri.service.tipselection.impl;
 
-import com.iota.iri.controllers.MilestoneViewModel;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.IntegerIndex;
@@ -35,7 +34,6 @@ public class EntryPointSelectorImplTest {
 
     @Before
     public void setUp() throws Exception {
-        MilestoneViewModel.cacheRelease(tangle);
         Mockito.when(snapshotProvider.getLatestSnapshot()).thenReturn(SnapshotMockUtils.createSnapshot());
         Mockito.when(snapshotProvider.getInitialSnapshot()).thenReturn(SnapshotMockUtils.createSnapshot());
     }


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Fixes the following
- A tx could be cached and updated but not saved to DB during `cacheRelease` that was only called during tangle shutdown
- Move release code from the cache to VMs. Ensures that txs are saved to DB before releasing.
- Ensure to release all `releaseCount` txs from the cache
- Release all txs from cache during tangle shutdown.
- `dirty` tx kept saving to DB (increasing size) because it was still dirty even after being brought back to live from weakstore after release.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Existing unit tests pass

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas