### PR TITLE
Fix reference transaction logic

### DIFF
--- a/python-regression/tests/features/steps/response_handling_steps.py
+++ b/python-regression/tests/features/steps/response_handling_steps.py
@@ -24,6 +24,8 @@ def compare_thread_return(step, api_call):
     # Exclude duration from response list
     if 'duration' in response_list:
         del response_list['duration']
+    if 'info' in response_list:
+        del response_list['info']
     response_keys = response_list.keys()
 
     # Prepare expected values list for comparison
@@ -35,7 +37,6 @@ def compare_thread_return(step, api_call):
     # Confirm that the lists are of equal length before comparing
     assert len(keys) == len(response_keys), "Response: {} does not contain""\
                                             ""the same number of arguments: {}".format(keys,response_keys)
-
     for count in range(len(keys)):
         response_key = response_keys[count]
         response_value = response_list[response_key]

--- a/python-regression/tests/features/steps/transaction_steps.py
+++ b/python-regression/tests/features/steps/transaction_steps.py
@@ -3,7 +3,6 @@ from iota import Transaction
 from util import static_vals as static
 from util.test_logic import api_test_logic as api_utils
 from util.transaction_bundle_logic import transaction_logic as transactions
-from util.threading_logic import pool_logic as pool
 from util.milestone_logic import milestones
 from time import sleep
 
@@ -101,24 +100,11 @@ def reference_stitch_transaction(step):
     api = api_utils.prepare_api_call(node)
 
     transaction_bundle = transactions.create_transaction_bundle(referencing_address, 'REFERENCE9TAG', 0)
+    branch =  api.get_transactions_to_approve(depth=3)['branchTransaction']
+    options = {'trunk_transaction': stitch, 'branch_transaction': branch, 'trytes':
+        transaction_bundle.as_tryte_strings(), 'min_weight_magnitude': 9}
 
-    def transactions_to_approve(node, arg_list):
-        response = api_utils.fetch_call('getTransactionsToApprove', arg_list['api'], {'depth': 3})
-        arg_list['responses']['getTransactionsToApprove'][node] = response
-        return response
-
-    gtta_results = pool.start_pool(transactions_to_approve, 1, {node: {'api': api, 'responses': world.responses}})
-    branch = pool.fetch_results(gtta_results[0], 30)
-    options = {'trunk': stitch, 'branch': branch, 'trytes': transaction_bundle.as_tryte_strings(),
-               'min_weight_magnitude': 9}
-
-    def make_transaction(node, arg_list):
-        response = transactions.attach_store_and_broadcast(arg_list['api'], options)
-        arg_list['responses']['attachToTangle'][node] = response
-        return response
-
-    transaction_results = pool.start_pool(make_transaction, 1, {node: {'api': api, 'responses': world.responses}})
-    pool.fetch_results(transaction_results[0], 30)
+    transactions.attach_store_and_broadcast(api, options)
 
 
 @step(r'"(\d+)" transactions are issued on "([^"]+)" with:')


### PR DESCRIPTION
# Description
A fix for transaction issuance referencing another transaction in the regression tests. The machine 4 tests are reliant on this and have been exhibiting failures using the pool logic. This replaces the pool logic with simple synchronous api calls to ensure the test follows through properly. 

## Fixes: #1736 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- Ran tests locally for machine 4 tests

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
