### PR TITLE
validate bundles as they come in

### DIFF
--- a/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
+++ b/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
@@ -3,6 +3,7 @@ package com.iota.iri.network;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.iota.iri.BundleValidator;
 import com.iota.iri.service.validation.TransactionValidator;
 import com.iota.iri.conf.IotaConfig;
 import com.iota.iri.controllers.TipsViewModel;
@@ -44,11 +45,11 @@ public class NetworkInjectionConfiguration extends AbstractModule {
     @Singleton
     @Provides
     TransactionProcessingPipeline provideTransactionProcessingPipeline(NeighborRouter neighborRouter,
-            TransactionValidator txValidator, Tangle tangle, SnapshotProvider snapshotProvider,
-            TipsViewModel tipsViewModel, LatestMilestoneTracker latestMilestoneTracker,
-            TransactionRequester transactionRequester) {
+                                                                       TransactionValidator txValidator, Tangle tangle, SnapshotProvider snapshotProvider,
+                                                                       TipsViewModel tipsViewModel, LatestMilestoneTracker latestMilestoneTracker,
+                                                                       TransactionRequester transactionRequester, BundleValidator bundleValidator) {
         return new TransactionProcessingPipelineImpl(neighborRouter, configuration, txValidator, tangle,
-                snapshotProvider, tipsViewModel, latestMilestoneTracker, transactionRequester);
+                snapshotProvider, tipsViewModel, latestMilestoneTracker, transactionRequester, bundleValidator);
     }
 
     @Singleton

--- a/src/main/java/com/iota/iri/network/pipeline/QuickBundleValidationPayload.java
+++ b/src/main/java/com/iota/iri/network/pipeline/QuickBundleValidationPayload.java
@@ -1,0 +1,45 @@
+package com.iota.iri.network.pipeline;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.network.neighbor.Neighbor;
+
+/**
+ * Defines the payload which gets submitted to the {@link QuickBundleValidationStage}
+ */
+public class QuickBundleValidationPayload extends Payload {
+
+    private Neighbor neighbor;
+    private TransactionViewModel tvm;
+
+    /**
+     * Creates a new {@link QuickBundleValidationPayload}
+     *
+     * @param neighbor The {@link Neighbor} form which the transaction originated from.
+     * @param tvm      The transaction
+     */
+    public QuickBundleValidationPayload(Neighbor neighbor, TransactionViewModel tvm) {
+        this.neighbor = neighbor;
+        this.tvm = tvm;
+    }
+
+    @Override
+    public Neighbor getOriginNeighbor() {
+        return neighbor;
+    }
+
+    /**
+     * Gets the transaction
+     * 
+     * @return The transaction
+     */
+    public TransactionViewModel getTransactionViewModel() {
+        return tvm;
+    }
+
+    @Override
+    public String toString() {
+        return "QuickBundleValidationPayload{" + "neighbor=" + neighbor.getHostAddressAndPort() + ", tvm="
+                + tvm.getHash() + '}';
+    }
+
+}

--- a/src/main/java/com/iota/iri/network/pipeline/QuickBundleValidationStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/QuickBundleValidationStage.java
@@ -1,0 +1,62 @@
+package com.iota.iri.network.pipeline;
+
+import com.iota.iri.BundleValidator;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.validation.TransactionValidator;
+import com.iota.iri.storage.Tangle;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link QuickBundleValidationStage} validates the transaction bundle and propagates it if it's valid.
+ */
+public class QuickBundleValidationStage implements Stage {
+
+    private static final Logger log = LoggerFactory.getLogger(QuickBundleValidationStage.class);
+
+    BundleValidator bundleValidator;
+    TransactionValidator transactionValidator;
+    Tangle tangle;
+    SnapshotProvider snapshotProvider;
+
+    /**
+     * Creates a new {@link QuickBundleValidationStage}
+     * 
+     * @param tangle               Tangle
+     * @param snapshotProvider     SnapshotProvider
+     * @param bundleValidator      BundleValidator
+     * @param transactionValidator TransactionValidator
+     */
+    public QuickBundleValidationStage(Tangle tangle, SnapshotProvider snapshotProvider, BundleValidator bundleValidator,
+            TransactionValidator transactionValidator) {
+        this.tangle = tangle;
+        this.snapshotProvider = snapshotProvider;
+        this.bundleValidator = bundleValidator;
+        this.transactionValidator = transactionValidator;
+    }
+
+    @Override
+    public ProcessingContext process(ProcessingContext ctx) {
+        QuickBundleValidationPayload payload = (QuickBundleValidationPayload) ctx.getPayload();
+        TransactionViewModel tvm = payload.getTransactionViewModel();
+
+        try {
+            if (tvm.isSolid() && tvm.getCurrentIndex() == 0) {
+                List<TransactionViewModel> bundleTransactions = bundleValidator.validate(tangle, true,
+                        snapshotProvider.getInitialSnapshot(), tvm.getHash());
+                if (!bundleTransactions.isEmpty()) {
+                    transactionValidator.addSolidTransaction(tvm.getHash());
+                }
+            }
+        } catch (Exception e) {
+            log.error("error validating bundle", e);
+        }
+        ctx.setNextStage(TransactionProcessingPipeline.Stage.BROADCAST);
+        ctx.setPayload(new BroadcastPayload(payload.getOriginNeighbor(), tvm));
+        return ctx;
+    }
+}

--- a/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
@@ -91,7 +91,7 @@ public class ReceivedStage implements Stage {
         }
 
         // broadcast the newly saved tx to the other neighbors
-        ctx.setNextStage(TransactionProcessingPipeline.Stage.BROADCAST);
+        ctx.setNextStage(TransactionProcessingPipeline.Stage.QUICK_BUNDLE_VALIDATION);
         ctx.setPayload(new BroadcastPayload(originNeighbor, tvm));
         return ctx;
     }

--- a/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipeline.java
+++ b/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipeline.java
@@ -14,7 +14,7 @@ public interface TransactionProcessingPipeline {
      * Defines the different stages of the {@link TransactionProcessingPipelineImpl}.
      */
     enum Stage {
-        PRE_PROCESS, HASHING, VALIDATION, REPLY, RECEIVED, BROADCAST, MULTIPLE, ABORT, FINISH,
+        PRE_PROCESS, HASHING, VALIDATION, REPLY, RECEIVED, QUICK_BUNDLE_VALIDATION, BROADCAST, MULTIPLE, ABORT, FINISH,
     }
 
     /**
@@ -111,4 +111,11 @@ public interface TransactionProcessingPipeline {
      * @param hashingStage the {@link HashingStage} to use
      */
     void setHashingStage(HashingStage hashingStage);
+
+    /**
+     * Sets the quick bundle validation stage.
+     *
+     * @param quickBundleValidationStage The {@link QuickBundleValidationStage} to use.
+     */
+    void setQuickBundleValidationStage(QuickBundleValidationStage quickBundleValidationStage);
 }

--- a/src/test/java/com/iota/iri/network/pipeline/QuickBundleValidationStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/QuickBundleValidationStageTest.java
@@ -1,0 +1,98 @@
+package com.iota.iri.network.pipeline;
+
+import com.iota.iri.BundleValidator;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.network.neighbor.Neighbor;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.validation.TransactionValidator;
+import com.iota.iri.storage.Tangle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class QuickBundleValidationStageTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    BundleValidator bundleValidator;
+    @Mock
+    TransactionValidator transactionValidator;
+    @Mock
+    Tangle tangle;
+    @Mock
+    SnapshotProvider snapshotProvider;
+    @Mock
+    private Neighbor neighbor;
+    @Mock
+    TransactionViewModel tvm;
+
+    @Test
+    public void propagatesSolidTailAndValidBundle() throws Exception {
+        List<TransactionViewModel> bundleTransactions = new ArrayList<TransactionViewModel>() {
+
+            {
+                add(tvm);
+            }
+        };
+        Mockito.when(tvm.isSolid()).thenReturn(true);
+        Mockito.when(tvm.getCurrentIndex()).thenReturn(0L);
+        Mockito.when(bundleValidator.validate(tangle, true, snapshotProvider.getInitialSnapshot(), tvm.getHash()))
+                .thenReturn(bundleTransactions);
+
+        QuickBundleValidationStage stage = new QuickBundleValidationStage(tangle, snapshotProvider, bundleValidator,
+                transactionValidator);
+        QuickBundleValidationPayload payload = new QuickBundleValidationPayload(neighbor, tvm);
+        ProcessingContext ctx = new ProcessingContext(null, payload);
+        stage.process(ctx);
+
+        Mockito.verify(transactionValidator).addSolidTransaction(tvm.getHash());
+    }
+
+    @Test
+    public void shouldNotPropagateNonSolidTail() throws Exception {
+        Mockito.when(tvm.isSolid()).thenReturn(false);
+        Mockito.when(tvm.getCurrentIndex()).thenReturn(0L);
+        QuickBundleValidationStage stage = new QuickBundleValidationStage(tangle, snapshotProvider, bundleValidator,
+                transactionValidator);
+        QuickBundleValidationPayload payload = new QuickBundleValidationPayload(neighbor, tvm);
+        ProcessingContext ctx = new ProcessingContext(null, payload);
+        stage.process(ctx);
+        Mockito.verify(transactionValidator, Mockito.never()).addSolidTransaction(tvm.getHash());
+    }
+
+    @Test
+    public void shouldNotPropagateNonTail() throws Exception {
+        Mockito.when(tvm.isSolid()).thenReturn(false);
+        Mockito.when(tvm.getCurrentIndex()).thenReturn(1L);
+        QuickBundleValidationStage stage = new QuickBundleValidationStage(tangle, snapshotProvider, bundleValidator,
+                transactionValidator);
+        QuickBundleValidationPayload payload = new QuickBundleValidationPayload(neighbor, tvm);
+        ProcessingContext ctx = new ProcessingContext(null, payload);
+        stage.process(ctx);
+        Mockito.verify(transactionValidator, Mockito.never()).addSolidTransaction(tvm.getHash());
+    }
+
+    @Test
+    public void shouldNotPropagateInvalidBundle() throws Exception {
+        Mockito.when(tvm.isSolid()).thenReturn(false);
+        Mockito.when(tvm.getCurrentIndex()).thenReturn(1L);
+        Mockito.when(bundleValidator.validate(tangle, true, snapshotProvider.getInitialSnapshot(), tvm.getHash()))
+                .thenReturn(Collections.emptyList());
+        QuickBundleValidationStage stage = new QuickBundleValidationStage(tangle, snapshotProvider, bundleValidator,
+                transactionValidator);
+        QuickBundleValidationPayload payload = new QuickBundleValidationPayload(neighbor, tvm);
+        ProcessingContext ctx = new ProcessingContext(null, payload);
+        stage.process(ctx);
+        Mockito.verify(transactionValidator, Mockito.never()).addSolidTransaction(tvm.getHash());
+    }
+}

--- a/src/test/java/com/iota/iri/network/pipeline/ReceivedStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/ReceivedStageTest.java
@@ -58,7 +58,7 @@ public class ReceivedStageTest {
         Mockito.verify(tvm).update(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(transactionRequester).removeRecentlyRequestedTransaction(Mockito.any());
         Mockito.verify(transactionRequester).requestTrunkAndBranch(Mockito.any());
-        assertEquals("should submit to broadcast stage next", TransactionProcessingPipeline.Stage.BROADCAST,
+        assertEquals("should submit to broadcast stage next", TransactionProcessingPipeline.Stage.QUICK_BUNDLE_VALIDATION,
                 ctx.getNextStage());
         BroadcastPayload broadcastPayload = (BroadcastPayload) ctx.getPayload();
         assertEquals("neighbor is still the same", neighbor, broadcastPayload.getOriginNeighbor());
@@ -79,7 +79,7 @@ public class ReceivedStageTest {
         Mockito.verify(tvm, Mockito.never()).update(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(transactionRequester).removeRecentlyRequestedTransaction(Mockito.any());
         Mockito.verify(transactionRequester, Mockito.never()).requestTrunkAndBranch(Mockito.any());
-        assertEquals("should submit to broadcast stage next", TransactionProcessingPipeline.Stage.BROADCAST,
+        assertEquals("should submit to broadcast stage next", TransactionProcessingPipeline.Stage.QUICK_BUNDLE_VALIDATION,
                 ctx.getNextStage());
         BroadcastPayload broadcastPayload = (BroadcastPayload) ctx.getPayload();
         assertEquals("neighbor should still be the same", neighbor, broadcastPayload.getOriginNeighbor());


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

This adds a new `QuickBundleValidation` stage between `Received` and `Broadcast` stages.
If the tx submitted to this stage is solid & is a tail, it propagates it via `TransactionValidator#addSolidTransaction`

Fixes #1810 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Existing unit tests pass
- Added difference scenarios that test edge cases for transaction solidity, tail and bundle validity.


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
