### PR TITLE
Fix: made gb default lowercase

### DIFF
--- a/src/main/java/com/iota/iri/utils/IotaUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaUtils.java
@@ -141,7 +141,7 @@ public class IotaUtils {
         }
 
         //Default to GB
-        String sub = amount == humanReadableSize.length() ? "GB" : humanReadableSize.substring(spaceNdx);
+        String sub = amount == humanReadableSize.length() ? "gb" : humanReadableSize.substring(spaceNdx);
         switch (sub) {
             case "tb":
                 return (long) (amount * TB_FACTOR);

--- a/src/test/java/com/iota/iri/utils/IotaUtilsTest.java
+++ b/src/test/java/com/iota/iri/utils/IotaUtilsTest.java
@@ -14,8 +14,9 @@ public class IotaUtilsTest {
 
         assertEquals("No space should be allowed in conversion", 1000000000l, IotaUtils.parseFileSize("1GB"));
         assertEquals("No space should be allowed in conversion", 1073741824l, IotaUtils.parseFileSize("1GiB"));
-        
 
+        assertEquals("Default should be GB", 1000000000l, IotaUtils.parseFileSize("1"));
+        
         assertEquals("-1 should return -1", -1l, IotaUtils.parseFileSize("-1"));
     }
 }


### PR DESCRIPTION
# Description

Default value for size should be gb, but it was in upper case. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

_Please delete items that are not relevant._

- [X] My code follows the style guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
