### PR TITLE
Fix: Milestone solidifier log milestone on validity not solidity

### DIFF
--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -197,6 +197,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             switch(validity) {
                 case VALID:
                     milestoneCandidate.isMilestone(tangle, snapshotProvider.getInitialSnapshot(), true);
+                    registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
                     if (milestoneCandidate.isSolid()) {
                         removeFromQueues(milestoneHash);
                         addSeenMilestone(milestoneHash, milestoneIndex);
@@ -338,7 +339,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     @Override
     public void addSeenMilestone(Hash milestoneHash, int milestoneIndex) {
-        registerNewMilestone(getLatestMilestoneIndex(), milestoneIndex, milestoneHash);
         if (!seenMilestones.containsKey(milestoneIndex)) {
             seenMilestones.put(milestoneIndex, milestoneHash);
         }


### PR DESCRIPTION
# Description of change
When making the change in 1845, the registration of milestones was placed into the `addSeenMilestones` method which is only called once a milestone is valid AND solid. Failing to register new milestones on validity regardless of solidity causes an error that flies under the radar with the regression test setup. We need to register and log the new milestones as they get validated, otherwise the solidification process never kicks off. This part of the logic is no different from the previous implementation with the `LatestMileStoneTracker` and shouldn't be changed. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Tests all passed on the last version and didn't catch this bug. Throwing it up onto the ICC and testing it there has allowed me to catch it in the act, and determine the cause. With this one line change the ICC syncs again without issue. 

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
