### PR TITLE
Change: Added check for jobs in the transaction pruner

### DIFF
--- a/src/main/java/com/iota/iri/service/snapshot/impl/LocalSnapshotManagerImpl.java
+++ b/src/main/java/com/iota/iri/service/snapshot/impl/LocalSnapshotManagerImpl.java
@@ -12,6 +12,7 @@ import com.iota.iri.service.snapshot.SnapshotService;
 import com.iota.iri.service.transactionpruning.PruningCondition;
 import com.iota.iri.service.transactionpruning.TransactionPruner;
 import com.iota.iri.service.transactionpruning.TransactionPruningException;
+import com.iota.iri.service.transactionpruning.jobs.MilestonePrunerJob;
 import com.iota.iri.utils.thread.ThreadIdentifier;
 import com.iota.iri.utils.thread.ThreadUtils;
 
@@ -241,7 +242,9 @@ public class LocalSnapshotManagerImpl implements LocalSnapshotManager {
     private boolean canPrune(int pruningMilestoneIndex) {
         int snapshotIndex = snapshotProvider.getInitialSnapshot().getIndex();
         // -1 means we can't prune, smaller than snapshotIndex because we prune until index + 1
-        return pruningMilestoneIndex > 0 && pruningMilestoneIndex < snapshotIndex;
+        return pruningMilestoneIndex > 0 
+                && pruningMilestoneIndex < snapshotIndex 
+                && !transactionPruner.hasActiveJobFor(MilestonePrunerJob.class);
     }
 
     /**

--- a/src/main/java/com/iota/iri/service/transactionpruning/TransactionPruner.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/TransactionPruner.java
@@ -46,4 +46,12 @@ public interface TransactionPruner {
      */
     void shutdown();
 
+    /**
+     * Checks if we have an active job running for the current type
+     * 
+     * @param jobClass  THe type of job we check for.
+     * @return <code>true</code> if there is a job running, otherwise <code>false</code>
+     */
+    <T extends TransactionPrunerJob> boolean hasActiveJobFor(Class<T> jobClass);
+
 }

--- a/src/main/java/com/iota/iri/service/transactionpruning/async/AsyncTransactionPruner.java
+++ b/src/main/java/com/iota/iri/service/transactionpruning/async/AsyncTransactionPruner.java
@@ -7,6 +7,7 @@ import com.iota.iri.service.spentaddresses.SpentAddressesProvider;
 import com.iota.iri.service.spentaddresses.SpentAddressesService;
 import com.iota.iri.service.transactionpruning.TransactionPruner;
 import com.iota.iri.service.transactionpruning.TransactionPrunerJob;
+import com.iota.iri.service.transactionpruning.TransactionPrunerJobStatus;
 import com.iota.iri.service.transactionpruning.TransactionPruningException;
 import com.iota.iri.service.transactionpruning.jobs.MilestonePrunerJob;
 import com.iota.iri.service.transactionpruning.jobs.UnconfirmedSubtanglePrunerJob;
@@ -277,6 +278,19 @@ public class AsyncTransactionPruner implements TransactionPruner {
         }
 
         return jobQueue;
+    }
+    
+    @Override
+    public <T extends TransactionPrunerJob> boolean hasActiveJobFor(Class<T> jobClass) {
+        JobQueue<T> jobQueue = jobQueues.get(jobClass);
+        if (jobQueue == null) {
+            return false;
+        }
+        
+        return jobQueue.stream().anyMatch(job -> {
+            return job.getStatus().equals(TransactionPrunerJobStatus.RUNNING)
+                    || job.getStatus().equals(TransactionPrunerJobStatus.PENDING);
+        });
     }
 
     /**


### PR DESCRIPTION
# Description

In order to prevent pruning logs for the same milestones, we wait for the current job to finish
This is done by checking the jobqueue for any active or pending jobs.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Only one times pruning message is logged

# Checklist:
- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
