### PR TITLE
Remove threshold from getbalances API call

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1059,20 +1059,12 @@ public class API {
       *
       * @param addresses Address for which to get the balance (do not include the checksum)
       * @param tips The optional tips to find the balance through.
-      * @param threshold The confirmation threshold between 0 and 100(inclusive).
-      *                  Should be set to 100 for getting balance by counting only confirmed transactions.
       * @return {@link com.iota.iri.service.dto.GetBalancesResponse}
       * @throws Exception When the database has encountered an error
       **/
     @Document(name="getBalances")
     private AbstractResponse getBalancesStatement(List<String> addresses, 
-                                                  List<String> tips,
-                                                  int threshold) throws Exception {
-
-        if (threshold <= 0 || threshold > 100) {
-            return ErrorResponse.create("Illegal 'threshold'");
-        }
-
+                                                  List<String> tips) throws Exception {
         final List<Hash> addressList = addresses.stream()
                 .map(address -> (HashFactory.ADDRESS.create(address)))
                 .collect(Collectors.toCollection(LinkedList::new));
@@ -1527,10 +1519,8 @@ public class API {
             final List<String> tips = request.containsKey("tips") ?
                 getParameterAsList(request,"tips", HASH_SIZE):
                 null;
-            final int threshold = getParameterAsInt(request, "threshold");
-            
             try {
-                return getBalancesStatement(addresses, tips, threshold);
+                return getBalancesStatement(addresses, tips);
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }

--- a/src/test/java/com/iota/iri/service/APIIntegrationTests.java
+++ b/src/test/java/com/iota/iri/service/APIIntegrationTests.java
@@ -358,7 +358,6 @@ public class APIIntegrationTests {
         final Map<String, Object> request = new HashMap<>();
         request.put("command", "getBalances");
         request.put("addresses", ADDRESSES);
-        request.put("threshold", 100);
 
         given().
             body(gson().toJson(request)).


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Removes the unused `threshold` parameter from `getBalances` API call.

Fixes #1723 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Existing unit tests pass
- Manually called `getBalances` on a node with and without threshold.


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
