### PR TITLE
Fix: Change INI config to be called MILESTONE_CACHE_SIZE

### DIFF
--- a/src/main/java/com/iota/iri/cache/impl/CacheManagerImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheManagerImpl.java
@@ -37,7 +37,7 @@ public class CacheManagerImpl implements CacheManager {
                 new CacheConfigurationImpl(dbConfig.getTxCacheSize(), dbConfig.getTxCacheReleaseCount()));
         add(ApproveeViewModel.class,
                 new CacheConfigurationImpl(dbConfig.getTxCacheSize(), dbConfig.getTxCacheReleaseCount()));
-        add(MilestoneViewModel.class, new CacheConfigurationImpl(dbConfig.getMilestoneBatchWrite(),
+        add(MilestoneViewModel.class, new CacheConfigurationImpl(dbConfig.getMilestoneCacheSize(),
                 dbConfig.getMilestoneCacheReleaseCount()));
     }
 

--- a/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
+++ b/src/main/java/com/iota/iri/conf/BaseIotaConfig.java
@@ -71,7 +71,7 @@ public abstract class BaseIotaConfig implements IotaConfig {
 
     // Cache
     protected int txCacheSize = Defaults.TX_CACHE_SIZE;
-    protected int milestoneBatchWrite = Defaults.MILESTONE_CACHE_SIZE;
+    protected int milestoneCacheSize = Defaults.MILESTONE_CACHE_SIZE;
     protected int txCacheReleaseCount = Defaults.TX_CACHE_RELEASE_COUNT;
     protected int milestoneCacheReleaseCount = Defaults.MILESTONE_CACHE_RELEASE_COUNT;
 
@@ -462,18 +462,18 @@ public abstract class BaseIotaConfig implements IotaConfig {
     }
 
     @Override
-    public int getMilestoneBatchWrite() {
-        return milestoneBatchWrite;
+    public int getMilestoneCacheSize() {
+        return milestoneCacheSize;
     }
 
     @JsonProperty
     @Parameter(names = { "--milestone-cache-size" }, description = DbConfig.Descriptions.MILESTONE_CACHE_SIZE)
-    protected void setMilestoneBatchWrite(int milestoneBatchWrite) {
-        if (milestoneBatchWrite < 1 || milestoneBatchWrite > Defaults.MAX_MILESTONE_CACHE_SIZE) {
+    protected void setMilestoneCacheSize(int milestoneCacheSize) {
+        if (milestoneCacheSize < 1 || milestoneCacheSize > Defaults.MAX_MILESTONE_CACHE_SIZE) {
             throw new ParameterException("MILESTONE_CACHE_SIZE should be between 1 and "
-                    + Defaults.MAX_MILESTONE_CACHE_SIZE + ". (found " + milestoneBatchWrite + ")");
+                    + Defaults.MAX_MILESTONE_CACHE_SIZE + ". (found " + milestoneCacheSize + ")");
         }
-        this.milestoneBatchWrite = milestoneBatchWrite;
+        this.milestoneCacheSize = milestoneCacheSize;
     }
 
     @Override

--- a/src/main/java/com/iota/iri/conf/DbConfig.java
+++ b/src/main/java/com/iota/iri/conf/DbConfig.java
@@ -66,7 +66,7 @@ public interface DbConfig extends Config {
      *
      * @return {@value DbConfig.Descriptions#MILESTONE_CACHE_SIZE}
      */
-    int getMilestoneBatchWrite();
+    int getMilestoneCacheSize();
 
     /**
      * Default Value: {@value BaseIotaConfig.Defaults#TX_CACHE_RELEASE_COUNT}

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -123,7 +123,7 @@ public class ConfigTest {
         Assert.assertEquals("--local-snapshots-pruning-delay", 40000, iotaConfig.getLocalSnapshotsPruningDelay());
         Assert.assertEquals("--tx-cache-size", 100, iotaConfig.getTxCacheSize());
         Assert.assertEquals("--tx-cache-release-count", 5, iotaConfig.getTxCacheReleaseCount());
-        Assert.assertEquals("--milestone-cache-size", 20, iotaConfig.getMilestoneBatchWrite());
+        Assert.assertEquals("--milestone-cache-size", 20, iotaConfig.getMilestoneCacheSize());
         Assert.assertEquals("--milestone-cache-release-count", 2, iotaConfig.getMilestoneCacheReleaseCount());
     }
 
@@ -195,7 +195,7 @@ public class ConfigTest {
                 iotaConfig.isDontValidateTestnetMilestoneSig());
         Assert.assertEquals("--tx-cache-size", 100, iotaConfig.getTxCacheSize());
         Assert.assertEquals("--tx-cache-release-count", 5, iotaConfig.getTxCacheReleaseCount());
-        Assert.assertEquals("--milestone-cache-size", 20, iotaConfig.getMilestoneBatchWrite());
+        Assert.assertEquals("--milestone-cache-size", 20, iotaConfig.getMilestoneCacheSize());
         Assert.assertEquals("--milestone-cache-release-count", 2, iotaConfig.getMilestoneCacheReleaseCount());
     }
 

--- a/src/test/java/com/iota/iri/conf/ConfigTest.java
+++ b/src/test/java/com/iota/iri/conf/ConfigTest.java
@@ -209,6 +209,7 @@ public class ConfigTest {
                 .append("ZMQ_ENABLED = true").append(System.lineSeparator())
                 .append("P_REMOVE_REQUEST = 0.4").append(System.lineSeparator())
                 .append("MWM = 4").append(System.lineSeparator())
+                .append("MILESTONE_CACHE_SIZE = 1").append(System.lineSeparator())
                 .append("FAKE").append(System.lineSeparator())
                 .append("FAKE2 = lies")
                 .toString();
@@ -231,6 +232,7 @@ public class ConfigTest {
 
         Assert.assertEquals("ZMQ_ENABLED", true, iotaConfig.isZmqEnabled());
         Assert.assertNotEquals("MWM", 4, iotaConfig.getMwm());
+        Assert.assertEquals("MILESTONE_CACHE_SIZE", 1, iotaConfig.getMilestoneCacheSize());
     }
 
     @Test


### PR DESCRIPTION
# Description

The configuration for Milestone cache size was erroneously called `MILESTONE_BATCH_WRITE`
Now it is called `MILESTONE_CACHE_SIZE`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

`ConfigTest#testIniParsingMainnet()` has been amended to check that INI parsing will work for this config.


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
