### PR TITLE
Only cache after exists check passes

### DIFF
--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -442,13 +442,13 @@ public class TransactionViewModel {
         // We need to save approvees, tags, and other metadata that is used by
         // non-cached operations.
         List<Pair<Indexable, Persistable>> batch = getSaveBatch();
-        cacheApprovees(tangle);
-        if (tangle.getCache(TransactionViewModel.class).get(hash) == null) {
-            cachePut(tangle, this, hash);
-        }
 
         if (tangle.exists(Transaction.class, hash)) {
             return false;
+        }
+        cacheApprovees(tangle);
+        if (tangle.getCache(TransactionViewModel.class).get(hash) == null) {
+            cachePut(tangle, this, hash);
         }
         tangle.saveBatch(batch);
         return true;


### PR DESCRIPTION
# Description

When a node sees a transaction it may have seen before it won't insert it into the cache to not override the existing transaction.

Fixes a problem where we may be switching instances of txs and thus not setting them solid, because we skip the `updateStatus` method

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

TBD

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
