### PR TITLE
validate port number on addNeighbor API

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
@@ -246,7 +246,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * Handles a new incoming connection and if it passes some initial conditions (via
      * {@link NeighborRouterImpl#okToConnect(String, SocketChannel)}), will start the handshaking process by placing a
      * handshake packet into the connection's send queue.
-     * 
+     *
      * @param key the selection key associated with the server socket channel
      * @return whether the new connection was accepted
      */
@@ -298,7 +298,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * <p>
      * In case the connection sequence fails, the connection will be dropped.
      * </p>
-     * 
+     *
      * @param channel  the associated channel for the given connection
      * @param key      the associated selection key associated with the given connection
      * @param identity the identity of the connection/neighbor
@@ -335,7 +335,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * <p>
      * Handles the write readiness by the given channel by writing a message into its send buffer.
      * </p>
-     * 
+     *
      * <p>
      * If there was no message to send, then the channel is de-registered from write interests. If the channel would not
      * be de-registered from write interests, the channel's write readiness would constantly fire this method even if
@@ -425,7 +425,7 @@ public class NeighborRouterImpl implements NeighborRouter {
 
     /**
      * Adjusts the given socket's configuration.
-     * 
+     *
      * @param socketChannel the socket to configure
      * @throws IOException throw during adjusting the socket's configuration
      */
@@ -440,7 +440,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * domain of the neighbor was known when the connection was established, it will be used to re-establish the
      * connection to the neighbor, otherwise the neighbor's current known IP address is used.<br/>
      * The neighbor is only added to the 'reconnect pool' if the neighbor was ready to send/process messages.
-     * 
+     *
      * @param neighbor the neighbor to attempt to reconnect to
      * @return whether the neighbor got added to the reconnect pool or not
      */
@@ -465,7 +465,7 @@ public class NeighborRouterImpl implements NeighborRouter {
     /**
      * Ensures that the neighbor is removed from the reconnect pool by using the neighbor's IP address and domain
      * identity.
-     * 
+     *
      * @param neighbor the neighbor to remove from the reconnect pool
      * @return whether the neighbor was removed from the reconnect pool or not
      */
@@ -496,7 +496,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * <li>the neighbor is already connected (checked by the identity)</li>
      * <li>the identity is not known (missing in {@link NeighborRouterImpl#allowedNeighbors})</li>
      * </ul>
-     * 
+     *
      * @param identity The identity of the neighbor
      * @param neighbor The {@link Neighbor} to finalize the handshaking with
      * @param channel  The associated {@link SocketChannel} of the {@link Neighbor}
@@ -638,7 +638,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * Initializes a new {@link SocketChannel} to the given neighbor. <br/>
      * The IP address of the neighbor is removed from the blacklist, added to the whitelist and registered as an allowed
      * neighbor by its identity.
-     * 
+     *
      * @param neighborURI The {@link URI} of the neighbor to connect to
      * @param addr        The {@link InetSocketAddress} extracted from the {@link URI}
      * @throws IOException if initializing the {@link SocketChannel} fails
@@ -687,7 +687,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * </ul>
      * The IP address is blacklisted to mute it from subsequent connection attempts. The blacklisting is removed if the
      * IP address is added through {@link NeighborRouter#addNeighbor(String)}.
-     * 
+     *
      * @param ipAddress       The IP address
      * @param newNeighborConn The {@link SocketChannel} to close if the connection is not allowed
      * @return true if allowed, false if not
@@ -722,7 +722,7 @@ public class NeighborRouterImpl implements NeighborRouter {
      * Closes the connection to the neighbor, re-registers the {@link ServerSocketChannel} for
      * {@link SelectionKey#OP_CONNECT} in case neighbor slots will be available again and finally removes the neighbor
      * from the connected neighbors map.
-     * 
+     *
      * @param channel  {@link SocketChannel} to close
      * @param identity The identity of the neighbor, null must be passed if the neighbor should not be marked as not
      *                 connected.
@@ -834,11 +834,14 @@ public class NeighborRouterImpl implements NeighborRouter {
      * - it is not null
      * - it uses TCP as the protocol and
      * - the port is in the range 0 and {@value MAX_PORT}
-     * 
+     *
      * @param uri The URI to check
      * @return true if the URI is valid, false if not
      */
     private static boolean isURIValid(final URI uri) {
+        if (uri == null) {
+            return false;
+        }
         if (!uri.getScheme().equals("tcp")) {
             log.error("'{}' is not a valid URI schema, only TCP ({}) is supported", uri, PROTOCOL_PREFIX);
             return false;

--- a/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
@@ -35,6 +35,7 @@ public class NeighborRouterImpl implements NeighborRouter {
 
     private static final Logger log = LoggerFactory.getLogger(NeighborRouterImpl.class);
     private static final String PROTOCOL_PREFIX = "tcp://";
+    private static final int MAX_PORT = 65535;
 
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
@@ -829,7 +830,10 @@ public class NeighborRouterImpl implements NeighborRouter {
     }
 
     /**
-     * Checks whether the given URI is valid. The URI is valid if it is not null and it uses TCP as the protocol.
+     * Checks whether the given URI is valid. The URI is valid if
+     * - it is not null
+     * - it uses TCP as the protocol and
+     * - the port is in the range 0 and {@value MAX_PORT}
      * 
      * @param uri The URI to check
      * @return true if the URI is valid, false if not
@@ -837,6 +841,10 @@ public class NeighborRouterImpl implements NeighborRouter {
     private static boolean isURIValid(final URI uri) {
         if (!uri.getScheme().equals("tcp")) {
             log.error("'{}' is not a valid URI schema, only TCP ({}) is supported", uri, PROTOCOL_PREFIX);
+            return false;
+        }
+        if (uri.getPort() < 0 || uri.getPort() > MAX_PORT) {
+            log.error("'{} is not in the valid port range of {} and {}", uri.getPort(), 0, MAX_PORT);
             return false;
         }
         return true;


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Adds port number validation to neighbour URI.
The port number is an unsigned 16-bit integer, so max is 65535. See [port](https://en.wikipedia.org/wiki/Port_(computer_networking))

Fixes #1678 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
