### PR TITLE
Force depth 0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"python.pythonPath": "C:\\Users\\Brord\\.windows-build-tools\\python27\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"python.pythonPath": "C:\\Users\\Brord\\.windows-build-tools\\python27\\python.exe"
-}

--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -1563,8 +1563,8 @@ public class API {
             Optional<Hash> reference = request.containsKey("reference") ?
                 Optional.of(HashFactory.TRANSACTION.create(getParameterAsStringAndValidate(request,"reference", HASH_SIZE)))
                 : Optional.empty();
-            int depth = getParameterAsInt(request, "depth");
-
+            // We force depth 0 as compass uses this, and it prevents problems with GTTA spammers
+            int depth = 0;
             return getTransactionsToApproveStatement(depth, reference);
         };
     }


### PR DESCRIPTION
# Description

As compass is using depth 1, we force our gtta to always be depth 0

Fixes some issues with GTTA spammers, makes the network faster as well

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
It builds, huray, what a suprise


# Checklist:

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
