### PR TITLE
Don't reply if there is nothing to request even if you are not synced

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
@@ -102,19 +102,11 @@ public class ReplyStage implements Stage {
 
         TransactionViewModel tvm = null;
 
+        // finish if there is nothing requested
         if (hashOfRequestedTx.equals(Hash.NULL_HASH)) {
             try {
-                // don't reply to random tip requests if we are synchronized with a max delta of one
-                // to the newest milestone
-                if (snapshotProvider.getLatestSnapshot().getIndex() >= latestMilestoneTracker.getLatestMilestoneIndex()
-                        - 1) {
-                    ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
-                    return ctx;
-                }
-                // retrieve random tx
-                neighbor.getMetrics().incrRandomTransactionRequestsCount();
-                Hash transactionPointer = getRandomTipPointer();
-                tvm = TransactionViewModel.fromHash(tangle, transactionPointer);
+                ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
+                return ctx;
             } catch (Exception e) {
                 log.error("error loading random tip for reply", e);
                 ctx.setNextStage(TransactionProcessingPipeline.Stage.ABORT);

--- a/src/test/java/com/iota/iri/network/pipeline/ReplyStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/ReplyStageTest.java
@@ -68,34 +68,6 @@ public class ReplyStageTest {
     private SecureRandom random;
 
     @Test
-    public void usingTheNullHashARandomTipIsGettingReplied() {
-        Mockito.when(random.nextDouble()).thenReturn(0.6d);
-        Mockito.when(nodeConfig.getpSendMilestone()).thenReturn(0.5);
-        Mockito.when(neighbor.getMetrics()).thenReturn(neighborMetrics);
-        Mockito.when(snapshotProvider.getLatestSnapshot()).thenReturn(snapshot);
-        Mockito.when(snapshot.getIndex()).thenReturn(8);
-        Mockito.when(latestMilestoneTracker.getLatestMilestoneIndex()).thenReturn(10);
-        Mockito.when(transactionRequester.numberOfTransactionsToRequest()).thenReturn(1);
-        Mockito.when(tipsViewModel.getRandomSolidTipHash()).thenReturn(SampleTransaction.CURL_HASH_OF_SAMPLE_TX);
-        TangleMockUtils.mockTransaction(tangle, SampleTransaction.CURL_HASH_OF_SAMPLE_TX,
-                SampleTransaction.SAMPLE_TRANSACTION);
-
-        ReplyStage stage = new ReplyStage(neighborRouter, nodeConfig, tangle, tipsViewModel, latestMilestoneTracker,
-                snapshotProvider, recentlySeenBytesCache, random);
-        ReplyPayload replyPayload = new ReplyPayload(neighbor, Hash.NULL_HASH);
-        ProcessingContext ctx = new ProcessingContext(replyPayload);
-        stage.process(ctx);
-
-        try {
-            Mockito.verify(neighborRouter).gossipTransactionTo(Mockito.any(), Mockito.any());
-            Mockito.verify(recentlySeenBytesCache).put(SampleTransaction.BYTES_DIGEST_OF_SAMPLE_TX,
-                    SampleTransaction.CURL_HASH_OF_SAMPLE_TX);
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
     public void usingASuppliedRequestedHashTheTransactionIsReplied() {
         TangleMockUtils.mockTransaction(tangle, SampleTransaction.CURL_HASH_OF_SAMPLE_TX,
                 SampleTransaction.SAMPLE_TRANSACTION);


### PR DESCRIPTION
# Description
We were seeing an issue of requesting too many needless transactions that clogged the pipeline queue.
So now a node won't reply even if it is not in sync

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

TBD


# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
