### PR TITLE
Remove conditions for sending

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
@@ -356,10 +356,6 @@ public class NeighborRouterImpl implements NeighborRouter {
         try {
             switch (neighbor.write()) {
                 case 0:
-                    // nothing was written, because no message was available to be sent.
-                    // lets unregister this channel from write interests until at least
-                    // one message is back available for sending.
-                    key.interestOps(SelectionKey.OP_READ);
                     break;
                 case -1:
                     if (neighbor.getState() == NeighborState.HANDSHAKING) {

--- a/src/main/java/com/iota/iri/network/neighbor/impl/NeighborImpl.java
+++ b/src/main/java/com/iota/iri/network/neighbor/impl/NeighborImpl.java
@@ -198,13 +198,6 @@ public class NeighborImpl<T extends SelectableChannel & ByteChannel> implements 
 
     @Override
     public void send(ByteBuffer buf) {
-        // re-register write interest
-        SelectionKey key = channel.keyFor(selector);
-        if (key != null && key.isValid() && (key.interestOps() & SelectionKey.OP_WRITE) == 0) {
-            key.interestOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
-            selector.wakeup();
-        }
-
         if (!sendQueue.offer(buf)) {
             metrics.incrDroppedSendPacketsCount();
         }


### PR DESCRIPTION
# Description of change
There is a race condition occurring between the tip requesting, and the broadcast and reply stages. There is a write flag being switched on and off by the various threads that stop the `sendQueue` from being polled from and sent to neighbours. As a result, we see a large spike in dropped transaction requests, and the node will stop synchronising. Once a node runs into this error the only remedy is to drop and reconnect the neighbour, and even then the problem could resurface any time there's a large amount of transactions being processed simultaneously. 

To fix this we can remove the back and forth switching of this write flag. 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Nodes no longer froze when synchronising with neighbours. 

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
