### PR TITLE
Remove ping pong from reply stage

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
@@ -148,13 +148,13 @@ public class ReplyStage implements Stage {
 
         // we didn't have the requested transaction (random or explicit) from the neighbor but we will immediately reply
         // with the latest known milestone and a needed transaction hash, to keep up the ping-pong
-        try {
-            final TransactionViewModel msTVM = TransactionViewModel.fromHash(tangle,
-                    latestMilestoneTracker.getLatestMilestoneHash());
-            neighborRouter.gossipTransactionTo(neighbor, msTVM, false);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        //try {
+        //    final TransactionViewModel msTVM = TransactionViewModel.fromHash(tangle,
+        //            latestMilestoneTracker.getLatestMilestoneHash());
+        //    neighborRouter.gossipTransactionTo(neighbor, msTVM, false);
+        //} catch (Exception e) {
+        //    e.printStackTrace();
+        //}
 
         ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
         return ctx;

--- a/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReplyStage.java
@@ -146,16 +146,6 @@ public class ReplyStage implements Stage {
             return ctx;
         }
 
-        // we didn't have the requested transaction (random or explicit) from the neighbor but we will immediately reply
-        // with the latest known milestone and a needed transaction hash, to keep up the ping-pong
-        //try {
-        //    final TransactionViewModel msTVM = TransactionViewModel.fromHash(tangle,
-        //            latestMilestoneTracker.getLatestMilestoneHash());
-        //    neighborRouter.gossipTransactionTo(neighbor, msTVM, false);
-        //} catch (Exception e) {
-        //    e.printStackTrace();
-        //}
-
         ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
         return ctx;
     }


### PR DESCRIPTION
# Description
There has been a syncing issue that arose from the internal tests that resulted in a flood of back and forth gossiping of the latest milestone. It fills the queues and stops the node from processing relevant transactions in a timely manner. This issue self corrects at times, but in other cases it stalls out for hours. It is possible that this is caused by the continued pushing of these transactions to the neighbors through the reply stage. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- After running a node with this change I did not experience the sync issue

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
