### PR TITLE
Update milestone bootstrapping

### DIFF
--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -315,21 +315,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
         if (!unsolidMilestones.containsKey(milestoneHash) && !seenMilestones.containsKey(milestoneIndex) &&
                 milestoneIndex > getLatestSolidMilestoneIndex()) {
             unsolidMilestones.put(milestoneHash, milestoneIndex);
-            updateQueues(milestoneHash, milestoneIndex);
         }
-    }
-
-    private void updateQueues(Hash milestoneHash, int milestoneIndex) {
-        if (solidificationQueue.containsKey(milestoneHash)) {
-            if (solidificationQueue.size() >= MAX_SIZE) {
-                Iterator<Map.Entry<Hash, Integer>> iterator = solidificationQueue.entrySet().iterator();
-                iterator.next();
-                iterator.remove();
-            }
-        }
-
-        solidificationQueue.put(milestoneHash, milestoneIndex);
-        scanMilestonesInQueue();
     }
 
     /**

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -137,9 +137,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      * found in the {@link #seenMilestones} queue, then the milestone is removed from the solidification pool. If not,
      * then the {@link #oldestMilestoneInQueue} is updated iterating through whatever milestones are still present in
      * the {@link #solidificationQueue}.
-     *
-     * If upon scanning the {@link #unsolidMilestones} queue is empty and {@link #initialized} is false, set
-     * {@link #initialized} to true.
      */
     private void scanMilestonesInQueue() {
         // refill the solidification queue with solidification candidates sorted by index
@@ -165,11 +162,6 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             if (!seenMilestones.containsKey(currentEntry.getValue())) {
                 updateOldestMilestone(currentEntry.getKey(), currentEntry.getValue());
             }
-        }
-
-
-        if (!initialized.get() && unsolidMilestones.size() == 0) {
-            initialized.set(true);
         }
     }
 
@@ -252,8 +244,10 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
     }
 
     /**
-     * Iterates through milestone indexes starting from the initial snapshot index, and returns the newest existing
-     * milestone index
+     * Sets the {@link #latestSolidMilestone} index to the snapshot index, and scans through all transactions that are
+     * present in the db associated with the coordinator address. It then iterates through these transactions, adding
+     * valid transactions to the {@link #seenMilestones} pool, and adding all valid and incomplete milestones to the
+     * solidification queue. Once completed the {@link #initialized} flag is set to true.
      *
      * @return  Latest Solid Milestone index
      * @throws Exception
@@ -287,6 +281,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
                 log.error("Error processing existing milestone index", e);
             }
         }
+        initialized.set(true);
     }
 
 

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -387,9 +387,9 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
         public void addToPropagationQueue(Hash hash) throws Exception{
             if(!solidTransactions.contains(hash)) {
                 if (solidTransactions.size() >= MAX_SIZE) {
-                    solidTransactions.poll();
+                    solidTransactions.remove();
                 }
-                solidTransactions.put(hash);
+                solidTransactions.offer(hash);
             }
         }
 


### PR DESCRIPTION
# Description of change
Milestone bootstrapping in the solidifier was registering solid milestones before the snapshot provider, and therefore the milestones were not being applied correctly. This caused a discrepancy between the `getNodeInfo` latest solid milestone vs the `MilestoneSolidifier` latest solid milestone. It also stopped milestone candidates that were between these 2 separate values from being properly processed. The change here ensures that any valid and incomplete milestone candidates are properly placed into the queue for processing.

As an addition the `updateQueues()` method has been removed as it is unnecessary logic. 

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Canary has been syncing continuously on Mainnet from a Local Snapshot 22k milestones behind.  

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
