### PR TITLE
Solidify transactions we walk across while doing GTTA

### DIFF
--- a/src/main/java/com/iota/iri/service/milestone/MilestoneSolidifier.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneSolidifier.java
@@ -1,5 +1,6 @@
 package com.iota.iri.service.milestone;
 
+import com.iota.iri.TransactionValidator;
 import com.iota.iri.model.Hash;
 
 /**
@@ -8,6 +9,19 @@ import com.iota.iri.model.Hash;
  * missing transactions until the milestones become solid.
  */
 public interface MilestoneSolidifier {
+
+    /**
+     * <p>
+     * Defines the maximum amount of transactions that are allowed to get processed while trying to solidify a
+     * milestone.
+     * </p>
+     * <p>
+     * Note: We want to find the next previous milestone and not get stuck somewhere at the end of the tangle with a
+     *       long running {@link TransactionValidator#checkSolidity(Hash)} call.
+     * </p>
+     */
+    int SOLIDIFICATION_TRANSACTIONS_LIMIT = 50000;
+
     /**
      * This method allows us to add new milestones to the solidifier that will consequently be solidified.
      *

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -38,18 +38,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
     private static final int SOLIDIFICATION_INTERVAL = 500;
 
     /**
-     * <p>
-     * Defines the maximum amount of transactions that are allowed to get processed while trying to solidify a
-     * milestone.
-     * </p>
-     * <p>
-     * Note: We want to find the next previous milestone and not get stuck somewhere at the end of the tangle with a
-     *       long running {@link TransactionValidator#checkSolidity(Hash)} call.
-     * </p>
-     */
-    private static final int SOLIDIFICATION_TRANSACTIONS_LIMIT = 50000;
-
-    /**
      * Logger for this class allowing us to dump debug and status messages.
      */
     private static final IntervalLogger log = new IntervalLogger(MilestoneSolidifier.class);

--- a/src/main/java/com/iota/iri/service/tipselection/TipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/TipSelSolidifier.java
@@ -1,0 +1,16 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+
+/**
+ * In charge of solidifying unsolid transactions we walked on during tipsel
+ */
+public interface TipSelSolidifier {
+
+    /**
+     * Solidify a give transaction
+     *
+     * @param transactionHash hash of transaction to solidify
+     */
+    void solidify(Hash transactionHash);
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
@@ -2,6 +2,7 @@ package com.iota.iri.service.tipselection.impl;
 
 import com.iota.iri.TransactionValidator;
 import com.iota.iri.model.Hash;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
 import com.iota.iri.service.tipselection.TipSelSolidifier;
 
 import java.util.Set;
@@ -40,7 +41,7 @@ public class AsyncTipSelSolidifier implements TipSelSolidifier {
             solidExecutor.submit(() -> {
                 try {
                     log.debug("attempting to solidify transaction {}", transactionHash);
-                    transactionValidator.checkSolidity(transactionHash);
+                    transactionValidator.checkSolidity(transactionHash, MilestoneSolidifier.SOLIDIFICATION_TRANSACTIONS_LIMIT);
                 } catch (Exception e) {
                     log.error("Failed to solidify transaction during a walk", e);
                 }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
@@ -1,0 +1,50 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.tipselection.TipSelSolidifier;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AsyncTipSelSolidifier implements TipSelSolidifier {
+
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncTipSelSolidifier.class);
+
+    private final TransactionValidator transactionValidator;
+    private final Set<Hash> transactionToSolidify = ConcurrentHashMap.newKeySet();
+    private final ExecutorService solidExecutor;
+
+    public AsyncTipSelSolidifier(TransactionValidator transactionValidator) {
+        this.transactionValidator = transactionValidator;
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(this.getClass().getSimpleName() + " %d")
+                .build();
+        solidExecutor = Executors.newCachedThreadPool(threadFactory);
+    }
+
+
+    @Override
+    public void solidify(Hash transactionHash) {
+        // Don't try to solidify transactions that are in the process of being solidified
+        //Problem: we are not checking transactions in the past cone here
+        if (transactionToSolidify.add(transactionHash)) {
+            solidExecutor.submit(() -> {
+                try {
+                    transactionValidator.checkSolidity(transactionHash);
+                } catch (Exception e) {
+                    log.error("Failed to solidify transaction during a walk", e);
+                }
+                transactionToSolidify.remove(transactionHash);
+            });
+        }
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/AsyncTipSelSolidifier.java
@@ -39,6 +39,7 @@ public class AsyncTipSelSolidifier implements TipSelSolidifier {
         if (transactionToSolidify.add(transactionHash)) {
             solidExecutor.submit(() -> {
                 try {
+                    log.debug("attempting to solidify transaction {}", transactionHash);
                     transactionValidator.checkSolidity(transactionHash);
                 } catch (Exception e) {
                     log.error("Failed to solidify transaction during a walk", e);

--- a/src/main/java/com/iota/iri/service/tipselection/impl/DummyTipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/DummyTipSelSolidifier.java
@@ -6,7 +6,7 @@ import com.iota.iri.service.tipselection.TipSelSolidifier;
 /**
  * Does nothing
  */
-public class FakeTipSelSolidifier implements TipSelSolidifier {
+public class DummyTipSelSolidifier implements TipSelSolidifier {
 
 
     @Override

--- a/src/main/java/com/iota/iri/service/tipselection/impl/FakeTipSelSolidifier.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/FakeTipSelSolidifier.java
@@ -1,0 +1,16 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.tipselection.TipSelSolidifier;
+
+/**
+ * Does nothing
+ */
+public class FakeTipSelSolidifier implements TipSelSolidifier {
+
+
+    @Override
+    public void solidify(Hash transactionHash) {
+        //DO NOTHING
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -11,11 +11,7 @@ import com.iota.iri.conf.TipSelConfig;
 import com.iota.iri.model.Hash;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.tipselection.EntryPointSelector;
-import com.iota.iri.service.tipselection.RatingCalculator;
-import com.iota.iri.service.tipselection.TipSelector;
-import com.iota.iri.service.tipselection.WalkValidator;
-import com.iota.iri.service.tipselection.Walker;
+import com.iota.iri.service.tipselection.*;
 import com.iota.iri.storage.Tangle;
 
 /**
@@ -37,6 +33,7 @@ public class TipSelectorImpl implements TipSelector {
     private final Tangle tangle;
     private final SnapshotProvider snapshotProvider;
     private final TipSelConfig config;
+    private final TipSelSolidifier tipSelSolidifier;
 
     /**
      * Constructor for Tip Selector.
@@ -47,6 +44,7 @@ public class TipSelectorImpl implements TipSelector {
      * @param entryPointSelector instance of the entry point selector to get tip selection starting points.
      * @param ratingCalculator instance of rating calculator, to calculate weighted walks.
      * @param walkerAlpha instance of walker (alpha), to perform weighted random walks as per the IOTA white paper.
+     * @param tipSelSolidifier solidifies unsolid transactions we walk on
      * @param config configurations to set internal parameters.
      */
     public TipSelectorImpl(Tangle tangle,
@@ -55,6 +53,7 @@ public class TipSelectorImpl implements TipSelector {
                            EntryPointSelector entryPointSelector,
                            RatingCalculator ratingCalculator,
                            Walker walkerAlpha,
+                           TipSelSolidifier tipSelSolidifier,
                            TipSelConfig config) {
 
         this.entryPointSelector = entryPointSelector;
@@ -66,6 +65,7 @@ public class TipSelectorImpl implements TipSelector {
         this.ledgerService = ledgerService;
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
+        this.tipSelSolidifier = tipSelSolidifier;
         this.config = config;
     }
 
@@ -104,7 +104,8 @@ public class TipSelectorImpl implements TipSelector {
             //random walk
             List<Hash> tips = new LinkedList<>();
             //ISSUE #786: walkValidator should become a stateless dependency
-            WalkValidator walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService, config);
+            WalkValidator walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
+                    tipSelSolidifier, config);
             Hash tip = walker.walk(entryPoint, rating, walkValidator);
             tips.add(tip);
 

--- a/src/test/java/com/iota/iri/service/APITest.java
+++ b/src/test/java/com/iota/iri/service/APITest.java
@@ -43,7 +43,7 @@ public class APITest {
         API api = new API(config, null, null, null,
                 null, null,
                 snapshotProvider, null, null, null, null,
-                transactionValidator, null, null);
+                transactionValidator, null, null, null);
 
         api.storeTransactionsStatement(Collections.singletonList("FOO"));
 

--- a/src/test/java/com/iota/iri/service/ApiCallTest.java
+++ b/src/test/java/com/iota/iri/service/ApiCallTest.java
@@ -14,7 +14,7 @@ public class ApiCallTest {
     @Before
     public void setUp() {
         IotaConfig configuration = Mockito.mock(IotaConfig.class);
-        api = new API(configuration, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        api = new API(configuration, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TipSelectorImplTest.java
@@ -21,10 +21,7 @@ import com.iota.iri.model.Hash;
 import com.iota.iri.model.HashFactory;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.snapshot.SnapshotProvider;
-import com.iota.iri.service.tipselection.EntryPointSelector;
-import com.iota.iri.service.tipselection.RatingCalculator;
-import com.iota.iri.service.tipselection.WalkValidator;
-import com.iota.iri.service.tipselection.Walker;
+import com.iota.iri.service.tipselection.*;
 import com.iota.iri.storage.Tangle;
 
 public class TipSelectorImplTest {
@@ -51,6 +48,9 @@ public class TipSelectorImplTest {
     private SnapshotProvider snapshotProvider;
 
     @Mock
+    private TipSelSolidifier tipSelSolidifier;
+
+    @Mock
     private TipSelConfig config;
 
     private static final Hash REFERENCE = HashFactory.TRANSACTION.create("ENTRYPOINT");
@@ -65,7 +65,7 @@ public class TipSelectorImplTest {
     public void setUpEach() {
         when(config.getAlpha()).thenReturn(BaseIotaConfig.Defaults.ALPHA);
         tipSelector = new TipSelectorImpl(tangle, snapshotProvider, ledgerService, entryPointSelector, ratingCalculator,
-                walker, config);
+                walker, tipSelSolidifier, config);
     }
 
     @Test

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -8,6 +8,7 @@ import com.iota.iri.model.Hash;
 import com.iota.iri.service.ledger.LedgerService;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.impl.SnapshotMockUtils;
+import com.iota.iri.service.tipselection.TipSelSolidifier;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
 import org.junit.After;
@@ -44,6 +45,9 @@ public class WalkValidatorImplTest {
 
     @Mock
     private static LedgerService ledgerService;
+
+    @Mock
+    private TipSelSolidifier tipSelSolidifier;
 
     @AfterClass
     public static void tearDown() throws Exception {
@@ -85,7 +89,8 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(depth);
 
-        WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService, config);
+        WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
+                tipSelSolidifier, config);
         Assert.assertTrue("Validation failed", walkValidator.isValid(hash));
     }
 
@@ -101,7 +106,7 @@ public class WalkValidatorImplTest {
         snapshotProvider.getLatestSnapshot().setIndex(depth);
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertFalse("Validation succeded but should have failed since tx is missing", walkValidator.isValid(hash));
     }
 
@@ -116,7 +121,7 @@ public class WalkValidatorImplTest {
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertFalse("Validation succeded but should have failed since we are not on a tail", walkValidator.isValid(hash));
     }
 
@@ -131,7 +136,7 @@ public class WalkValidatorImplTest {
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+        tipSelSolidifier ,config);
         Assert.assertFalse("Validation succeded but should have failed since tx is not solid",
                 walkValidator.isValid(hash));
     }
@@ -147,7 +152,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertFalse("Validation succeeded but should have failed tx is below max depth",
                 walkValidator.isValid(hash));
     }
@@ -170,7 +175,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(100);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+        tipSelSolidifier ,config);
         Assert.assertTrue("Validation failed but should have succeeded since tx is above max depth",
                 walkValidator.isValid(hash));
     }
@@ -195,7 +200,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(100);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+        tipSelSolidifier, config);
         Assert.assertFalse("Validation succeeded but should have failed since tx is below max depth",
                 walkValidator.isValid(hash));
     }
@@ -217,7 +222,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(15);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertTrue("Validation failed but should have succeeded. We didn't exceed the maximal amount of" +
                         "transactions that may be analyzed.",
                 walkValidator.isValid(tx.getHash()));
@@ -241,7 +246,7 @@ public class WalkValidatorImplTest {
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(17);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+        tipSelSolidifier, config);
         Assert.assertFalse("Validation succeeded but should have failed. We exceeded the maximal amount of" +
                         "transactions that may be analyzed.",
                 walkValidator.isValid(tx.getHash()));
@@ -258,7 +263,7 @@ public class WalkValidatorImplTest {
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
 
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertFalse("Validation succeded but should have failed due to inconsistent ledger state",
                 walkValidator.isValid(hash));
     }
@@ -302,7 +307,7 @@ public class WalkValidatorImplTest {
 
         snapshotProvider.getLatestSnapshot().setIndex(100);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+                tipSelSolidifier, config);
         Assert.assertFalse("Validation of tx4 succeeded but should have failed since tx is below max depth",
                 walkValidator.isValid(tx4.getHash()));
         Assert.assertTrue("Validation of tx2 failed but should have succeeded since tx is above max depth",
@@ -346,7 +351,7 @@ public class WalkValidatorImplTest {
 
         snapshotProvider.getLatestSnapshot().setIndex(100);
         WalkValidatorImpl walkValidator = new WalkValidatorImpl(tangle, snapshotProvider, ledgerService,
-        config);
+        tipSelSolidifier, config);
         Assert.assertFalse("Validation of tx4 succeeded but should have failed since tx is below max depth",
                 walkValidator.isValid(tx4.getHash()));
 

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -139,6 +139,7 @@ public class WalkValidatorImplTest {
         tipSelSolidifier ,config);
         Assert.assertFalse("Validation succeded but should have failed since tx is not solid",
                 walkValidator.isValid(hash));
+        Mockito.verify(tipSelSolidifier, Mockito.times(1)).solidify(hash);
     }
 
     @Test


### PR DESCRIPTION
# Description

While doing GTTA we will attempt to solidify transactions we walk across.
This will make sure that transactions that we missed out on for whatever reason will solidify

Fixes #1818

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

I ran both 1.8.5 and a canary with this change.
I called GTTA in a loop on both with JMETER

GTTA with this change was still faster compared to 1.8.5.
Throughput: 176.662 ops/minute compared to 71.603 ops/minute

However, profiling showed that solidifying takes 30 % of cpu time...

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
