### PR TITLE
Fix milestone solidification on reboot

### DIFF
--- a/src/main/java/com/iota/iri/MainInjectionConfiguration.java
+++ b/src/main/java/com/iota/iri/MainInjectionConfiguration.java
@@ -141,7 +141,7 @@ public class MainInjectionConfiguration extends AbstractModule {
     @Singleton
     @Provides
     TransactionSolidifier provideTransactionSolidifier(Tangle tangle, SnapshotProvider snapshotProvider, TransactionRequester transactionRequester, TipsViewModel tipsViewModel){
-        return new TransactionSolidifierImpl(tangle, snapshotProvider, transactionRequester, tipsViewModel);
+        return new TransactionSolidifierImpl(tangle, snapshotProvider, transactionRequester, tipsViewModel, configuration.getCoordinator());
     }
 
     @Singleton

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -297,10 +297,14 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             }
         }
 
-        if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex)) &&
-                (seenMilestones.size() + unsolidMilestones.size()) <
-                        (getLatestMilestoneIndex() - getLatestSolidMilestoneIndex())) {
-            scanAddressHashes();
+        if (lowestIndex <= getLatestSolidMilestoneIndex()) {
+            removeCurrentAndLowerSeenMilestone(lowestIndex);
+        } else {
+            if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex)) &&
+                    (seenMilestones.size() + unsolidMilestones.size()) <
+                            (getLatestMilestoneIndex() - getLatestSolidMilestoneIndex())) {
+                scanAddressHashes();
+            }
         }
     }
 

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -295,7 +295,9 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
             }
         }
 
-        if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex))) {
+        if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex)) &&
+                (seenMilestones.size() + unsolidMilestones.size()) <
+                        (getLatestMilestoneIndex() - getLatestSolidMilestoneIndex())) {
             scanAddressHashes();
         }
     }

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -288,7 +288,12 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
         initialized.set(true);
     }
 
-
+    /**
+     * Checks the seen milestones queue for the lowest index available, and tries to solidify it. If it is already
+     * solid but not syncing, there are milestone objects in the db that have not been processed through the solidifier
+     * (likely due to shutting down during synchronisation). If this is the case, an address scan is performed to
+     * find and process all present milestone transactions through the milestone solidifier.
+     */
     private void checkOldestSeenMilestoneSolidity() {
         int lowestIndex = 0;
         for (int index: seenMilestones.keySet()) {

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -241,6 +241,10 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
                         transactionSolidifier.addToSolidificationQueue(milestone.getHash());
                     }
                 }
+
+                if (!seenMilestones.isEmpty()) {
+                    checkOldestSeenMilestoneSolidity();
+                }
             }
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -281,6 +285,17 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
         initialized.set(true);
     }
 
+
+    private void checkOldestSeenMilestoneSolidity() {
+        int lowestIndex = 0;
+        for (int index: seenMilestones.keySet()) {
+            if (lowestIndex == 0 || lowestIndex > index) {
+                lowestIndex = index;
+            }
+        }
+
+        transactionSolidifier.addToSolidificationQueue(seenMilestones.get(lowestIndex));
+    }
 
 
     private void updateSolidMilestone(int currentSolidMilestoneIndex) throws Exception {

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -295,20 +295,16 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
      * find and process all present milestone transactions through the milestone solidifier.
      */
     private void checkOldestSeenMilestoneSolidity() {
-        int lowestIndex = 0;
-        for (int index: seenMilestones.keySet()) {
-            if (lowestIndex == 0 || lowestIndex > index) {
-                lowestIndex = index;
-            }
-        }
-
-        if (lowestIndex <= getLatestSolidMilestoneIndex()) {
-            removeCurrentAndLowerSeenMilestone(lowestIndex);
-        } else {
-            if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex)) &&
-                    (seenMilestones.size() + unsolidMilestones.size()) <
-                            (getLatestMilestoneIndex() - getLatestSolidMilestoneIndex())) {
-                scanAddressHashes();
+        Optional<Integer> lowestIndex = seenMilestones.keySet().stream().min(Integer::compareTo);
+        if (lowestIndex.isPresent()) {
+            if (lowestIndex.get() <= getLatestSolidMilestoneIndex()) {
+                removeCurrentAndLowerSeenMilestone(lowestIndex.get());
+            } else {
+                if (!transactionSolidifier.addMilestoneToSolidificationQueue(seenMilestones.get(lowestIndex.get())) &&
+                        (seenMilestones.size() + unsolidMilestones.size()) <
+                                (getLatestMilestoneIndex() - getLatestSolidMilestoneIndex())) {
+                    scanAddressHashes();
+                }
             }
         }
     }

--- a/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/milestone/impl/MilestoneSolidifierImpl.java
@@ -232,10 +232,12 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
         try {
             if (getLatestMilestoneIndex() > getLatestSolidMilestoneIndex()) {
                 int nextMilestone = getLatestSolidMilestoneIndex() + 1;
+                boolean isSyncing = false;
                 if (seenMilestones.containsKey(nextMilestone)) {
                     TransactionViewModel milestone = TransactionViewModel.fromHash(tangle,
                             seenMilestones.get(nextMilestone));
                     if (milestone.isSolid()) {
+                        isSyncing = true;
                         updateSolidMilestone(getLatestSolidMilestoneIndex());
                         transactionSolidifier.addToPropagationQueue(milestone.getHash());
                     } else {
@@ -243,7 +245,7 @@ public class MilestoneSolidifierImpl implements MilestoneSolidifier {
                     }
                 }
 
-                if (!seenMilestones.isEmpty()) {
+                if (!seenMilestones.isEmpty() && !isSyncing) {
                     checkOldestSeenMilestoneSolidity();
                 }
             }

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -33,7 +33,7 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
     /**
      * Max size for all queues.
      */
-    private static final int MAX_SIZE= 10000;
+    private static final int MAX_SIZE= 100;
 
     private static final int SOLIDIFICATION_INTERVAL = 100;
 

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -72,6 +72,8 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
 
     private TransactionPropagator transactionPropagator;
 
+    private Hash cooAddress;
+
     /**
      * Constructor for the solidifier.
      * @param tangle                    The DB reference
@@ -79,12 +81,13 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
      * @param transactionRequester      A requester for missing transactions
      */
     public TransactionSolidifierImpl(Tangle tangle, SnapshotProvider snapshotProvider, TransactionRequester transactionRequester,
-                                     TipsViewModel tipsViewModel){
+                                     TipsViewModel tipsViewModel, Hash cooAddress){
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
         this.transactionRequester = transactionRequester;
         this.tipsViewModel = tipsViewModel;
         this.transactionPropagator = new TransactionPropagator();
+        this.cooAddress = cooAddress;
     }
 
     /**
@@ -225,6 +228,9 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
                 } else {
                     nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
                     nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
+                    if (transaction.getAddressHash().equals(cooAddress)) {
+                        checkRequester(hashPointer);
+                    }
                 }
             }
         }

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -134,13 +134,13 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
             TransactionViewModel tx = fromHash(tangle, hash);
             if (tx.isSolid()) {
                 transactionPropagator.addToPropagationQueue(hash);
-                return true;
+                return false;
             }
             addToSolidificationQueue(hash);
-            return false;
+            return true;
         } catch (Exception e) {
             log.error("Error adding milestone to solidification queue", e);
-            return false;
+            return true;
         }
     }
 

--- a/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
+++ b/src/main/java/com/iota/iri/service/validation/impl/TransactionSolidifierImpl.java
@@ -140,7 +140,7 @@ public class TransactionSolidifierImpl implements TransactionSolidifier {
             return true;
         } catch (Exception e) {
             log.error("Error adding milestone to solidification queue", e);
-            return true;
+            return false;
         }
     }
 

--- a/src/test/java/com/iota/iri/service/validation/impl/TransactionSolidifierImplTest.java
+++ b/src/test/java/com/iota/iri/service/validation/impl/TransactionSolidifierImplTest.java
@@ -3,6 +3,7 @@ package com.iota.iri.service.validation.impl;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.crypto.SpongeFactory;
+import com.iota.iri.model.Hash;
 import com.iota.iri.model.TransactionHash;
 import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.service.snapshot.SnapshotProvider;
@@ -52,6 +53,9 @@ public class TransactionSolidifierImplTest {
     @Mock
     private static TransactionRequester txRequester;
 
+    @Mock
+    private static Hash cooAddress;
+
     @BeforeClass
     public static void setUp() throws Exception {
         dbFolder.create();
@@ -74,7 +78,7 @@ public class TransactionSolidifierImplTest {
     public void setUpEach() {
         when(snapshotProvider.getInitialSnapshot()).thenReturn(SnapshotMockUtils.createSnapshot());
         txRequester = new TransactionRequester(tangle, snapshotProvider);
-        txSolidifier = new TransactionSolidifierImpl(tangle, snapshotProvider, txRequester, tipsViewModel);
+        txSolidifier = new TransactionSolidifierImpl(tangle, snapshotProvider, txRequester, tipsViewModel, cooAddress);
         txSolidifier.start();
     }
 


### PR DESCRIPTION
# Description of change
If a sync is midway through and the node is shut off, it's possible for milestone transactions to get lost in the mix on restart. The transaction object may be present but the milestone object has not been generated. This means that if the node tries to solidify a transaction that references this milestone, it will always skip requesting this transaction as it is already stored. 

This stops the milestones from making it into the solidification queue again. By making the `TransactionSolidifier` request milestones regardless of solidity, and adding an address scanning method for when synchronization stalls out on reboot, we can mitigate most issues that would pop up revolving around syncing and restarting during a sync. 

Also lowers the max size of the `TransactionSolidifier` processing queue to ensure we solidify from bottom up in a more efficient manner. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
I have started, stopped and restarted many times on mainnet from a Local Snapshot 13k milestones back. Stops and starts resumed syncing in almost all instances. 

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
