### PR TITLE
Regression: Add ZMQ tests

### DIFF
--- a/python-regression/tests/features/machine1/1_api_tests.feature
+++ b/python-regression/tests/features/machine1/1_api_tests.feature
@@ -113,7 +113,12 @@ Feature: Test API calls on Machine 1
 
 
 	Scenario: GetTransactionsToApprove is called
-		Given "getTransactionsToApprove" is called on "nodeA-m1" with:
+		#Subscribe to zmq stream for walker topic
+		Given "nodeA-m1" is subscribed to the following zmq topics:
+		|keys						|
+		|mctn						|
+
+		And "getTransactionsToApprove" is called on "nodeA-m1" with:
 		|keys       |values				|type           |
 		|depth      |3					|int            |
 
@@ -122,6 +127,10 @@ Feature: Test API calls on Machine 1
 		|branchTransaction				|
 		|duration					|
 		|trunkTransaction				|
+
+		And the zmq stream for "nodeA-m1" contains a response for following topics:
+		|keys						|
+		|mctn						|
 
 
 	Scenario: CheckConsistency is called

--- a/python-regression/tests/features/machine2/2_transaction_tests.feature
+++ b/python-regression/tests/features/machine2/2_transaction_tests.feature
@@ -3,7 +3,15 @@ Feature: Test transaction confirmation
     Scenario: Zero Value Transactions are confirmed
         In this test, a number of zero value transactions will be made to a specified node.
         A milestone will be issued that references these transactions, and this should
-        confirm the transations.
+        confirm the transactions.
+
+        #Subscribe to zmq stream transaction topics
+        Given "nodeA-m2" is subscribed to the following zmq topics:
+        |keys                   |
+        |sn                     |
+        |sn_trytes              |
+        |tx                     |
+        |tx_trytes              |
 
         Given "10" transactions are issued on "nodeA-m2" with:
         |keys                   |values                     |type           |
@@ -30,18 +38,25 @@ Feature: Test transaction confirmation
 
 
         When a transaction is generated and attached on "nodeA-m2" with:
-            | keys    | values       | type        |
-            | address | TEST_ADDRESS | staticValue |
-            | value   | 0            | int         |
+        | keys                  | values                    | type          |
+        | address               | TEST_ADDRESS              | staticValue   |
+        | value                 | 0                         | int           |
 
         And "getInclusionStates" is called on "nodeA-m2" with:
-            | keys         | values             | type        |
-            | transactions | TEST_STORE_ADDRESS | staticList  |
-            | tips         | latestMilestone    | configValue |
+        | keys                  | values                    | type          |
+        | transactions          | TEST_STORE_ADDRESS        | staticList    |
+        | tips                  | latestMilestone           | configValue   |
 
         Then the response for "getInclusionStates" should return with:
-            | keys   | values | type          |
-            | states | False  | boolListMixed |
+        | keys                  | values                    | type          |
+        | states                | False                     | boolListMixed |
+
+        And the zmq stream for "nodeA-m2" contains a response for following topics:
+        |keys                   |
+        |sn                     |
+        |sn_trytes              |
+        |tx                     |
+        |tx_trytes              |
 
 
     Scenario: Value Transactions are confirmed

--- a/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
+++ b/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
@@ -14,6 +14,7 @@ Feature: Test Bootstrapping With LS
     |keys					|
     |lmi					|
     |lmsi					|
+    |lmhs					|
 
 
     #First make sure nodes are neighbored
@@ -29,6 +30,7 @@ Feature: Test Bootstrapping With LS
     |keys					|
     |lmi					|
     |lmsi					|
+    |lmhs					|
 
 
   Scenario: DB node is synced, and files contain expected values

--- a/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
+++ b/python-regression/tests/features/machine6/6_local_snapshots_tests.feature
@@ -9,6 +9,13 @@ Feature: Test Bootstrapping With LS
   Scenario: PermaNode is synced
     Check that the permanode has been started correctly and is synced.
 
+    #Subscribe to zmq streams for milestones
+    Given "nodeA-m6" is subscribed to the following zmq topics:
+    |keys					|
+    |lmi					|
+    |lmsi					|
+
+
     #First make sure nodes are neighbored
     Given "nodeA-m6" and "nodeB-m6" are neighbors
     And "nodeA-m6" and "nodeC-m6" are neighbors
@@ -17,6 +24,11 @@ Feature: Test Bootstrapping With LS
     When milestone 10322 is issued on "nodeA-m6"
     And we wait "30" second/seconds
     Then "nodeA-m6" is synced up to milestone 10322
+
+    And the zmq stream for "nodeA-m6" contains a response for following topics:
+    |keys					|
+    |lmi					|
+    |lmsi					|
 
 
   Scenario: DB node is synced, and files contain expected values

--- a/python-regression/tests/features/steps/zmq_steps.py
+++ b/python-regression/tests/features/steps/zmq_steps.py
@@ -1,0 +1,47 @@
+from aloe import world, step
+import zmq
+
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+context = zmq.Context()
+socket = context.socket(zmq.SUB)
+poller = zmq.Poller()
+
+
+@step(r'"([^"]+)" is subscribed to the following zmq topics:')
+def subscribe_zmq(step, node):
+    arg_list = step.hashes
+
+    host = world.machine['nodes'][node]['podip']
+    port = world.machine['nodes'][node]['clusterip_ports']['zmq-feed']
+    socket.connect("tcp://{}:{}".format(host, port))
+
+    for arg in arg_list:
+        socket.setsockopt_string(zmq.SUBSCRIBE, arg['keys'])
+
+    poller.register(socket, zmq.POLLIN)
+
+
+@step(r'the zmq stream for "([^"]+)" contains a response for following topics:')
+def check_zmq_response(step, node):
+    arg_list = step.hashes
+
+    keys = []
+    for arg in arg_list:
+        keys.append(arg['keys'])
+
+    scan_sockets = True
+    while scan_sockets:
+        if len(poller.poll(timeout=1000)) != 0:
+            received = socket.recv().split()
+            contains_response = False
+            for arg in keys:
+                if received[0].decode() == arg:
+                    contains_response = True
+
+            assert contains_response is True, \
+                "The expected response in the zmq subscription '{}' is missing".format(arg)
+        else:
+            scan_sockets = False

--- a/python-regression/tests/features/steps/zmq_steps.py
+++ b/python-regression/tests/features/steps/zmq_steps.py
@@ -12,6 +12,12 @@ poller = zmq.Poller()
 
 @step(r'"([^"]+)" is subscribed to the following zmq topics:')
 def subscribe_zmq(step, node):
+    """
+    Subscribe to the given topics on the indicated node.
+
+    :param step.hashes:     List of topics to subscribe to
+    :param node:            The node to subscribe to
+    """
     arg_list = step.hashes
 
     host = world.machine['nodes'][node]['podip']
@@ -26,6 +32,13 @@ def subscribe_zmq(step, node):
 
 @step(r'the zmq stream for "([^"]+)" contains a response for following topics:')
 def check_zmq_response(step, node):
+    """"
+    Read the zmq stream on the indicated node, and ensure that all the provided topics are present in the
+    stream response.
+
+    :param step.hashes:     List of topics to check response for
+    :param node:            The node the stream is being read from (Not used in test, provided for clarity)
+    """
     arg_list = step.hashes
 
     keys = []


### PR DESCRIPTION
# Description
Add to the current tests to account for zmq topic publishing. It is intended to catch any breaking changes to zmq publishing of transaction and milestone data. 

Fixes #1598 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
- Tests were run locally to ensure zmq steps work in the different machines that they have been added to

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
