### PR TITLE
Config: Db maximum size explanation

### DIFF
--- a/src/main/java/com/iota/iri/conf/SnapshotConfig.java
+++ b/src/main/java/com/iota/iri/conf/SnapshotConfig.java
@@ -111,7 +111,8 @@ public interface SnapshotConfig extends Config {
         String LOCAL_SNAPSHOTS_INTERVAL_SYNCED = "Take local snapshots every n milestones if the node is fully synced.";
         String LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = "Take local snapshots every n milestones if the node is syncing.";
         String LOCAL_SNAPSHOTS_DEPTH = "Number of milestones to keep.";
-        String LOCAL_SNAPSHOTS_DB_MAX_SIZE = "The maximum size this database should be on disk. Human readable format (GB, GiB, MB, MiB)";
+        String LOCAL_SNAPSHOTS_DB_MAX_SIZE = "The maximum size this database should be on disk. Human readable format (GB, GiB, MB, MiB)."
+                + "If set to -1, the database size will not affect the node.";
         String SNAPSHOT_TIME = "Epoch time of the last snapshot.";
         String SNAPSHOT_FILE = "Path of the file that contains the state of the ledger at the last snapshot.";
         String SNAPSHOT_SIGNATURE_FILE = "Path to the file that contains a signature for the snapshot file.";


### PR DESCRIPTION
# Description
`LOCAL_SNAPSHOTS_DB_MAX_SIZE` could be set to -1, but its behaviour was undefined.
Now we clearly say that it means that the database size does not affect anything when set to -1

## Type of change
- Documentation Fix

# Checklist:

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
