### PR TITLE
Temporary: Update devnet image for getTips removal 

### DIFF
--- a/src/main/java/com/iota/iri/model/persistables/Transaction.java
+++ b/src/main/java/com/iota/iri/model/persistables/Transaction.java
@@ -66,9 +66,6 @@ public class Transaction implements Persistable {
      */
     public long arrivalTime = 0;
 
-
-    //public boolean confirmed = false;
-
     /**
      * This flag indicates if the transaction metadata was parsed from a byte array.
      */


### PR DESCRIPTION
# Description
This is for generating an image for devnet to use that contains all the previous commits. The latest devnet image does not have the removal of gettips in it. This can be closed once the image has been generated. 