### PR TITLE
Feature: Sync check added to broadcast stage

### DIFF
--- a/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
+++ b/src/main/java/com/iota/iri/network/NetworkInjectionConfiguration.java
@@ -1,19 +1,21 @@
 package com.iota.iri.network;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
-import com.iota.iri.service.validation.TransactionSolidifier;
-import com.iota.iri.service.validation.TransactionValidator;
 import com.iota.iri.conf.IotaConfig;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.network.impl.TipsRequesterImpl;
 import com.iota.iri.network.pipeline.TransactionProcessingPipeline;
 import com.iota.iri.network.pipeline.TransactionProcessingPipelineImpl;
-import com.iota.iri.service.milestone.MilestoneSolidifier;
+import com.iota.iri.service.milestone.InSyncService;
 import com.iota.iri.service.milestone.MilestoneService;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
 import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.validation.TransactionSolidifier;
+import com.iota.iri.service.validation.TransactionValidator;
 import com.iota.iri.storage.Tangle;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 
 /**
  * Guice module for network package. Configuration class for dependency injection.
@@ -49,10 +51,10 @@ public class NetworkInjectionConfiguration extends AbstractModule {
             TransactionValidator txValidator, Tangle tangle, SnapshotProvider snapshotProvider,
             TipsViewModel tipsViewModel, TransactionRequester transactionRequester,
             TransactionSolidifier transactionSolidifier, MilestoneService milestoneService,
-            MilestoneSolidifier milestoneSolidifier) {
+            MilestoneSolidifier milestoneSolidifier, InSyncService inSyncService) {
         return new TransactionProcessingPipelineImpl(neighborRouter, configuration, txValidator, tangle,
                 snapshotProvider, tipsViewModel, milestoneSolidifier, transactionRequester, transactionSolidifier,
-                milestoneService);
+                milestoneService, inSyncService);
     }
 
     @Singleton

--- a/src/main/java/com/iota/iri/network/pipeline/BroadcastStage.java
+++ b/src/main/java/com/iota/iri/network/pipeline/BroadcastStage.java
@@ -3,7 +3,9 @@ package com.iota.iri.network.pipeline;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.network.NeighborRouter;
 import com.iota.iri.network.neighbor.Neighbor;
+import com.iota.iri.service.milestone.InSyncService;
 import com.iota.iri.service.validation.TransactionSolidifier;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,13 +24,19 @@ public class BroadcastStage implements Stage {
     private TransactionSolidifier transactionSolidifier;
 
     /**
+     * Service used to determine if we send back tx to the original neighbour
+     */
+    private InSyncService inSyncService;
+
+    /**
      * Creates a new {@link BroadcastStage}.
      * 
      * @param neighborRouter The {@link NeighborRouter} instance to use to broadcast
      */
-    public BroadcastStage(NeighborRouter neighborRouter, TransactionSolidifier transactionSolidifier) {
+    public BroadcastStage(NeighborRouter neighborRouter, TransactionSolidifier transactionSolidifier, InSyncService inSyncService) {
         this.neighborRouter = neighborRouter;
         this.transactionSolidifier = transactionSolidifier;
+        this.inSyncService = inSyncService;
     }
 
     /**
@@ -47,8 +55,10 @@ public class BroadcastStage implements Stage {
         // racy
         Map<String, Neighbor> currentlyConnectedNeighbors = neighborRouter.getConnectedNeighbors();
         for (Neighbor neighbor : currentlyConnectedNeighbors.values()) {
-            // don't send back to origin neighbor
-            if (neighbor.equals(originNeighbor)) {
+            
+            // don't send back to origin neighbor, unless we are not in sync yet
+            // Required after PR: #1745 which removes ping pong behaviour  
+            if (neighbor.equals(originNeighbor) && inSyncService.isInSync()) {
                 continue;
             }
             try {

--- a/src/main/java/com/iota/iri/service/milestone/InSyncService.java
+++ b/src/main/java/com/iota/iri/service/milestone/InSyncService.java
@@ -1,0 +1,16 @@
+package com.iota.iri.service.milestone;
+
+/**
+ * 
+ * Service for checking our node status
+ *
+ */
+public interface InSyncService {
+    
+    /**
+     * Verifies if this node is currently considered in sync
+     * 
+     * @return <code>true</code> if we are in sync, otherwise <code>false</code>
+     */
+    boolean isInSync();
+}

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneInSyncService.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneInSyncService.java
@@ -6,6 +6,8 @@ import com.iota.iri.service.snapshot.SnapshotProvider;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * 
  * A node is defined in sync when the latest snapshot milestone index and the
@@ -28,7 +30,7 @@ public class MilestoneInSyncService implements InSyncService {
     /**
      * If this node is currently seen as in sync
      */
-    private boolean isInSync;
+    private AtomicBoolean isInSync;
     
     /**
      * Data provider for the latest solid index
@@ -46,7 +48,7 @@ public class MilestoneInSyncService implements InSyncService {
     public MilestoneInSyncService(SnapshotProvider snapshotProvider, MilestoneSolidifier milestoneSolidifier) {
         this.snapshotProvider = snapshotProvider;
         this.milestoneSolidifier = milestoneSolidifier;
-        this.isInSync = false;
+        this.isInSync = new AtomicBoolean(false);
     }
 
     @Override
@@ -59,15 +61,15 @@ public class MilestoneInSyncService implements InSyncService {
         int latestSnapshot = snapshotProvider.getLatestSnapshot().getIndex();
 
         // If we are out of sync, only a full sync will get us in
-        if (!isInSync && latestIndex == latestSnapshot) {
-            isInSync = true;
+        if (!isInSync.get() && latestIndex == latestSnapshot) {
+            isInSync.set(true);
 
         // When we are in sync, only dropping below the buffer gets us out of sync
         } else if (latestSnapshot < latestIndex - LOCAL_SNAPSHOT_SYNC_BUFFER) {
-            isInSync = false;
+            isInSync.set(false);
         }
 
-        return isInSync;
+        return isInSync.get();
     }
 
 }

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneInSyncService.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneInSyncService.java
@@ -1,0 +1,73 @@
+package com.iota.iri.service.milestone.impl;
+
+import com.iota.iri.service.milestone.InSyncService;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * 
+ * A node is defined in sync when the latest snapshot milestone index and the
+ * latest milestone index are equal. In order to prevent a bounce between in and
+ * out of sync, a buffer is added when a node became in sync.
+ * 
+ * This will always return false if we are not done scanning milestone
+ * candidates during initialization.
+ *
+ */
+public class MilestoneInSyncService implements InSyncService {
+    
+    /**
+     * To prevent jumping back and forth in and out of sync, there is a buffer in between.
+     * Only when the latest milestone and latest snapshot differ more than this number, we fall out of sync
+     */
+    @VisibleForTesting
+    static final int LOCAL_SNAPSHOT_SYNC_BUFFER = 5;
+    
+    /**
+     * If this node is currently seen as in sync
+     */
+    private boolean isInSync;
+    
+    /**
+     * Data provider for the latest solid index
+     */
+    private SnapshotProvider snapshotProvider;
+    
+    /**
+     * Data provider for the latest index
+     */
+    private MilestoneSolidifier milestoneSolidifier;
+    
+    /**
+     * @param snapshotProvider data provider for the snapshots that are relevant for the node
+     */
+    public MilestoneInSyncService(SnapshotProvider snapshotProvider, MilestoneSolidifier milestoneSolidifier) {
+        this.snapshotProvider = snapshotProvider;
+        this.milestoneSolidifier = milestoneSolidifier;
+        this.isInSync = false;
+    }
+
+    @Override
+    public boolean isInSync() {
+        if (!milestoneSolidifier.isInitialScanComplete()) {
+            return false;
+        }
+
+        int latestIndex = milestoneSolidifier.getLatestMilestoneIndex();
+        int latestSnapshot = snapshotProvider.getLatestSnapshot().getIndex();
+
+        // If we are out of sync, only a full sync will get us in
+        if (!isInSync && latestIndex == latestSnapshot) {
+            isInSync = true;
+
+        // When we are in sync, only dropping below the buffer gets us out of sync
+        } else if (latestSnapshot < latestIndex - LOCAL_SNAPSHOT_SYNC_BUFFER) {
+            isInSync = false;
+        }
+
+        return isInSync;
+    }
+
+}

--- a/src/test/java/com/iota/iri/network/NetworkInjectionConfigurationTest.java
+++ b/src/test/java/com/iota/iri/network/NetworkInjectionConfigurationTest.java
@@ -1,21 +1,24 @@
 package com.iota.iri.network;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.iota.iri.service.milestone.MilestoneService;
-import com.iota.iri.service.milestone.MilestoneSolidifier;
-import com.iota.iri.service.validation.TransactionSolidifier;
-import com.iota.iri.service.validation.TransactionValidator;
-import com.iota.iri.conf.BaseIotaConfig;
-import com.iota.iri.conf.IotaConfig;
-import com.iota.iri.network.pipeline.TransactionProcessingPipeline;
-import com.iota.iri.service.snapshot.SnapshotProvider;
-import org.junit.Test;
-
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.iota.iri.conf.BaseIotaConfig;
+import com.iota.iri.conf.IotaConfig;
+import com.iota.iri.network.pipeline.TransactionProcessingPipeline;
+import com.iota.iri.service.milestone.InSyncService;
+import com.iota.iri.service.milestone.MilestoneService;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.validation.TransactionSolidifier;
+import com.iota.iri.service.validation.TransactionValidator;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.Test;
 
 public class NetworkInjectionConfigurationTest {
 
@@ -44,6 +47,11 @@ public class NetworkInjectionConfigurationTest {
         assertNotNull("instance creation did not work", testInjector().getInstance(TransactionSolidifier.class));
     }
 
+    @Test
+    public void provideInSyncService(){
+        assertNotNull("instance creation did not work", testInjector().getInstance(InSyncService.class));
+    }
+
     private Injector testInjector() {
         IotaConfig config = mock(IotaConfig.class);
         when(config.getCoordinator()).thenReturn(BaseIotaConfig.Defaults.COORDINATOR);
@@ -59,6 +67,7 @@ public class NetworkInjectionConfigurationTest {
             bind(TransactionValidator.class).toInstance(mock(TransactionValidator.class));
             bind(TransactionSolidifier.class).toInstance(mock(TransactionSolidifier.class));
             bind(MilestoneService.class).toInstance(mock(MilestoneService.class));
+            bind(InSyncService.class).toInstance(mock(InSyncService.class));
         }
 
     }

--- a/src/test/java/com/iota/iri/network/pipeline/BroadcastStageTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/BroadcastStageTest.java
@@ -5,17 +5,18 @@ import com.iota.iri.model.persistables.Transaction;
 import com.iota.iri.network.NeighborRouter;
 import com.iota.iri.network.neighbor.Neighbor;
 import com.iota.iri.network.neighbor.impl.NeighborImpl;
-
-import java.util.HashMap;
-import java.util.Map;
-
+import com.iota.iri.service.milestone.InSyncService;
 import com.iota.iri.service.validation.TransactionSolidifier;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class BroadcastStageTest {
 
@@ -27,6 +28,14 @@ public class BroadcastStageTest {
 
     @Mock
     private NeighborRouter neighborRouter;
+    
+    private InSyncService inSyncService = new InSyncService() {
+        
+        @Override
+        public boolean isInSync() {
+            return true;
+        }
+    };
 
     // setup neighbors
     private final static Neighbor neighborA = new NeighborImpl<>(null, null, "A", 0, null);
@@ -42,7 +51,7 @@ public class BroadcastStageTest {
     public void doesntGossipToOriginNeighbor() {
         Mockito.when(neighborRouter.getConnectedNeighbors()).thenReturn(neighbors);
 
-        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier);
+        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier, inSyncService);
         TransactionViewModel tvm = new TransactionViewModel(new Transaction(), null);
         BroadcastPayload broadcastPayload = new BroadcastPayload(neighborA, tvm);
         ProcessingContext ctx = new ProcessingContext(null, broadcastPayload);
@@ -62,7 +71,7 @@ public class BroadcastStageTest {
     public void gossipsToAllIfNoOriginNeighbor() {
         Mockito.when(neighborRouter.getConnectedNeighbors()).thenReturn(neighbors);
 
-        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier);
+        BroadcastStage broadcastStage = new BroadcastStage(neighborRouter, transactionSolidifier, inSyncService);
         TransactionViewModel tvm = new TransactionViewModel(new Transaction(), null);
         BroadcastPayload broadcastPayload = new BroadcastPayload(null, tvm);
         ProcessingContext ctx = new ProcessingContext(null, broadcastPayload);

--- a/src/test/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineTest.java
+++ b/src/test/java/com/iota/iri/network/pipeline/TransactionProcessingPipelineTest.java
@@ -1,16 +1,17 @@
 package com.iota.iri.network.pipeline;
 
-import com.iota.iri.service.milestone.MilestoneService;
-import com.iota.iri.service.milestone.MilestoneSolidifier;
-import com.iota.iri.service.validation.TransactionSolidifier;
-import com.iota.iri.service.validation.TransactionValidator;
 import com.iota.iri.conf.NodeConfig;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.network.NeighborRouter;
 import com.iota.iri.network.SampleTransaction;
 import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.network.neighbor.Neighbor;
+import com.iota.iri.service.milestone.InSyncService;
+import com.iota.iri.service.milestone.MilestoneService;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
 import com.iota.iri.service.snapshot.SnapshotProvider;
+import com.iota.iri.service.validation.TransactionSolidifier;
+import com.iota.iri.service.validation.TransactionValidator;
 import com.iota.iri.storage.Tangle;
 
 import org.junit.Rule;
@@ -121,6 +122,14 @@ public class TransactionProcessingPipelineTest {
 
     @Mock
     private TransactionSolidifier transactionSolidifier;
+    
+    private InSyncService inSyncService = new InSyncService() {
+        
+        @Override
+        public boolean isInSync() {
+            return true;
+        }
+    };
 
     private void mockHashingStage(TransactionProcessingPipeline pipeline) {
         Mockito.when(hashingPayload.getTxTrits()).thenReturn(null);
@@ -146,7 +155,7 @@ public class TransactionProcessingPipelineTest {
 
         TransactionProcessingPipeline pipeline = new TransactionProcessingPipelineImpl(neighborRouter, nodeConfig,
                 transactionValidator, tangle, snapshotProvider, tipsViewModel, milestoneSolidifier,
-                transactionRequester, transactionSolidifier, milestoneService);
+                transactionRequester, transactionSolidifier, milestoneService, inSyncService);
 
         // inject mocks
         injectMockedStagesIntoPipeline(pipeline);
@@ -198,7 +207,7 @@ public class TransactionProcessingPipelineTest {
     public void processingAValidMilestone() throws InterruptedException {
         TransactionProcessingPipeline pipeline = new TransactionProcessingPipelineImpl(neighborRouter, nodeConfig,
                 transactionValidator, tangle, snapshotProvider, tipsViewModel, milestoneSolidifier,
-                transactionRequester, transactionSolidifier, milestoneService);
+                transactionRequester, transactionSolidifier, milestoneService, inSyncService);
 
         injectMockedStagesIntoPipeline(pipeline);
 
@@ -255,7 +264,7 @@ public class TransactionProcessingPipelineTest {
     public void processingAKnownTransactionOnlyFlowsToTheReplyStage() throws InterruptedException {
         TransactionProcessingPipeline pipeline = new TransactionProcessingPipelineImpl(neighborRouter, nodeConfig,
                 transactionValidator, tangle, snapshotProvider, tipsViewModel, milestoneSolidifier,
-                transactionRequester, transactionSolidifier, milestoneService);
+                transactionRequester, transactionSolidifier, milestoneService, inSyncService);
 
         // inject mocks
         pipeline.setPreProcessStage(preProcessStage);
@@ -290,7 +299,7 @@ public class TransactionProcessingPipelineTest {
             throws InterruptedException {
         TransactionProcessingPipeline pipeline = new TransactionProcessingPipelineImpl(neighborRouter, nodeConfig,
                 transactionValidator, tangle, snapshotProvider, tipsViewModel, milestoneSolidifier,
-                transactionRequester, transactionSolidifier, milestoneService);
+                transactionRequester, transactionSolidifier, milestoneService, inSyncService);
         // inject mocks
         injectMockedStagesIntoPipeline(pipeline);
 
@@ -340,7 +349,7 @@ public class TransactionProcessingPipelineTest {
     public void anInvalidNewTransactionStopsBeingProcessedAfterTheValidationStage() throws InterruptedException {
         TransactionProcessingPipeline pipeline = new TransactionProcessingPipelineImpl(neighborRouter, nodeConfig,
                 transactionValidator, tangle, snapshotProvider, tipsViewModel, milestoneSolidifier,
-                transactionRequester, transactionSolidifier, milestoneService);
+                transactionRequester, transactionSolidifier, milestoneService, inSyncService);
 
         // inject mocks
         injectMockedStagesIntoPipeline(pipeline);

--- a/src/test/java/com/iota/iri/service/milestone/impl/MilestoneInSyncServiceTest.java
+++ b/src/test/java/com/iota/iri/service/milestone/impl/MilestoneInSyncServiceTest.java
@@ -1,0 +1,78 @@
+package com.iota.iri.service.milestone.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.iota.iri.service.milestone.InSyncService;
+import com.iota.iri.service.milestone.MilestoneSolidifier;
+import com.iota.iri.service.snapshot.SnapshotProvider;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class MilestoneInSyncServiceTest {
+    
+    private static final int BUFFER = 5;
+
+    @Rule 
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    
+    InSyncService inSyncService;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    SnapshotProvider snapshotProvider;
+    
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    MilestoneSolidifier milestoneSolidifier;
+    
+    @Before
+    public void setUp() throws Exception {
+        inSyncService = new MilestoneInSyncService(snapshotProvider, milestoneSolidifier);
+    }
+    
+    @Test
+    public void isInSyncTestScanIncomplete() {
+        when(milestoneSolidifier.isInitialScanComplete()).thenReturn(false);
+        
+        assertFalse("We should be out of sync when he havent finished initial scans", inSyncService.isInSync());
+    }
+    
+    @Test
+    public void isInSyncTestScanComplete() {
+        // Always return true
+        when(milestoneSolidifier.isInitialScanComplete()).thenReturn(true);
+        
+        // We don't really support -1 indexes, but if this breaks, it is a good indication to be careful going further
+        when(milestoneSolidifier.getLatestMilestoneIndex()).thenReturn(-1, 5, 10, 998 + BUFFER - 1, 2000);
+        when(snapshotProvider.getLatestSnapshot().getIndex()).thenReturn(-5, -1, 10, 998, 999, 1999, 2000);
+        
+        
+        // snapshotProvider & milestoneTracker
+        // -5 & -1 -> not in sync
+        assertFalse("Previous out of sync and not equal index should not be in sync", inSyncService.isInSync());
+        
+        // -1 and 5 -> not in sync
+        assertFalse("Previous out of sync and not equal index should not be in sync", inSyncService.isInSync());
+        
+        // 10 and 10 -> in sync
+        assertTrue("Equal index should be in sync", inSyncService.isInSync());
+        
+        // 998 and 1002 -> in sync since sync gap = 5
+        assertTrue("Index difference less than the buffer still should be in sync", inSyncService.isInSync());
+        
+        // 999 and 2000 -> out of sync again, bigger gap than 5
+        assertFalse("Index difference more than the buffer should be out of sync again ", inSyncService.isInSync());
+        
+        // 1999 and 2000 -> out of sync still
+        assertFalse("Previous out of sync and not equal index should not be in sync", inSyncService.isInSync());
+        
+        // 2000 and 2000 -> in sync again
+        assertTrue("Equal index should be in sync", inSyncService.isInSync());
+    }
+}

--- a/src/test/java/com/iota/iri/service/snapshot/impl/LocalSnapshotManagerImplTest.java
+++ b/src/test/java/com/iota/iri/service/snapshot/impl/LocalSnapshotManagerImplTest.java
@@ -1,8 +1,14 @@
 package com.iota.iri.service.snapshot.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.iota.iri.TangleMockUtils;
 import com.iota.iri.TransactionTestUtils;
 import com.iota.iri.conf.SnapshotConfig;
+import com.iota.iri.service.milestone.InSyncService;
 import com.iota.iri.service.milestone.MilestoneSolidifier;
 import com.iota.iri.service.snapshot.SnapshotProvider;
 import com.iota.iri.service.snapshot.SnapshotService;
@@ -22,16 +28,7 @@ import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 public class LocalSnapshotManagerImplTest {
-    
-    private static final int BUFFER = LocalSnapshotManagerImpl.LOCAL_SNAPSHOT_SYNC_BUFFER;
     
     private static final int DELAY_SYNC = 5;
     private static final int DELAY_UNSYNC = 1;
@@ -63,10 +60,14 @@ public class LocalSnapshotManagerImplTest {
 
     @Before
     public void setUp() throws Exception {
-        this.lsManager = new LocalSnapshotManagerImpl(snapshotProvider, snapshotService, transactionPruner, config);
-        this.lsManager.addSnapshotCondition(new SnapshotDepthCondition(config, snapshotProvider));
+        this.lsManager = new LocalSnapshotManagerImpl(snapshotProvider, snapshotService, transactionPruner, config, new InSyncService() {
+            @Override
+            public boolean isInSync() {
+                return true;
+            }
+        });
         
-        when(snapshotProvider.getLatestSnapshot().getIndex()).thenReturn(-5, -1, 10, 998, 999, 1999, 2000);
+        this.lsManager.addSnapshotCondition(new SnapshotDepthCondition(config, snapshotProvider));
         
         when(config.getLocalSnapshotsIntervalSynced()).thenReturn(DELAY_SYNC);
         when(config.getLocalSnapshotsIntervalUnsynced()).thenReturn(DELAY_UNSYNC);
@@ -109,43 +110,5 @@ public class LocalSnapshotManagerImplTest {
         } catch (MockitoAssertionError e) {
             throw new MockitoAssertionError("A snapshot should have been taken when we are below SNAPSHOT_DEPTH");
         }
-    }
-
-    @Test
-    public void isInSyncTestScanIncomplete() {
-        when(milestoneTracker.isInitialScanComplete()).thenReturn(false);
-        
-        assertFalse("We should be out of sync when he havent finished initial scans", lsManager.isInSync(milestoneTracker));
-    }
-    
-    @Test
-    public void isInSyncTestScanComplete() {
-        // Always return true
-        when(milestoneTracker.isInitialScanComplete()).thenReturn(true);
-        
-        // We don't really support -1 indexes, but if this breaks, it is a good indication to be careful going further
-        when(milestoneTracker.getLatestMilestoneIndex()).thenReturn(-1, 5, 10, 998 + BUFFER - 1, 2000);
-        
-        // snapshotProvider & milestoneTracker
-        // -5 & -1 -> not in sync
-        assertFalse("Previous out of sync and not equal index should not be in sync", lsManager.isInSync(milestoneTracker));
-        
-        // -1 and 5 -> not in sync
-        assertFalse("Previous out of sync and not equal index should not be in sync", lsManager.isInSync(milestoneTracker));
-        
-        // 10 and 10 -> in sync
-        assertTrue("Equal index should be in sync", lsManager.isInSync(milestoneTracker));
-        
-        // 998 and 1002 -> in sync since sync gap = 5
-        assertTrue("Index difference less than the buffer still should be in sync", lsManager.isInSync(milestoneTracker));
-        
-        // 999 and 2000 -> out of sync again, bigger gap than 5
-        assertFalse("Index difference more than the buffer should be out of sync again ", lsManager.isInSync(milestoneTracker));
-        
-        // 1999 and 2000 -> out of sync still
-        assertFalse("Previous out of sync and not equal index should not be in sync", lsManager.isInSync(milestoneTracker));
-        
-        // 2000 and 2000 -> in sync again
-        assertTrue("Equal index should be in sync", lsManager.isInSync(milestoneTracker));
     }
 }


### PR DESCRIPTION
# Description of change

Extracts our sync checker to a service, and uses that service in the BroadcastStage of the Network pipeline.

This is required because if you get all your new transactions from 1 neighbour, and have 1 other neighbour which doesnt have the transaction you need, there is no chance of syncing.

If that second neighbour sends you a very low amount of new transactions(compared to the other neighbour) you will still sync, but very slow.

This has been introduced due to our removal of "ping pong" in #1745 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

The stuck node got unstuck in the scenario described above