### PR TITLE
Use LinkedBlockingQueue to fix sync problems

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
+++ b/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
@@ -72,12 +72,12 @@ public class TransactionProcessingPipelineImpl implements TransactionProcessingP
     private HashingStage hashingStage;
     private SolidifyStage solidifyStage;
 
-    private BlockingQueue<ProcessingContext> preProcessStageQueue = new LinkedBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> validationStageQueue = new LinkedBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> receivedStageQueue = new LinkedBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> replyStageQueue = new LinkedBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> broadcastStageQueue = new LinkedBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> solidifyStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> preProcessStageQueue = new LinkedBlockingQueue<>();
+    private BlockingQueue<ProcessingContext> validationStageQueue = new LinkedBlockingQueue<>();
+    private BlockingQueue<ProcessingContext> receivedStageQueue = new LinkedBlockingQueue<>();
+    private BlockingQueue<ProcessingContext> replyStageQueue = new LinkedBlockingQueue<>();
+    private BlockingQueue<ProcessingContext> broadcastStageQueue = new LinkedBlockingQueue<>();
+    private BlockingQueue<ProcessingContext> solidifyStageQueue = new LinkedBlockingQueue<>();
 
     /**
      * Creates a {@link TransactionProcessingPipeline}.

--- a/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
+++ b/src/main/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineImpl.java
@@ -21,7 +21,7 @@ import com.iota.iri.utils.Converter;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -72,12 +72,12 @@ public class TransactionProcessingPipelineImpl implements TransactionProcessingP
     private HashingStage hashingStage;
     private SolidifyStage solidifyStage;
 
-    private BlockingQueue<ProcessingContext> preProcessStageQueue = new ArrayBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> validationStageQueue = new ArrayBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> receivedStageQueue = new ArrayBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> replyStageQueue = new ArrayBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> broadcastStageQueue = new ArrayBlockingQueue<>(100);
-    private BlockingQueue<ProcessingContext> solidifyStageQueue = new ArrayBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> preProcessStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> validationStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> receivedStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> replyStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> broadcastStageQueue = new LinkedBlockingQueue<>(100);
+    private BlockingQueue<ProcessingContext> solidifyStageQueue = new LinkedBlockingQueue<>(100);
 
     /**
      * Creates a {@link TransactionProcessingPipeline}.


### PR DESCRIPTION
# Description of change

Resolves a syncing problem by using a linked blocking queue

Fixes #1742 
Replaces #1833 which was merged to another branch

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

IRI was synced without needing to restart and no error appeared
It should be noted that I did notice a slow down in syncing

I think we should investigate going back to array based queues later on to speed things up

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
