### PR TITLE
Fix: max propagate up to 10 transactions for solidification

### DIFF
--- a/src/main/java/com/iota/iri/network/pipeline/MilestoneStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/MilestoneStage.java
@@ -62,9 +62,8 @@ public class MilestoneStage implements Stage {
 
             TransactionViewModel milestone = payload.getMilestoneTransaction();
             int newMilestoneIndex = payload.getMilestoneIndex();
-            boolean isTail = (milestone.getCurrentIndex() == 0);
+            boolean isTail = milestone.getCurrentIndex() == 0;
 
-            // Add milestone tails to the milestone solidifier, if transaction is solid, add to the propagation queue
             if (isTail) {
                 milestoneSolidifier.addMilestoneCandidate(milestone.getHash(), newMilestoneIndex);
             }

--- a/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/ReceivedStage.java
@@ -31,7 +31,7 @@ public class ReceivedStage implements Stage {
      * Creates a new {@link ReceivedStage}.
      * 
      * @param tangle           The {@link Tangle} database used to store/update the transaction
-     * @param txSolidifier      The {@link TransactionValidator} used to store/update the transaction
+     * @param txSolidifier      The {@link TransactionSolidifier} used to store/update the transaction
      * @param snapshotProvider The {@link SnapshotProvider} used to store/update the transaction
      */
     public ReceivedStage(Tangle tangle, TransactionSolidifier txSolidifier, SnapshotProvider snapshotProvider,

--- a/src/main/java/com/iota/iri/service/milestone/MilestoneRepairer.java
+++ b/src/main/java/com/iota/iri/service/milestone/MilestoneRepairer.java
@@ -2,6 +2,11 @@ package com.iota.iri.service.milestone;
 
 import com.iota.iri.controllers.MilestoneViewModel;
 
+/**
+ * Contains the logic for comparing and repairing corrupted milestones. Used by the
+ * {@link com.iota.iri.service.milestone.MilestoneSolidifier} to forward transactions to the
+ * {@link MilestoneService#resetCorruptedMilestone(int)} method.
+ */
 public interface MilestoneRepairer {
     /**
      * <p>

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneRepairerImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneRepairerImpl.java
@@ -6,9 +6,7 @@ import com.iota.iri.service.milestone.MilestoneRepairer;
 import com.iota.iri.service.milestone.MilestoneService;
 
 /**
- * Contains the logic for comparing and repairing corrupted milestones. Used by the
- * {@link com.iota.iri.service.milestone.MilestoneSolidifier} to forward transactions to the
- * {@link MilestoneService#resetCorruptedMilestone(int)} method.
+ * Creates a {@link MilestoneRepairer} service to fix corrupted milestone objects.
  */
 public class MilestoneRepairerImpl implements MilestoneRepairer {
 

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -197,6 +197,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             switch(validity) {
                 case VALID:
                     milestoneCandidate.isMilestone(tangle, snapshotProvider.getInitialSnapshot(), true);
+                    registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
                     if (milestoneCandidate.isSolid()) {
                         removeFromQueues(milestoneHash);
                         addSeenMilestone(milestoneHash, milestoneIndex);
@@ -205,9 +206,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
                     }
                     break;
                 case INCOMPLETE:
-                    if(milestoneIndex > getLatestMilestoneIndex()) {
-                        registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
-                    }
+                    registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
                     transactionSolidifier.addToSolidificationQueue(milestoneHash);
                     break;
                 case INVALID:
@@ -341,10 +340,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     @Override
     public void addSeenMilestone(Hash milestoneHash, int milestoneIndex) {
-        if (milestoneIndex > getLatestMilestoneIndex()) {
-            registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
-        }
-
         if (!seenMilestones.containsKey(milestoneIndex)) {
             seenMilestones.put(milestoneIndex, milestoneHash);
         }
@@ -419,9 +414,11 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     @Override
     public void registerNewMilestone(int oldMilestoneIndex, int newMilestoneIndex, Hash newMilestoneHash) {
-        setLatestMilestone(newMilestoneHash, newMilestoneIndex);
-        tangle.publish("lmi %d %d", oldMilestoneIndex, newMilestoneIndex);
-        log.info("Latest milestone has changed from #" + oldMilestoneIndex + " to #" + newMilestoneIndex);
+        if (oldMilestoneIndex > getLatestMilestoneIndex()) {
+            setLatestMilestone(newMilestoneHash, newMilestoneIndex);
+            tangle.publish("lmi %d %d", oldMilestoneIndex, newMilestoneIndex);
+            log.info("Latest milestone has changed from #" + oldMilestoneIndex + " to #" + newMilestoneIndex);
+        }
     }
 
     /**

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -414,7 +414,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     @Override
     public void registerNewMilestone(int oldMilestoneIndex, int newMilestoneIndex, Hash newMilestoneHash) {
-        if (oldMilestoneIndex > getLatestMilestoneIndex()) {
+        if (newMilestoneIndex > oldMilestoneIndex) {
             setLatestMilestone(newMilestoneHash, newMilestoneIndex);
             tangle.publish("lmi %d %d", oldMilestoneIndex, newMilestoneIndex);
             log.info("Latest milestone has changed from #" + oldMilestoneIndex + " to #" + newMilestoneIndex);

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -197,7 +197,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             switch(validity) {
                 case VALID:
                     milestoneCandidate.isMilestone(tangle, snapshotProvider.getInitialSnapshot(), true);
-                    registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
                     if (milestoneCandidate.isSolid()) {
                         removeFromQueues(milestoneHash);
                         addSeenMilestone(milestoneHash, milestoneIndex);
@@ -206,7 +205,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
                     }
                     break;
                 case INCOMPLETE:
-                    registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
                     transactionSolidifier.addToSolidificationQueue(milestoneHash);
                     break;
                 case INVALID:
@@ -340,6 +338,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     @Override
     public void addSeenMilestone(Hash milestoneHash, int milestoneIndex) {
+        registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
         if (!seenMilestones.containsKey(milestoneIndex)) {
             seenMilestones.put(milestoneIndex, milestoneHash);
         }

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -371,6 +371,14 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
          */
         private BlockingQueue<Hash> solidTransactions = new ArrayBlockingQueue<>(MAX_SIZE);
 
+
+        /**
+         * Defines the maximum number of transactions that will be processed in a single run of the
+         * {@link TransactionPropagator#propagateSolidTransactions()} call. This is to stop the propagator from potentially
+         * stalling out solidification with an endless addition of new transactions to propagate.
+         */
+        private static final int PROPAGATION_QUEUE_MAX_PROCESS = 10;
+
         /**
          * Add to the propagation queue where it will be processed to help solidify approving transactions faster
          * @param hash      The transaction hash to be removed
@@ -387,8 +395,11 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
 
         @VisibleForTesting
         void propagateSolidTransactions() {
-            while(!Thread.currentThread().isInterrupted() && solidTransactions.peek() != null) {
+            int processed = 0;
+            while(!Thread.currentThread().isInterrupted() && solidTransactions.peek() != null
+                    && processed < PROPAGATION_QUEUE_MAX_PROCESS) {
                 try {
+                    ++processed;
                     Hash hash = solidTransactions.poll();
                     TransactionViewModel transaction = fromHash(tangle, hash);
                     Set<Hash> approvers = transaction.getApprovers(tangle).getHashes();


### PR DESCRIPTION
# Description of change
After removing the cache with the dev branch merge, the propagation process takes a little longer to complete, and holds up the transaction solidifier processing time. To mitigate this, the propagation queue will be processed in batches to avoid the issue of holding up transactions in the solidification queue from being processed. Also, a small bug fix to the milestone solidifier to make sure we are registering new milestones that are not solid but valid.  

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Tests that failed the merge into dev are passing now.  

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
