### PR TITLE
Cache: Check for empty entries before adding them to cache

### DIFF
--- a/src/main/java/com/iota/iri/controllers/ApproveeViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/ApproveeViewModel.java
@@ -74,7 +74,7 @@ public class ApproveeViewModel implements HashesViewModel {
         }
 
         approveeViewModel = new ApproveeViewModel((Approvee) tangle.load(Approvee.class, hash), hash);
-        if (cache != null) {
+        if (cache != null && approveeViewModel.getHashes().size() > 0) {
             cachePut(tangle, approveeViewModel, hash);
         }
 

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -318,6 +318,7 @@ public class TransactionViewModel {
         }
         cachePut(tangle, this, hash);
         tangle.updateMessageQueueProvider(transaction, hash, item);
+        tangle.update(transaction, hash, item);
     }
 
     /**

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -318,7 +318,6 @@ public class TransactionViewModel {
         }
         cachePut(tangle, this, hash);
         tangle.updateMessageQueueProvider(transaction, hash, item);
-        tangle.update(transaction, hash, item);
     }
 
     /**

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -167,7 +167,7 @@ public class TransactionViewModel {
         transactionViewModel = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash), hash);
         fillMetadata(tangle, transactionViewModel);
 
-        if (cache != null) {
+        if (cache != null && transactionViewModel.getType() != PREFILLED_SLOT) {
             cachePut(tangle, transactionViewModel, hash);
         }
         return transactionViewModel;


### PR DESCRIPTION
# Description
During creation of TVM's the `TransactionViewModel.fromHash()` function will try to fetch the object from the cache first. If the object doesn't exist in the cache it will then try to fetch it from the db. If it doesn't exist in the db a new transaction is formed for the TVM, and then subsequently placed in the cache. This can happen in several places but there is a compounding effect during syncing as a transaction may be stored, but the trunk and branch of that transaction are not. Each time a `fromHash()` is called on those objects they are found in the cache as empty objects. So long as the empty object is found in the cache, new transactions will not be allowed to be stored until the empty object has been released. This cascades over into the `ApproveeViewModel` as well by filling the cache with empty AVM's.  

This patch makes sure to only store relevant TVM's and AVM's which helps to correct the synchronisation problem. 

Fixes: synchronisation issue in caching branch 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- Local testing for synchronisation between nodes sped up significantly after restoring the call

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
