### PR TITLE
Revert milestone sorting

### DIFF
--- a/src/main/java/com/iota/iri/controllers/AddressViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/AddressViewModel.java
@@ -7,13 +7,8 @@ import com.iota.iri.storage.Indexable;
 import com.iota.iri.storage.Persistable;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.Pair;
-import pl.touk.throwing.ThrowingFunction;
-import pl.touk.throwing.ThrowingPredicate;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Acts as a controller interface for an {@link Address} set. This controller is used within a
@@ -41,25 +36,6 @@ public class AddressViewModel implements HashesViewModel {
     private AddressViewModel(Address hashes, Indexable hash) {
         self = hashes == null || hashes.set == null ? new Address(): hashes;
         this.hash = hash;
-    }
-
-    /**
-     * Loads all transaction that mutate a certain address. It sorts them by the attachment timestamp. Sorting by
-     * attachmentTimeStamp is an arbitrary choice.
-     * 
-     *
-     * @param tangle The tangle reference for the database to find the {@link Address} set in
-     * @param hash   hash The address we are loading the transactions for
-     * @return The list of {@link AddressViewModel} controllers generated
-     * @throws Exception Thrown if the database cannot load an {@link Address} set from the reference {@link Hash}
-     */
-    public static List<TransactionViewModel> loadAsSortedList(Tangle tangle, Indexable hash) throws Exception {
-        Address hashes = (Address) tangle.load(Address.class, hash);
-        return hashes.set.stream()
-                .filter(ThrowingPredicate.unchecked(hash1 -> TransactionViewModel.exists(tangle, hash1)))
-                .map(ThrowingFunction.unchecked(item -> TransactionViewModel.fromHash(tangle, item)))
-                .sorted(Comparator.comparing(TransactionViewModel::getAttachmentTimestamp))
-                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
This reverts commit b658b8857ed9fdf5736c124e148d4e1e0037e6e6.

# Description
In DB's with large collections of milestones, the `LatestMilestoneTracker` gets stalled out in the collection phase as it tries to create and sort all the milestone transaction objects. This can also cause memory errors in large enough db's and can stall out the milestone tracking process.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- Started node with 1M+ milestones and it did not stall on milestone tracking

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
