### PR TITLE
Update Broadcast Stage logic 

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/BroadcastStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/BroadcastStage.java
@@ -58,6 +58,8 @@ public class BroadcastStage implements Stage {
             }
         }
 
+        // Check the transaction solidifier to see if there are solid transactions that need to be broadcast.
+        // If so, forward them to the BroadcastStageQueue to be processed.
         TransactionViewModel transactionToBroadcast;
         if((transactionToBroadcast = transactionSolidifier.getNextTxInBroadcastQueue()) != null){
             ctx.setNextStage(TransactionProcessingPipeline.Stage.BROADCAST);

--- a/src/main/java/com/iota/iri/network/pipeline/SolidifyStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/SolidifyStage.java
@@ -71,20 +71,14 @@ public class SolidifyStage implements Stage {
     }
 
     private ProcessingContext broadcastTip(ProcessingContext ctx, SolidifyPayload payload) throws  Exception{
-        // First check if there is a transaction available to broadcast from the broadcast queue
-        TransactionViewModel tip = txSolidifier.getNextTxInBroadcastQueue();
+        Hash tipHash = tipsViewModel.getRandomSolidTipHash();
 
-        // If there is not a transaction available from the broadcast queue, instead try to send a solid tip
-        if (tip == null) {
-            Hash tipHash = tipsViewModel.getRandomSolidTipHash();
-
-            if (tipHash == null) {
-                ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
-                return ctx;
-            }
-
-            tip = fromHash(tangle, tipHash);
+        if (tipHash == null) {
+            ctx.setNextStage(TransactionProcessingPipeline.Stage.FINISH);
+            return ctx;
         }
+
+        TransactionViewModel tip = fromHash(tangle, tipHash);
 
         ctx.setNextStage(TransactionProcessingPipeline.Stage.BROADCAST);
         ctx.setPayload(new BroadcastPayload(payload.getOriginNeighbor(), tip));

--- a/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
+++ b/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
@@ -99,7 +99,7 @@ public class TransactionProcessingPipelineImpl implements TransactionProcessingP
         this.preProcessStage = new PreProcessStage(recentlySeenBytesCache);
         this.replyStage = new ReplyStage(neighborRouter, config, tangle, tipsViewModel, latestMilestoneTracker,
                 snapshotProvider, recentlySeenBytesCache);
-        this.broadcastStage = new BroadcastStage(neighborRouter);
+        this.broadcastStage = new BroadcastStage(neighborRouter, txSolidifier);
         this.validationStage = new ValidationStage(txValidator, recentlySeenBytesCache);
         this.receivedStage = new ReceivedStage(tangle, txSolidifier, snapshotProvider, transactionRequester);
         this.batchedHasher = BatchedHasherFactory.create(BatchedHasherFactory.Type.BCTCURL81, 20);

--- a/src/test/java/com/iota/iri/network/pipeline/BroadcastStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/BroadcastStageTest.java
@@ -9,6 +9,7 @@ import com.iota.iri.network.neighbor.impl.NeighborImpl;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.iota.iri.service.validation.TransactionSolidifier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -20,6 +21,9 @@ public class BroadcastStageTest {
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private TransactionSolidifier transactionSolidifier;
 
     @Mock
     private NeighborRouter neighborRouter;
@@ -38,7 +42,7 @@ public class BroadcastStageTest {
     public void doesntGossipToOriginNeighbor() {
         Mockito.when(neighborRouter.getConnectedNeighbors()).thenReturn(neighbors);
 
-        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter);
+        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier);
         TransactionViewModel tvm = new TransactionViewModel(new Transaction(), null);
         BroadcastPayload broadcastPayload = new BroadcastPayload(neighborA, tvm);
         ProcessingContext ctx = new ProcessingContext(null, broadcastPayload);
@@ -58,7 +62,7 @@ public class BroadcastStageTest {
     public void gossipsToAllIfNoOriginNeighbor() {
         Mockito.when(neighborRouter.getConnectedNeighbors()).thenReturn(neighbors);
 
-        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter);
+        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier);
         TransactionViewModel tvm = new TransactionViewModel(new Transaction(), null);
         BroadcastPayload broadcastPayload = new BroadcastPayload(null, tvm);
         ProcessingContext ctx = new ProcessingContext(null, broadcastPayload);


### PR DESCRIPTION
# Description
When the transaction solidifier was introduced, we updated how transactions are passed through to broadcast, and under initial review we opted to fetch broadcast transactions at the end of the solidification stage, to pass them forward to the broadcast stage in the event the original solidifying transaction is not solid. This sequential loading of transactions from the broadcast queue does not forward transactions fast enough. To correct this, the logic has been moved to the broadcast stage instead. The broadcast stage will complete the transaction forwarding as it was previously designed to do, and the broadcast stage will check if a transaction still exists to broadcast, and if there is, it will pass it to the broadcast stage queue until there is nothing left to pull out of the set. 

Fixes an error that occurred in high tps environments that would cause a delay in the forwarding of transactions via broadcast 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Using the same topology that the problem was first observed in (within the ICC network) transactions, specifically milestone transactions, are being forwarded in a timely fashion. 

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
