### PR TITLE
Update queue size for solidifier

### DIFF
--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -46,7 +46,7 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
      * NOte: we want to find the next previous milestone and not get stuck somewhere at the end of the tangle with a
      * long running {@link #checkSolidity(Hash)} call.
      */
-    private static final int SOLIDIFICATION_TRANSACTIONS_LIMIT = 50000;
+    private static final int SOLIDIFICATION_TRANSACTIONS_LIMIT = 300_000;
 
 
     /**


### PR DESCRIPTION
# Description of change
The `TransactionSolidifier` has a set value of 50k transactions for analyzed hashes as legacy from the previous milestone logic. With high tps environments it's possible for this low threshold to be reached between milestones and slow or stall out synchronisation. To accommodate this the max value should be increased to 300k minimum to account for the possibility of a 1000TPS environment with a 30 second tick rate for compass. 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Less false returns for solidification as a result of the maximum capacity of analyzed transactions being reached. 

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
