### PR TITLE
Fix: resolve race in networking layer assigning write operation to key

### DIFF
--- a/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
+++ b/src/main/java/com/iota/iri/network/NeighborRouterImpl.java
@@ -356,6 +356,10 @@ public class NeighborRouterImpl implements NeighborRouter {
         try {
             switch (neighbor.write()) {
                 case 0:
+                    // nothing was written, because no message was available to be sent.
+                    // lets unregister this channel from write interests until at least
+                    // one message is back available for sending.
+                    key.interestOps(SelectionKey.OP_READ);
                     break;
                 case -1:
                     if (neighbor.getState() == NeighborState.HANDSHAKING) {

--- a/src/main/java/com/iota/iri/network/neighbor/Neighbor.java
+++ b/src/main/java/com/iota/iri/network/neighbor/Neighbor.java
@@ -131,4 +131,11 @@ public interface Neighbor {
      */
     int getProtocolVersion();
 
+    /**
+     * Checks if we have data (transactions) to send to the neighbor
+     *
+     * @return {@code true} if we have data to send, else returns {@code false}
+     */
+    boolean hasDataToSendTo();
+
 }

--- a/src/main/java/com/iota/iri/network/neighbor/impl/NeighborImpl.java
+++ b/src/main/java/com/iota/iri/network/neighbor/impl/NeighborImpl.java
@@ -198,6 +198,13 @@ public class NeighborImpl<T extends SelectableChannel & ByteChannel> implements 
 
     @Override
     public void send(ByteBuffer buf) {
+        // re-register write interest
+        SelectionKey key = channel.keyFor(selector);
+        if (key != null && key.isValid() && (key.interestOps() & SelectionKey.OP_WRITE) == 0) {
+            key.interestOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
+            selector.wakeup();
+        }
+
         if (!sendQueue.offer(buf)) {
             metrics.incrDroppedSendPacketsCount();
         }

--- a/src/test/java/com/iota/iri/network/neighbor/impl/NeighborImplTest.java
+++ b/src/test/java/com/iota/iri/network/neighbor/impl/NeighborImplTest.java
@@ -167,6 +167,42 @@ public class NeighborImplTest {
     }
 
     @Test
+    public void aSendWhileWriteInterestIsDisabledActivatesItAgain() {
+        SelectionKey fakeSelectionKey = new FakeSelectionKey() {
+
+            private int ops = SelectionKey.OP_READ;
+
+            @Override
+            public boolean isValid() {
+                return true;
+            }
+
+            @Override
+            public int interestOps() {
+                return ops;
+            }
+
+            @Override
+            public SelectionKey interestOps(int ops) {
+                this.ops = ops;
+                return null;
+            }
+        };
+        Neighbor neighbor = new NeighborImpl<>(selector, new FakeChannel() {
+
+            @Override
+            public SelectionKey keyFor(Selector sel) {
+                return fakeSelectionKey;
+            }
+        }, localAddr, serverSocketPort, pipeline);
+        neighbor.send(createEmptyTxPacket());
+
+        Mockito.verify(selector).wakeup();
+        assertEquals("should be interested in read and write readiness", SelectionKey.OP_READ | SelectionKey.OP_WRITE,
+                fakeSelectionKey.interestOps());
+    }
+
+    @Test
     public void markingTheNeighborForDisconnectWillNeverMakeItReadyForMessagesAgain() {
         Neighbor neighbor = new NeighborImpl<>(selector, null, localAddr, serverSocketPort, pipeline);
         neighbor.setState(NeighborState.MARKED_FOR_DISCONNECT);


### PR DESCRIPTION
# Description of change

Tries to solve the syncing problem from #1863 by synchronizing between registering of operation to keys, to ensure no race conditions...

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

It was ran w.o. data races and no noticeable sync slow down

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
