### PR TITLE
getTrytes API: add null to response list of tvm is null

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -566,6 +566,8 @@ public class API {
             final TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, HashFactory.TRANSACTION.create(hash));
             if (transactionViewModel != null) {
                 elements.add(Converter.trytes(transactionViewModel.trits()));
+            } else {
+                elements.add(null);
             }
         }
         if (elements.size() > maxGetTrytes){


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
If the tvm for a  hash supplied during `getTrytes` api call is null, put null in the response instead of returning a shorter list.

Fixes #965

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests pass

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
