### PR TITLE
Fix visibility problem on shouldPersist and refactor tvm update methods

### DIFF
--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -341,7 +341,6 @@ public class TransactionValidator {
                 for(Hash h: approvers) {
                     TransactionViewModel tx = fromHash(tangle, h);
                     if(quietQuickSetSolid(tx)) {
-                        tx.update(tangle, snapshotProvider.getInitialSnapshot(), "solid|height");
                         tipsViewModel.setSolid(h);
                         addSolidTransaction(h);
                     }
@@ -386,7 +385,6 @@ public class TransactionValidator {
         tipsViewModel.removeTipHash(transactionViewModel.getBranchTransactionHash());
 
         if(quickSetSolid(transactionViewModel)) {
-            transactionViewModel.update(tangle, snapshotProvider.getInitialSnapshot(), "solid|height");
             tipsViewModel.setSolid(transactionViewModel.getHash());
             addSolidTransaction(transactionViewModel.getHash());
         }
@@ -423,7 +421,7 @@ public class TransactionValidator {
                 solid = false;
             }
             if(solid) {
-                transactionViewModel.updateSolid(true);
+                transactionViewModel.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
                 transactionViewModel.updateHeights(tangle, snapshotProvider.getInitialSnapshot());
                 return true;
             }

--- a/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
+++ b/src/main/java/com/iota/iri/cache/impl/CacheImpl.java
@@ -6,6 +6,7 @@ import com.iota.iri.cache.CacheConfiguration;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.MapMaker;
 
@@ -50,8 +51,8 @@ public class CacheImpl<K, V> implements Cache<K, V> {
     private final ConcurrentLinkedQueue<K> releaseQueue;
 
     // stats
-    private int cacheHits = 0;
-    private int cacheMisses = 0;
+    private AtomicInteger cacheHits = new AtomicInteger(0);
+    private AtomicInteger cacheMisses = new AtomicInteger(0);
 
     /**
      * Constructor
@@ -158,21 +159,21 @@ public class CacheImpl<K, V> implements Cache<K, V> {
     }
 
     private void cacheHit() {
-        cacheHits++;
+        cacheHits.addAndGet(1);
     }
 
     private void cacheMiss() {
-        cacheMisses++;
+        cacheMisses.addAndGet(1);
     }
 
     @Override
     public int getCacheHits() {
-        return cacheHits;
+        return cacheHits.get();
     }
 
     @Override
     public int getCacheMisses() {
-        return cacheMisses;
+        return cacheMisses.get();
     }
 
     @Override

--- a/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
@@ -63,8 +63,8 @@ public class ReceivedStage implements Stage {
         }
 
         if (stored) {
-            tvm.setArrivalTime(System.currentTimeMillis());
             try {
+                tvm.setArrivalTime(tangle, snapshotProvider.getInitialSnapshot(), System.currentTimeMillis());
                 txValidator.updateStatus(tvm);
 
                 // free up the recently requested transaction set
@@ -77,9 +77,8 @@ public class ReceivedStage implements Stage {
 
                 // neighbor might be null because tx came from a broadcastTransaction command
                 if (originNeighbor != null) {
-                    tvm.updateSender(originNeighbor.getHostAddressAndPort());
+                    tvm.updateSender(tangle, snapshotProvider.getInitialSnapshot(), originNeighbor.getHostAddressAndPort());
                 }
-                tvm.update(tangle, snapshotProvider.getInitialSnapshot(), "arrivalTime|sender");
             } catch (Exception e) {
                 log.error("error updating newly received tx", e);
             }

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -717,10 +717,9 @@ public class API {
         for (final TransactionViewModel transactionViewModel : elements) {
             //store transactions
             if(transactionViewModel.store(tangle, snapshotProvider.getInitialSnapshot())) {
-                transactionViewModel.setArrivalTime(System.currentTimeMillis());
+                transactionViewModel.setArrivalTime(tangle, snapshotProvider.getInitialSnapshot(), System.currentTimeMillis());
                 transactionValidator.updateStatus(transactionViewModel);
-                transactionViewModel.updateSender("local");
-                transactionViewModel.update(tangle, snapshotProvider.getInitialSnapshot(), "sender");
+                transactionViewModel.updateSender(tangle, snapshotProvider.getInitialSnapshot(),"local");
             }
         }
         return AbstractResponse.createEmptyResponse();

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -146,25 +146,25 @@ public class TransactionValidatorTest {
     @Test
     public void testTransactionPropagation() throws Exception {
         TransactionViewModel leftChildLeaf = TransactionTestUtils.createTransactionWithTrytes("CHILDTX");
-        leftChildLeaf.updateSolid(true);
+        leftChildLeaf.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         leftChildLeaf.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel rightChildLeaf = TransactionTestUtils.createTransactionWithTrytes("CHILDTWOTX");
-        rightChildLeaf.updateSolid(true);
+        rightChildLeaf.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         rightChildLeaf.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel parent = TransactionTestUtils.createTransactionWithTrunkAndBranch("PARENT",
                 leftChildLeaf.getHash(), rightChildLeaf.getHash());
-        parent.updateSolid(false);
+        parent.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
         parent.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel parentSibling = TransactionTestUtils.createTransactionWithTrytes("PARENTLEAF");
-        parentSibling.updateSolid(true);
+        parentSibling.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         parentSibling.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel grandParent = TransactionTestUtils.createTransactionWithTrunkAndBranch("GRANDPARENT", parent.getHash(),
                         parentSibling.getHash());
-        grandParent.updateSolid(false);
+        grandParent.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
         grandParent.store(tangle, snapshotProvider.getInitialSnapshot());
 
         txValidator.addSolidTransaction(leftChildLeaf.getHash());
@@ -181,25 +181,25 @@ public class TransactionValidatorTest {
   @Test
   public void testTransactionPropagationFailure() throws Exception {
     TransactionViewModel leftChildLeaf = new TransactionViewModel(getTransactionTrits(), getTransactionHash());
-    leftChildLeaf.updateSolid(true);
+    leftChildLeaf.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
     leftChildLeaf.store(tangle, snapshotProvider.getInitialSnapshot());
 
     TransactionViewModel rightChildLeaf = new TransactionViewModel(getTransactionTrits(), getTransactionHash());
-    rightChildLeaf.updateSolid(true);
+    rightChildLeaf.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
     rightChildLeaf.store(tangle, snapshotProvider.getInitialSnapshot());
 
     TransactionViewModel parent = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(leftChildLeaf.getHash(),
             rightChildLeaf.getHash()), getTransactionHash());
-    parent.updateSolid(false);
+    parent.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
     parent.store(tangle, snapshotProvider.getInitialSnapshot());
 
     TransactionViewModel parentSibling = new TransactionViewModel(getTransactionTrits(), getTransactionHash());
-    parentSibling.updateSolid(false);
+    parentSibling.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
     parentSibling.store(tangle, snapshotProvider.getInitialSnapshot());
 
     TransactionViewModel grandParent = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(parent.getHash(),
             parentSibling.getHash()), getTransactionHash());
-    grandParent.updateSolid(false);
+    grandParent.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
     grandParent.store(tangle, snapshotProvider.getInitialSnapshot());
 
     txValidator.addSolidTransaction(leftChildLeaf.getHash());

--- a/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
@@ -34,6 +34,7 @@ import static com.iota.iri.TransactionTestUtils.getTransactionTritsWithTrunkAndB
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TransactionViewModelTest {
 
@@ -428,7 +429,7 @@ public class TransactionViewModelTest {
         cacheManager.add(TransactionViewModel.class, new CacheConfigurationImpl(1));
         tangle.setCacheManager(cacheManager);
 
-        int numberOfTxs = 2;
+        int numberOfTxs = 3;
         String trytes = "";
 
         TransactionViewModel tvms[] = new TransactionViewModel[numberOfTxs];
@@ -438,11 +439,19 @@ public class TransactionViewModelTest {
             tvms[i].store(tangle, snapshot);
         }
         tvms[0].isMilestone(tangle, snapshot, true);
-        tvms[1].isMilestone(tangle, snapshot, true);
+        tvms[1].updateSolid(tangle, snapshot, true);
+        tvms[2].updateSender(tangle, snapshot, "sender");
+        tvms[0].isMilestone(tangle, snapshot, false); //Another update to kick the previous tx from cache
 
-        Hash hash = tvms[0].getHash();
-        TransactionViewModel tvm = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash), hash);
-        Assert.assertTrue("TVM should be a milestone", tvm.isMilestone());
+        Hash hash0 = tvms[0].getHash();
+        TransactionViewModel tvm0 = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash0), hash0);
+        assertTrue("TVM should be a milestone", tvm0.isMilestone());
+        Hash hash1 = tvms[1].getHash();
+        TransactionViewModel tvm1 = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash1), hash1);
+        assertTrue("TVM should be solid", tvm1.isSolid());
+        Hash hash2 = tvms[2].getHash();
+        TransactionViewModel tvm2 = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash2), hash2);
+        assertEquals("TVM sender should be equal", "sender", tvm2.getSender());
     }
 
     @Test
@@ -468,7 +477,12 @@ public class TransactionViewModelTest {
         for (int i : tvmIndicesToUpdate) {
             TransactionViewModel tvm = cache.get(tvms[i].getHash());
             if (tvm != null) {
-                tvm.isMilestone(tangle, snapshot, true);
+                if(i%2 == 0){
+                    tvm.isMilestone(tangle, snapshot, true);
+                }else{
+                    //just another test
+                    tvm.updateSolid(tangle, snapshot, true);
+                }
             }
         }
 
@@ -479,7 +493,11 @@ public class TransactionViewModelTest {
             Hash hash = tvms[i].getHash();
             TransactionViewModel tvm = new TransactionViewModel((Transaction) tangle.load(Transaction.class, hash),
                     hash);
-            Assert.assertTrue("TVM should be a milestone", tvm.isMilestone());
+            if(i%2 == 0){
+                assertTrue("TVM should be a milestone", tvm.isMilestone());
+            }else{
+                assertTrue("TVM should be solid", tvm.isSolid());
+            }
         }
     }
 

--- a/src/test/java/com/iota/iri/network/pipeline/ReceivedStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/ReceivedStageTest.java
@@ -54,8 +54,8 @@ public class ReceivedStageTest {
         ProcessingContext ctx = new ProcessingContext(null, receivedPayload);
         stage.process(ctx);
 
-        Mockito.verify(tvm).setArrivalTime(Mockito.anyLong());
-        Mockito.verify(tvm).update(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(tvm).setArrivalTime(Mockito.any(), Mockito.any(), Mockito.anyLong());
+        Mockito.verify(tvm).updateSender(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(transactionRequester).removeRecentlyRequestedTransaction(Mockito.any());
         Mockito.verify(transactionRequester).requestTrunkAndBranch(Mockito.any());
         assertEquals("should submit to broadcast stage next", TransactionProcessingPipeline.Stage.BROADCAST,
@@ -75,7 +75,7 @@ public class ReceivedStageTest {
         ProcessingContext ctx = new ProcessingContext(null, receivedPayload);
         stage.process(ctx);
 
-        Mockito.verify(tvm, Mockito.never()).setArrivalTime(Mockito.anyLong());
+        Mockito.verify(tvm, Mockito.never()).setArrivalTime(Mockito.any(), Mockito.any(), Mockito.anyLong());
         Mockito.verify(tvm, Mockito.never()).update(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(transactionRequester).removeRecentlyRequestedTransaction(Mockito.any());
         Mockito.verify(transactionRequester, Mockito.never()).requestTrunkAndBranch(Mockito.any());

--- a/src/test/java/com/iota/iri/service/APITest.java
+++ b/src/test/java/com/iota/iri/service/APITest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -47,7 +48,7 @@ public class APITest {
 
         api.storeTransactionsStatement(Collections.singletonList("FOO"));
 
-        verify(transaction).setArrivalTime(longThat(this::isCloseToCurrentMillis));
+        verify(transaction).setArrivalTime(Mockito.any(), Mockito.any(), longThat(this::isCloseToCurrentMillis));
 
     }
 

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -82,7 +82,7 @@ public class WalkValidatorImplTest {
     public void shouldPassValidation() throws Exception {
         int depth = 15;
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
-        tx.updateSolid(true);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         Hash hash = tx.getHash();
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
@@ -100,7 +100,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         Hash hash = tx.getTrunkTransactionHash();
-        tx.updateSolid(true);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(depth);
@@ -115,7 +115,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(2);
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         Hash hash = tx.getHash();
-        tx.updateSolid(true);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
@@ -130,7 +130,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         Hash hash = tx.getHash();
-        tx.updateSolid(false);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), false);
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
@@ -148,7 +148,7 @@ public class WalkValidatorImplTest {
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         tx.setSnapshot(tangle, snapshotProvider.getInitialSnapshot(), 2);
         Hash hash = tx.getHash();
-        tx.updateSolid(true);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(true);
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
@@ -168,7 +168,7 @@ public class WalkValidatorImplTest {
             tx = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(hash, hash), getTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
-            tx.updateSolid(true);
+            tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
             hash = tx.getHash();
             tx.store(tangle, snapshotProvider.getInitialSnapshot());
         }
@@ -194,7 +194,7 @@ public class WalkValidatorImplTest {
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
             hash = tx.getHash();
-            tx.updateSolid(true);
+            tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
             tx.store(tangle, snapshotProvider.getInitialSnapshot());
         }
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
@@ -215,7 +215,7 @@ public class WalkValidatorImplTest {
             tx = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(hash, hash), getTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
-            tx.updateSolid(true);
+            tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
             hash = tx.getHash();
             tx.store(tangle, snapshotProvider.getInitialSnapshot());
         }
@@ -239,7 +239,7 @@ public class WalkValidatorImplTest {
                     getTransactionHash());
             TransactionTestUtils.setLastIndex(tx,0);
             TransactionTestUtils.setCurrentIndex(tx,0);
-            tx.updateSolid(true);
+            tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
             tx.store(tangle, snapshotProvider.getInitialSnapshot());
             hash = tx.getHash();
         }
@@ -258,7 +258,7 @@ public class WalkValidatorImplTest {
         TransactionViewModel tx = TransactionTestUtils.createBundleHead(0);
         tx.store(tangle, snapshotProvider.getInitialSnapshot());
         Hash hash = tx.getHash();
-        tx.updateSolid(true);
+        tx.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), hash))
                 .thenReturn(false);
         snapshotProvider.getLatestSnapshot().setIndex(Integer.MAX_VALUE);
@@ -284,21 +284,21 @@ public class WalkValidatorImplTest {
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx2,0);
         TransactionTestUtils.setCurrentIndex(tx2,0);
-        tx2.updateSolid(true);
+        tx2.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx2.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel tx3 = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx3,0);
         TransactionTestUtils.setCurrentIndex(tx3,0);
-        tx3.updateSolid(true);
+        tx3.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx3.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel tx4 = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx4,0);
         TransactionTestUtils.setCurrentIndex(tx4,0);
-        tx4.updateSolid(true);
+        tx4.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx4.store(tangle, snapshotProvider.getInitialSnapshot());
 
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), tx4.getHash()))
@@ -330,21 +330,21 @@ public class WalkValidatorImplTest {
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx2,0);
         TransactionTestUtils.setCurrentIndex(tx2,0);
-        tx2.updateSolid(true);
+        tx2.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx2.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel tx3 = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(tx1.getHash(), txBad.getHash()),
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx3,0);
         TransactionTestUtils.setCurrentIndex(tx3,0);
-        tx3.updateSolid(true);
+        tx3.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx3.store(tangle, snapshotProvider.getInitialSnapshot());
 
         TransactionViewModel tx4 = new TransactionViewModel(getTransactionTritsWithTrunkAndBranch(tx2.getHash(), tx3.getHash()),
                 getTransactionHash());
         TransactionTestUtils.setLastIndex(tx4,0);
         TransactionTestUtils.setCurrentIndex(tx4,0);
-        tx4.updateSolid(true);
+        tx4.updateSolid(tangle, snapshotProvider.getInitialSnapshot(), true);
         tx4.store(tangle, snapshotProvider.getInitialSnapshot());
 
         Mockito.when(ledgerService.isBalanceDiffConsistent(new HashSet<>(), new HashMap<>(), tx4.getHash()))


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Txs that were being quick set solid were not being persisted upon release from cache.
This change ensures that updates are always persisted by assuming responsibility to always call `tvm.update`
Also, fixes is a possible race condition with `tvm.shouldPersist` and cache metric fields.

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Existing and new unit tests that assert persistence pass.
- Buildkite will run reg tests :)

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
