### PR TITLE
Remove address scan in bootstrap

### DIFF
--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -272,6 +272,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
         int index = getLatestSolidMilestoneIndex();
         MilestoneViewModel nextMilestone;
 
+        log.info("Starting milestone bootstrapping...");
         while (milestonePresent) {
             index++;
             if ((nextMilestone = MilestoneViewModel.get(tangle, index)) != null) {
@@ -282,6 +283,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             }
         }
 
+        log.info("Done bootstrapping milestones.");
         initialized.set(true);
     }
 

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -268,33 +268,20 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      */
     private void bootStrapSolidMilestones() throws Exception {
         setLatestSolidMilestone(snapshotProvider.getLatestSnapshot().getIndex());
-        Set<Hash> milestoneTransactions = AddressViewModel.load(tangle, config.getCoordinator()).getHashes();
-        int processed = 0;
-        int index;
-        for (Hash hash: milestoneTransactions) {
-            try {
-                processed += 1;
-                TransactionViewModel tvm = TransactionViewModel.fromHash(tangle, hash);
-                boolean isTail = tvm.getCurrentIndex() == 0;
-                if (isTail && (index = milestoneService
-                        .getMilestoneIndex(tvm)) > getLatestSolidMilestoneIndex()) {
-                    MilestoneValidity validity = milestoneService.validateMilestone(tvm, index);
-                    if (validity == MilestoneValidity.VALID) {
-                        tvm.isMilestone(tangle, snapshotProvider.getInitialSnapshot(), true);
-                        registerNewMilestone(getLatestMilestoneIndex(), index, tvm.getHash());
-                    }
+        boolean milestonePresent = true;
+        int index = getLatestSolidMilestoneIndex();
+        MilestoneViewModel nextMilestone;
 
-                    if (validity != MilestoneValidity.INVALID) {
-                        addMilestoneCandidate(hash, index);
-                    }
-                }
-                if (processed % 1000 == 0 || processed % milestoneTransactions.size() == 0){
-                    log.info("Bootstrapping milestones: [ " + processed  + " / " + milestoneTransactions.size() + " ]");
-                }
-            } catch(Exception e) {
-                log.error("Error processing existing milestone index", e);
+        while (milestonePresent) {
+            index++;
+            if ((nextMilestone = MilestoneViewModel.get(tangle, index)) != null) {
+                registerNewMilestone(getLatestMilestoneIndex(), index, nextMilestone.getHash());
+                addMilestoneCandidate(nextMilestone.getHash(), nextMilestone.index());
+            } else {
+                milestonePresent = false;
             }
         }
+
         initialized.set(true);
     }
 


### PR DESCRIPTION
# Description of change
No longer scan milestones via the coo address. Instead walk up from the latest solid milestone and add the existing milestones to the solidifier queue to process. 
 
## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Took an older local snapshot and ran the node with a db that is up to date. The milestones above the LS were processed and solidified faster and bootstrapping took much less time. 

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
